### PR TITLE
Hotfix 0.22.4: move SFTP ItemProvider callbacks out of MainActor views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.22.4
+
+- Исправлено аварийное завершение приложения при drag-and-drop файлов между двумя SFTP-серверами.
+- NSItemProvider callbacks полностью вынесены из MainActor-изолированных SwiftUI представлений в отдельный non-actor bridge.
+- Обработка данных drag-and-drop теперь возвращается на MainActor только после получения Sendable-значения от Foundation.
+- Исправление применяется также к Mac ↔ Server и Server → Mac путям передачи файлов.
+- Добавлены runtime regression tests для асинхронной доставки NSItemProvider и actor isolation.
+
 ## 0.22.3
 
 - Исправлено аварийное завершение приложения при drag-and-drop файлов между двумя SFTP-серверами.

--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -1,3 +1,11 @@
+## 0.22.4
+
+- Fixed an application crash when dragging files between two SFTP servers.
+- Moved NSItemProvider callbacks completely out of MainActor-isolated SwiftUI views into a dedicated non-actor bridge.
+- Drag-and-drop handling now hops back to MainActor only after Foundation has delivered a Sendable value.
+- The fix also covers Mac ↔ Server and Server → Mac file transfer paths.
+- Added runtime regression tests for asynchronous NSItemProvider delivery and actor isolation.
+
 ## 0.22.3
 
 - Fixed an application crash when dragging files between two SFTP servers.

--- a/Resources/updates.example.json
+++ b/Resources/updates.example.json
@@ -1,8 +1,8 @@
 {
-  "version": "0.22.3",
-  "build": 128,
-  "downloadURL": "https://github.com/PastFly/Selective-Remote/releases/download/v0.22.3/SelectiveRemote-0.22.3-arm64.dmg",
-  "releaseNotesURL": "https://github.com/PastFly/Selective-Remote/releases/tag/v0.22.3",
+  "version": "0.22.4",
+  "build": 129,
+  "downloadURL": "https://github.com/PastFly/Selective-Remote/releases/download/v0.22.4/SelectiveRemote-0.22.4-arm64.dmg",
+  "releaseNotesURL": "https://github.com/PastFly/Selective-Remote/releases/tag/v0.22.4",
   "releaseNotesHistoryURL": "https://raw.githubusercontent.com/PastFly/Selective-Remote/main/CHANGELOG.md",
   "releaseNotesHistoryENURL": "https://raw.githubusercontent.com/PastFly/Selective-Remote/main/CHANGELOG_EN.md",
   "minimumMacOS": "14.0"

--- a/Resources/updates.json
+++ b/Resources/updates.json
@@ -1,8 +1,8 @@
 {
-  "version": "0.22.3",
-  "build": 128,
-  "downloadURL": "https://github.com/PastFly/Selective-Remote/releases/download/v0.22.3/SelectiveRemote-0.22.3-arm64.dmg",
-  "releaseNotesURL": "https://github.com/PastFly/Selective-Remote/releases/tag/v0.22.3",
+  "version": "0.22.4",
+  "build": 129,
+  "downloadURL": "https://github.com/PastFly/Selective-Remote/releases/download/v0.22.4/SelectiveRemote-0.22.4-arm64.dmg",
+  "releaseNotesURL": "https://github.com/PastFly/Selective-Remote/releases/tag/v0.22.4",
   "releaseNotesHistoryURL": "https://raw.githubusercontent.com/PastFly/Selective-Remote/main/CHANGELOG.md",
   "releaseNotesHistoryENURL": "https://raw.githubusercontent.com/PastFly/Selective-Remote/main/CHANGELOG_EN.md",
   "minimumMacOS": "14.0"

--- a/Sources/SelectiveRemote/SFTPBrowserModels.swift
+++ b/Sources/SelectiveRemote/SFTPBrowserModels.swift
@@ -16,6 +16,77 @@ struct SFTPRemoteDragPayload: Codable, Sendable {
     let isDirectory: Bool
 }
 
+
+// NSItemProvider may invoke its completion handlers on a Foundation-owned
+// background queue. Keep those callbacks completely outside MainActor-
+// isolated SwiftUI views and pass only Sendable values back to MainActor.
+final class SFTPMainActorValueHandler<Value: Sendable>: @unchecked Sendable {
+    private let callback: @MainActor @Sendable (Value) -> Void
+
+    @MainActor
+    init(_ callback: @escaping @MainActor @Sendable (Value) -> Void) {
+        self.callback = callback
+    }
+
+    @MainActor
+    func call(_ value: Value) {
+        callback(value)
+    }
+}
+
+enum SFTPItemProviderBridge {
+    static func loadRemotePayload(
+        from provider: NSItemProvider,
+        handler: SFTPMainActorValueHandler<SFTPRemoteDragPayload>
+    ) {
+        provider.loadDataRepresentation(
+            forTypeIdentifier: SFTPDragType.remoteEntry.identifier
+        ) { data, _ in
+            guard let data,
+                  let payload = try? JSONDecoder().decode(
+                      SFTPRemoteDragPayload.self,
+                      from: data
+                  )
+            else { return }
+
+            Task { @MainActor in
+                handler.call(payload)
+            }
+        }
+    }
+
+    static func loadString(
+        from provider: NSItemProvider,
+        handler: SFTPMainActorValueHandler<String>
+    ) {
+        provider.loadDataRepresentation(
+            forTypeIdentifier: NSPasteboard.PasteboardType.string.rawValue
+        ) { data, _ in
+            guard let data,
+                  let value = String(data: data, encoding: .utf8)
+            else { return }
+
+            Task { @MainActor in
+                handler.call(value)
+            }
+        }
+    }
+
+    static func loadFileURL(
+        from provider: NSItemProvider,
+        handler: SFTPMainActorValueHandler<URL>
+    ) {
+        provider.loadObject(ofClass: NSURL.self) { object, _ in
+            guard let nsURL = object as? NSURL else { return }
+            let url = nsURL as URL
+
+            Task { @MainActor in
+                handler.call(url)
+            }
+        }
+    }
+}
+
 struct SFTPLocalEntry: Identifiable, Equatable, Sendable {
     let url: URL
     let isDirectory: Bool

--- a/Sources/SelectiveRemote/SFTPWorkspace.swift
+++ b/Sources/SelectiveRemote/SFTPWorkspace.swift
@@ -1361,23 +1361,17 @@ private struct SFTPWorkspaceLocalPaneView: View {
            !source.remote.isBusy,
            !model.isBusy {
             for provider in remoteProviders {
-                provider.loadDataRepresentation(
-                    forTypeIdentifier: SFTPDragType.remoteEntry.identifier
-                ) { @Sendable data, _ in
-                    guard let data,
-                          let payload = try? JSONDecoder().decode(
-                              SFTPRemoteDragPayload.self,
-                              from: data
-                          )
-                    else { return }
-                    Task { @MainActor in
-                        source.remote.download(
-                            payload: payload,
-                            to: destination,
-                            settings: settings
-                        )
-                    }
+                let handler = SFTPMainActorValueHandler<SFTPRemoteDragPayload> { payload in
+                    source.remote.download(
+                        payload: payload,
+                        to: destination,
+                        settings: settings
+                    )
                 }
+                SFTPItemProviderBridge.loadRemotePayload(
+                    from: provider,
+                    handler: handler
+                )
             }
             return true
         }
@@ -1389,19 +1383,16 @@ private struct SFTPWorkspaceLocalPaneView: View {
         }
         if !stringProviders.isEmpty {
   for provider in stringProviders {
-      provider.loadDataRepresentation(
-          forTypeIdentifier: NSPasteboard.PasteboardType.string.rawValue
-      ) { @Sendable data, _ in
-          guard let data,
-                let value = String(data: data, encoding: .utf8)
-          else { return }
-          Task { @MainActor in
-              _ = acceptInternalRemoteDrag(
-                  [value],
-                  destination: destination
-              )
-          }
+      let handler = SFTPMainActorValueHandler<String> { value in
+          _ = acceptInternalRemoteDrag(
+              [value],
+              destination: destination
+          )
       }
+      SFTPItemProviderBridge.loadString(
+          from: provider,
+          handler: handler
+      )
   }
   return true
         }
@@ -1411,13 +1402,13 @@ private struct SFTPWorkspaceLocalPaneView: View {
         }
         guard !fileProviders.isEmpty else { return false }
         for provider in fileProviders {
-            provider.loadObject(ofClass: NSURL.self) { @Sendable object, _ in
-                guard let nsURL = object as? NSURL else { return }
-                let url = nsURL as URL
-                Task { @MainActor in
-                    model.copyItems([url], to: destination)
-                }
+            let handler = SFTPMainActorValueHandler<URL> { url in
+                model.copyItems([url], to: destination)
             }
+            SFTPItemProviderBridge.loadFileURL(
+                from: provider,
+                handler: handler
+            )
         }
         return true
     }
@@ -1907,17 +1898,17 @@ private struct SFTPWorkspaceRemotePaneView: View {
         }
         if !fileProviders.isEmpty {
   for provider in fileProviders {
-      provider.loadObject(ofClass: NSURL.self) { @Sendable object, _ in
-          guard let nsURL = object as? NSURL else { return }
-          let url = nsURL as URL
-          Task { @MainActor in
-              remote.upload(
-                  localURLs: [url],
-                  to: destinationDirectory,
-                  settings: destinationSettings
-              )
-          }
+      let handler = SFTPMainActorValueHandler<URL> { url in
+          remote.upload(
+              localURLs: [url],
+              to: destinationDirectory,
+              settings: destinationSettings
+          )
       }
+      SFTPItemProviderBridge.loadFileURL(
+          from: provider,
+          handler: handler
+      )
   }
   return true
         }
@@ -1929,20 +1920,17 @@ private struct SFTPWorkspaceRemotePaneView: View {
         }
         guard !stringProviders.isEmpty else { return false }
         for provider in stringProviders {
-  provider.loadDataRepresentation(
-      forTypeIdentifier: NSPasteboard.PasteboardType.string.rawValue
-  ) { @Sendable data, _ in
-      guard let data,
-            let value = String(data: data, encoding: .utf8)
-      else { return }
-      Task { @MainActor in
-          _ = acceptInternalRemoteDrag(
-              [value],
-              to: destinationDirectory,
-              destinationSettings: destinationSettings
-          )
-      }
+  let handler = SFTPMainActorValueHandler<String> { value in
+      _ = acceptInternalRemoteDrag(
+          [value],
+          to: destinationDirectory,
+          destinationSettings: destinationSettings
+      )
   }
+  SFTPItemProviderBridge.loadString(
+      from: provider,
+      handler: handler
+  )
         }
         return true
 

--- a/Tests/SelectiveRemoteTests/SFTPLifecycleRegressionTests.swift
+++ b/Tests/SelectiveRemoteTests/SFTPLifecycleRegressionTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Testing
 @testable import SelectiveRemote
@@ -101,36 +102,56 @@ func legacySingleSessionSFTPRuntimeStaysRemoved() throws {
 }
 
 
-@Test("SFTP ItemProvider callbacks do not inherit MainActor")
-func sftpItemProviderCallbacksDoNotInheritMainActor() throws {
+@Test("SFTP Workspace keeps ItemProvider callbacks outside MainActor views")
+func sftpWorkspaceUsesNonActorItemProviderBridge() throws {
     let root = URL(fileURLWithPath: #filePath)
         .deletingLastPathComponent()
         .deletingLastPathComponent()
         .deletingLastPathComponent()
 
-    let source = try String(
+    let workspace = try String(
         contentsOf: root.appendingPathComponent(
             "Sources/SelectiveRemote/SFTPWorkspace.swift"
         ),
         encoding: .utf8
     )
 
-    // NSItemProvider completion handlers may execute on Foundation's
-    // callback queue. They must remain Sendable/nonisolated and perform
-    // the actual SFTP/UI work only after an explicit MainActor hop.
-    #expect(
-        source.components(
-            separatedBy: "{ @Sendable data, _ in"
-        ).count >= 4
-    )
-    #expect(
-        source.components(
-            separatedBy: "{ @Sendable object, _ in"
-        ).count >= 3
+    let models = try String(
+        contentsOf: root.appendingPathComponent(
+            "Sources/SelectiveRemote/SFTPBrowserModels.swift"
+        ),
+        encoding: .utf8
     )
 
-    #expect(!source.contains(") { data, _ in"))
-    #expect(!source.contains("NSURL.self) { object, _ in"))
+    // Foundation callbacks must never be created inside SwiftUI Views.
+    #expect(!workspace.contains("loadDataRepresentation("))
+    #expect(!workspace.contains("loadObject(ofClass: NSURL.self)"))
 
-    #expect(source.contains("Task { @MainActor in"))
+    #expect(models.contains("enum SFTPItemProviderBridge"))
+    #expect(models.contains("SFTPMainActorValueHandler"))
+    #expect(models.contains("Task { @MainActor in"))
+}
+
+@Test("SFTP ItemProvider bridge survives asynchronous delivery")
+@MainActor
+func sftpItemProviderBridgeSurvivesAsynchronousDelivery() async {
+    let expected = "selective-remote-server-to-server-probe"
+
+    let provider = NSItemProvider(
+        item: Data(expected.utf8) as NSData,
+        typeIdentifier: NSPasteboard.PasteboardType.string.rawValue
+    )
+
+    let received: String = await withCheckedContinuation { continuation in
+        let handler = SFTPMainActorValueHandler<String> { value in
+            continuation.resume(returning: value)
+        }
+
+        SFTPItemProviderBridge.loadString(
+            from: provider,
+            handler: handler
+        )
+    }
+
+    #expect(received == expected)
 }

--- a/Tests/SelectiveRemoteTests/SFTPWorkspaceSmartLinksTests.swift
+++ b/Tests/SelectiveRemoteTests/SFTPWorkspaceSmartLinksTests.swift
@@ -333,20 +333,55 @@ func sftpWorkspaceIsObservedDirectlyByConnectionCenter() throws {
 }
 
 
-@Test("SFTP file URL drop loads NSURL instead of file contents")
+@Test("SFTP file URL drop loads NSURL through non-actor bridge")
 func sftpFileURLDropLoadsURLObject() throws {
     let projectRoot = URL(fileURLWithPath: #filePath)
         .deletingLastPathComponent()
         .deletingLastPathComponent()
         .deletingLastPathComponent()
-    let source = try String(
+
+    let workspace = try String(
         contentsOf: projectRoot
-  .appendingPathComponent("Sources/SelectiveRemote/SFTPWorkspace.swift"),
+            .appendingPathComponent(
+                "Sources/SelectiveRemote/SFTPWorkspace.swift"
+            ),
         encoding: .utf8
     )
 
-    #expect(source.components(separatedBy: "provider.loadObject(ofClass: NSURL.self)").count - 1 == 2)
-    #expect(!source.contains("forTypeIdentifier: UTType.fileURL.identifier\n            ) { data, _ in"))
+    let models = try String(
+        contentsOf: projectRoot
+            .appendingPathComponent(
+                "Sources/SelectiveRemote/SFTPBrowserModels.swift"
+            ),
+        encoding: .utf8
+    )
+
+    // SwiftUI/MainActor views must not own NSItemProvider callbacks.
+    #expect(
+        !workspace.contains(
+            "provider.loadObject(ofClass: NSURL.self)"
+        )
+    )
+
+    // Both Mac -> Server and file URL drops use the shared bridge.
+    #expect(
+        workspace.components(
+            separatedBy: "SFTPItemProviderBridge.loadFileURL("
+        ).count - 1 == 2
+    )
+
+    // The shared bridge loads NSURL itself, not the file contents.
+    #expect(
+        models.components(
+            separatedBy: "provider.loadObject(ofClass: NSURL.self)"
+        ).count - 1 == 1
+    )
+
+    #expect(
+        !models.contains(
+            "forTypeIdentifier: UTType.fileURL.identifier"
+        )
+    )
 }
 
 

--- a/scripts/build_app.sh
+++ b/scripts/build_app.sh
@@ -4,11 +4,11 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-VERSION="0.22.3"
+VERSION="0.22.4"
 # CFBundleVersion is an internal monotonically increasing identifier required
 # by macOS and the update comparator. It is deliberately not shown as part of
 # the public application version.
-BUILD_NUMBER="128"
+BUILD_NUMBER="129"
 APP_NAME="Selective Remote"
 ARTIFACT_NAME="SelectiveRemote"
 EXECUTABLE_NAME="SelectiveRemote"


### PR DESCRIPTION
## Summary

Fixes the production Server → Server SFTP drag-and-drop crash that remained in 0.22.3.

## Root cause

NSItemProvider completion handlers were still created inside MainActor-isolated SwiftUI views. On the production Swift 6 toolchain, Foundation invokes those callbacks on NSItemProvider-callback-queue, causing runtime executor validation to terminate the app with SIGTRAP.

## Fix

- Move all NSItemProvider completion handlers into a dedicated non-actor bridge.
- Pass only Sendable values from Foundation callbacks.
- Hop to MainActor only after asynchronous provider delivery completes.
- Cover Server → Server, Server → Mac, Mac → Server and local file URL drops.
- Replace source-text-only regression coverage with runtime asynchronous bridge testing.

## Validation

- swift test: 257/257 passed
- swift build -c release: passed
- Version: 0.22.4 / build 129

Manual DMG validation will be completed before merge.