### PR TITLE
Add global SSH Snippets with targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,5 +41,8 @@ jobs:
       - name: Test
         run: swift test
 
+      - name: Test terminal web interactions
+        run: node --test Tests/TerminalResourcesTests/*.test.js
+
       - name: Release build
         run: swift build -c release

--- a/.github/workflows/snippets-test-dmg.yml
+++ b/.github/workflows/snippets-test-dmg.yml
@@ -1,0 +1,60 @@
+name: Snippets Test DMG
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "Sources/SelectiveRemote/EmbeddedTerminalView.swift"
+      - "Sources/SelectiveRemote/TerminalCommandHistory.swift"
+      - "Sources/SelectiveRemote/TerminalSnippets.swift"
+      - "Sources/SelectiveRemote/TerminalResources/terminal-host.css"
+      - "Sources/SelectiveRemote/TerminalResources/terminal-host.js"
+      - "Sources/SelectiveRemote/TerminalResources/terminal.html"
+      - "Sources/SelectiveRemote/TerminalResources/terminal-snippet-interactions.js"
+      - "Tests/SelectiveRemoteTests/TerminalInteractionRegressionTests.swift"
+      - "Tests/SelectiveRemoteTests/TerminalSmartWorkspaceTests.swift"
+      - "Tests/SelectiveRemoteTests/TerminalTests.swift"
+      - "Tests/TerminalResourcesTests/terminal-snippet-interactions.test.js"
+      - ".github/workflows/snippets-test-dmg.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: snippets-test-dmg-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-test-dmg:
+    name: Build ARM64 Snippets test DMG on Xcode 16.2
+    runs-on: macos-14
+    timeout-minutes: 60
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_16.2.app/Contents/Developer
+      SELECTIVEREMOTE_UPDATE_FEED_URL: https://raw.githubusercontent.com/PastFly/Selective-Remote/main/Resources/updates.json
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v6
+
+      - name: Environment
+        run: |
+          xcodebuild -version
+          swift --version
+          swift --version | grep -E 'Swift version 6\.'
+
+      - name: Install build dependencies
+        run: brew install freerdp sdl3
+
+      - name: Build test DMG
+        run: ./scripts/build_app.sh
+
+      - name: Upload test DMG
+        uses: actions/upload-artifact@v4
+        with:
+          name: SelectiveRemote-snippets-test-${{ github.event.pull_request.number }}-${{ github.sha }}
+          path: |
+            dist/*.dmg
+            dist/*.dmg.sha256
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/snippets-test-dmg.yml
+++ b/.github/workflows/snippets-test-dmg.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout PR
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Environment
         run: |
@@ -52,7 +54,7 @@ jobs:
       - name: Upload test DMG
         uses: actions/upload-artifact@v4
         with:
-          name: SelectiveRemote-snippets-test-${{ github.event.pull_request.number }}-${{ github.sha }}
+          name: SelectiveRemote-snippets-test-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
           path: |
             dist/*.dmg
             dist/*.dmg.sha256

--- a/Sources/SelectiveRemote/AppModel.swift
+++ b/Sources/SelectiveRemote/AppModel.swift
@@ -314,6 +314,7 @@ final class AppModel: NSObject, ObservableObject {
     }
     @Published var statusMessage = ""
     @Published var errorMessage: String?
+    @Published private(set) var latestSnippetRun: TerminalSnippetRunSummary?
     @Published var updateMessage: String?
     @Published private(set) var isCheckingForUpdates = false
     @Published private(set) var availableUpdateURL: URL?
@@ -3315,13 +3316,44 @@ final class AppModel: NSObject, ObservableObject {
         let targets = snippet.targetProfileIDs.filter(availableTargets.contains)
         guard !targets.isEmpty else { return .noTargets }
 
+        let runID = UUID()
+        latestSnippetRun = TerminalSnippetRunSummary(
+            id: runID,
+            snippetID: snippet.id,
+            title: snippet.title,
+            startedAt: Date(),
+            targets: targets.compactMap { profileID in
+                guard let profile = profiles.first(where: { $0.id == profileID }) else {
+                    return nil
+                }
+                return TerminalSnippetTargetRunStatus(
+                    profileID: profileID,
+                    name: profile.friendlyName.isEmpty ? profile.host : profile.friendlyName,
+                    state: .connecting
+                )
+            }
+        )
+
         var startedConnection = false
         var acceptedTargets = 0
         for profileID in targets {
-            guard let tab = snippetTerminalTab(for: profileID) else { continue }
+            guard let tab = snippetTerminalTab(for: profileID) else {
+                updateSnippetRun(
+                    id: runID,
+                    profileID: profileID,
+                    state: .failed("Не удалось подготовить вкладку терминала")
+                )
+                continue
+            }
             acceptedTargets += 1
             if case .running = tab.session.phase {
-                sendSnippetInput(input, command: snippet.command, profileID: profileID, session: tab.session)
+                sendSnippetInput(
+                    input,
+                    command: snippet.command,
+                    profileID: profileID,
+                    session: tab.session,
+                    runID: runID
+                )
             } else {
                 startedConnection = true
                 if !tab.session.isRunning {
@@ -3335,7 +3367,8 @@ final class AppModel: NSObject, ObservableObject {
                     input,
                     command: snippet.command,
                     profileID: profileID,
-                    session: tab.session
+                    session: tab.session,
+                    runID: runID
                 )
             }
         }
@@ -3377,7 +3410,8 @@ final class AppModel: NSObject, ObservableObject {
         _ input: Data,
         command: String,
         profileID: UUID,
-        session: TerminalSessionModel
+        session: TerminalSessionModel,
+        runID: UUID
     ) {
         Task { @MainActor [weak self, weak session] in
             var runningTicks = 0
@@ -3392,7 +3426,8 @@ final class AppModel: NSObject, ObservableObject {
                             input,
                             command: command,
                             profileID: profileID,
-                            session: session
+                            session: session,
+                            runID: runID
                         )
                         return
                     }
@@ -3400,11 +3435,21 @@ final class AppModel: NSObject, ObservableObject {
                     runningTicks = 0
                 }
                 if case .finished = session.phase {
+                    self.updateSnippetRun(
+                        id: runID,
+                        profileID: profileID,
+                        state: .failed("SSH-сессия завершилась до отправки команды")
+                    )
                     self.errorMessage = "Snippets: SSH-подключение к Target завершилось до выполнения команды"
                     return
                 }
                 try? await Task.sleep(for: .milliseconds(100))
             }
+            self?.updateSnippetRun(
+                id: runID,
+                profileID: profileID,
+                state: .failed("SSH не подключился за 40 секунд")
+            )
             self?.errorMessage = "Snippets: SSH-подключение к Target не завершилось за 40 секунд"
         }
     }
@@ -3428,13 +3473,55 @@ final class AppModel: NSObject, ObservableObject {
         _ input: Data,
         command: String,
         profileID: UUID,
-        session: TerminalSessionModel
+        session: TerminalSessionModel,
+        runID: UUID
     ) {
         _ = TerminalCommandHistoryStore.shared.record(
             command: command,
             profileID: profileID
         )
         session.sendInput(input)
+        updateSnippetRun(id: runID, profileID: profileID, state: .sent)
+    }
+
+    private func updateSnippetRun(
+        id: UUID,
+        profileID: UUID,
+        state: TerminalSnippetTargetRunState
+    ) {
+        guard var summary = latestSnippetRun, summary.id == id,
+              let index = summary.targets.firstIndex(where: { $0.profileID == profileID })
+        else { return }
+        summary.targets[index].state = state
+        latestSnippetRun = summary
+    }
+
+    func disconnectTerminalSnippetTargets(_ profileIDs: [UUID]) {
+        let targetIDs = Set(profileIDs)
+        guard !targetIDs.isEmpty else { return }
+        var stoppedSessions = Set<ObjectIdentifier>()
+        var stoppedCount = 0
+        for workspace in terminalWorkspaces.values {
+            for tab in workspace.tabs {
+                guard let profileID = tab.connection.profileID,
+                      targetIDs.contains(profileID)
+                else { continue }
+                let identifier = ObjectIdentifier(tab.session)
+                guard tab.session.isRunning, stoppedSessions.insert(identifier).inserted else { continue }
+                tab.session.stop()
+                stoppedCount += 1
+            }
+        }
+        for profileID in targetIDs {
+            guard let session = sshTerminalSessions[profileID], session.isRunning else { continue }
+            let identifier = ObjectIdentifier(session)
+            guard stoppedSessions.insert(identifier).inserted else { continue }
+            session.stop()
+            stoppedCount += 1
+        }
+        statusMessage = stoppedCount == 0
+            ? "Snippets: активных SSH-сессий Targets нет"
+            : "Snippets: отключаем SSH-сессии Targets — \(stoppedCount)"
     }
 
     private func canAutomaticallyReconnectSSH(

--- a/Sources/SelectiveRemote/AppModel.swift
+++ b/Sources/SelectiveRemote/AppModel.swift
@@ -3304,6 +3304,139 @@ final class AppModel: NSObject, ObservableObject {
         }
     }
 
+    @discardableResult
+    func runTerminalSnippet(_ snippet: TerminalCommandTemplate) -> TerminalSnippetRunResult {
+        guard let input = TerminalSnippetExecution.inputData(for: snippet.command) else {
+            return .invalidSnippet
+        }
+        let availableTargets = Set(
+            profiles.lazy.filter { $0.connectionType == .ssh }.map(\.id)
+        )
+        let targets = snippet.targetProfileIDs.filter(availableTargets.contains)
+        guard !targets.isEmpty else { return .noTargets }
+
+        var startedConnection = false
+        var acceptedTargets = 0
+        for profileID in targets {
+            guard let tab = snippetTerminalTab(for: profileID) else { continue }
+            acceptedTargets += 1
+            if case .running = tab.session.phase {
+                sendSnippetInput(input, command: snippet.command, profileID: profileID, session: tab.session)
+            } else {
+                startedConnection = true
+                if !tab.session.isRunning {
+                    connectSSHTerminal(
+                        connection: tab.connection,
+                        tabID: tab.id,
+                        session: tab.session
+                    )
+                }
+                enqueueSnippetInputAfterConnect(
+                    input,
+                    command: snippet.command,
+                    profileID: profileID,
+                    session: tab.session
+                )
+            }
+        }
+        guard acceptedTargets > 0 else { return .noTargets }
+        statusMessage = startedConnection
+            ? "Snippets: подключаем Targets и готовим выполнение"
+            : "Snippets: команда отправлена на \(acceptedTargets) SSH-целей"
+        return startedConnection ? .connecting : .success
+    }
+
+    private func snippetTerminalTab(for profileID: UUID) -> TerminalWorkspaceTab? {
+        let connection = TerminalTabConnection.savedProfile(profileID)
+        if let running = terminalWorkspaces.values
+            .flatMap(\.tabs)
+            .first(where: { $0.connection == connection && $0.session.isRunning }) {
+            return running
+        }
+
+        let global = globalTerminalWorkspace()
+        if let existing = global.tabs.first(where: { $0.connection == connection }) {
+            return existing
+        }
+
+        let profileWorkspace = terminalWorkspace(
+            profileID: profileID,
+            primaryConnection: connection
+        )
+        if let existing = profileWorkspace.tabs.first(where: { $0.connection == connection }) {
+            return existing
+        }
+        return profileWorkspace.addTab(
+            connection: connection,
+            title: connection.displayLabel(profiles: profiles),
+            select: false
+        )
+    }
+
+    private func enqueueSnippetInputAfterConnect(
+        _ input: Data,
+        command: String,
+        profileID: UUID,
+        session: TerminalSessionModel
+    ) {
+        Task { @MainActor [weak self, weak session] in
+            var runningTicks = 0
+            for _ in 0..<400 {
+                guard let self, let session else { return }
+                if case .running = session.phase {
+                    runningTicks += 1
+                    if runningTicks >= 10,
+                       self.snippetShellAppearsReady(session.recentOutputText())
+                            || runningTicks >= 300 {
+                        self.sendSnippetInput(
+                            input,
+                            command: command,
+                            profileID: profileID,
+                            session: session
+                        )
+                        return
+                    }
+                } else {
+                    runningTicks = 0
+                }
+                if case .finished = session.phase {
+                    self.errorMessage = "Snippets: SSH-подключение к Target завершилось до выполнения команды"
+                    return
+                }
+                try? await Task.sleep(for: .milliseconds(100))
+            }
+            self?.errorMessage = "Snippets: SSH-подключение к Target не завершилось за 40 секунд"
+        }
+    }
+
+    private func snippetShellAppearsReady(_ output: String) -> Bool {
+        let cleaned = output.replacingOccurrences(
+            of: "\u{001B}\\[[0-9;?]*[ -/]*[@-~]",
+            with: "",
+            options: .regularExpression
+        )
+        guard let line = cleaned
+            .split(whereSeparator: { $0.isNewline })
+            .last?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              let marker = line.last
+        else { return false }
+        return marker == "$" || marker == "#" || marker == ">" || marker == "%"
+    }
+
+    private func sendSnippetInput(
+        _ input: Data,
+        command: String,
+        profileID: UUID,
+        session: TerminalSessionModel
+    ) {
+        _ = TerminalCommandHistoryStore.shared.record(
+            command: command,
+            profileID: profileID
+        )
+        session.sendInput(input)
+    }
+
     private func canAutomaticallyReconnectSSH(
         settings: SSHConnectionSettings,
         connection: TerminalTabConnection,

--- a/Sources/SelectiveRemote/ContentView.swift
+++ b/Sources/SelectiveRemote/ContentView.swift
@@ -33,6 +33,7 @@ private enum ProfileTab: String, CaseIterable, Identifiable {
 private enum MainArea: String, CaseIterable, Identifiable {
     case connectionCenter = "Connection Center"
     case connections = "Подключения"
+    case snippets = "Сниппеты"
     case terminal = "Терминал"
     case sftp = "SFTP"
     case forwarding = "Forwarding"
@@ -45,6 +46,7 @@ private enum MainArea: String, CaseIterable, Identifiable {
         switch self {
         case .connectionCenter: "point.3.connected.trianglepath.dotted"
         case .connections: "rectangle.stack"
+        case .snippets: "curlybraces"
         case .terminal: "terminal"
         case .sftp: "folder.badge.gearshape"
         case .diagnostics: "stethoscope"
@@ -71,6 +73,7 @@ struct ContentView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @StateObject private var terminalAppearance = TerminalAppearanceStore()
     @StateObject private var appAppearance = AppAppearanceStore()
+    @StateObject private var snippets = TerminalCommandHistoryStore.shared
     @State private var selectedTab = ProfileTab.general
     @State private var profileTabs: [UUID: ProfileTab] = [:]
     @State private var mainArea = MainArea.connectionCenter
@@ -620,6 +623,12 @@ struct ContentView: View {
                 connectionCenterDetail
             case .connections:
                 profileDetail
+            case .snippets:
+                TerminalSnippetsLibraryView(
+                    store: snippets,
+                    profiles: model.profiles,
+                    onRun: model.runTerminalSnippet
+                )
             case .terminal:
                 globalTerminalDetail
             case .sftp:
@@ -1932,6 +1941,7 @@ struct ContentView: View {
                 )
                 selectedTab = .sftp
             },
+            executeSnippet: model.runTerminalSnippet,
             discoverContext: { tab in
                 try await model.discoverTerminalContext(
                     connection: tab.connection,
@@ -1984,6 +1994,7 @@ struct ContentView: View {
                 )
                 setMainArea(.sftp)
             },
+            executeSnippet: model.runTerminalSnippet,
             discoverContext: { tab in
                 try await model.discoverTerminalContext(
                     connection: tab.connection,

--- a/Sources/SelectiveRemote/ContentView.swift
+++ b/Sources/SelectiveRemote/ContentView.swift
@@ -33,10 +33,10 @@ private enum ProfileTab: String, CaseIterable, Identifiable {
 private enum MainArea: String, CaseIterable, Identifiable {
     case connectionCenter = "Connection Center"
     case connections = "Подключения"
-    case snippets = "Сниппеты"
     case terminal = "Терминал"
     case sftp = "SFTP"
     case forwarding = "Forwarding"
+    case snippets = "Сниппеты"
     case diagnostics = "Диагностика"
     case keychain = "Keychain"
 
@@ -626,8 +626,7 @@ struct ContentView: View {
             case .snippets:
                 TerminalSnippetsLibraryView(
                     store: snippets,
-                    profiles: model.profiles,
-                    onRun: model.runTerminalSnippet
+                    model: model
                 )
             case .terminal:
                 globalTerminalDetail

--- a/Sources/SelectiveRemote/EmbeddedTerminalView.swift
+++ b/Sources/SelectiveRemote/EmbeddedTerminalView.swift
@@ -568,12 +568,15 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
                 else { return }
                 let category = payload["category"] as? String
                     ?? TerminalCommandHistoryStore.defaultSnippetGroupName
+                let targetProfileIDs = (payload["targetProfileIDs"] as? [String])?
+                    .compactMap(UUID.init(uuidString:))
                 _ = store.saveTemplate(
                     id: id,
                     title: title,
                     command: command,
                     category: category,
-                    profileID: context.profileID
+                    profileID: context.profileID,
+                    targetProfileIDs: targetProfileIDs
                 )
                 refreshHistory()
             case "removeTemplate", "removeSnippet":
@@ -660,6 +663,7 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
                   let context = historyContext,
                   let json = TerminalCommandHistoryStore.shared.webPayload(
                       for: context.profileID,
+                      snippetTargets: context.snippetTargets,
                       remote: remoteContext
                   )
             else { return }
@@ -1614,7 +1618,14 @@ struct SSHTerminalView: View {
                 session: tab.session,
                 appearance: appearance.snapshot,
                 historyContext: TerminalHistoryContext(
-                    profileID: historyContextID(for: tab)
+                    profileID: historyContextID(for: tab),
+                    snippetTargets: sshProfiles.map { profile in
+                        TerminalSnippetTargetOption(
+                            id: profile.id,
+                            title: profile.friendlyName.isEmpty ? profile.host : profile.friendlyName,
+                            subtitle: profile.host
+                        )
+                    }
                 ),
                 remoteContext: workspace.remoteContext(for: tab.id) ?? .empty,
                 snippetRevision: snippetStore.snippetRevision,

--- a/Sources/SelectiveRemote/EmbeddedTerminalView.swift
+++ b/Sources/SelectiveRemote/EmbeddedTerminalView.swift
@@ -33,12 +33,13 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
     let appearance: TerminalAppearanceSnapshot
     let historyContext: TerminalHistoryContext?
     let remoteContext: TerminalRemoteContextSnapshot
+    let snippetRevision: Int
     let onRemoteContextRetry: () -> Void
     let onFocus: () -> Void
     let onInput: (Data) -> Void
     let onTabNavigation: (Int) -> Void
     let onSmartLink: (TerminalSmartLink) -> Void
-    let onSnippetRun: (String) -> TerminalSnippetRunResult
+    let onSnippetRun: (TerminalCommandTemplate) -> TerminalSnippetRunResult
     @Binding var historyVisible: Bool
     @Binding var snippetsVisible: Bool
 
@@ -47,12 +48,13 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
         appearance: TerminalAppearanceSnapshot,
         historyContext: TerminalHistoryContext? = nil,
         remoteContext: TerminalRemoteContextSnapshot = .empty,
+        snippetRevision: Int = 0,
         onRemoteContextRetry: @escaping () -> Void = {},
         onFocus: @escaping () -> Void = {},
         onInput: ((Data) -> Void)? = nil,
         onTabNavigation: @escaping (Int) -> Void = { _ in },
         onSmartLink: @escaping (TerminalSmartLink) -> Void = { _ in },
-        onSnippetRun: @escaping (String) -> TerminalSnippetRunResult = { _ in
+        onSnippetRun: @escaping (TerminalCommandTemplate) -> TerminalSnippetRunResult = { _ in
             .inactiveSession
         },
         historyVisible: Binding<Bool> = .constant(false),
@@ -62,6 +64,7 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
         self.appearance = appearance
         self.historyContext = historyContext
         self.remoteContext = remoteContext
+        self.snippetRevision = snippetRevision
         self.onRemoteContextRetry = onRemoteContextRetry
         self.onFocus = onFocus
         self.onInput = onInput ?? { _ in }
@@ -79,6 +82,7 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
             languageCode: locale.identifier.lowercased().hasPrefix("en") ? "en" : "ru",
             historyContext: historyContext,
             remoteContext: remoteContext,
+            snippetRevision: snippetRevision,
             onRemoteContextRetry: onRemoteContextRetry,
             onFocus: onFocus,
             onInput: onInput,
@@ -154,6 +158,7 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
             locale.identifier.lowercased().hasPrefix("en") ? "en" : "ru"
         )
         context.coordinator.updateRemoteContext(remoteContext)
+        context.coordinator.updateSnippetRevision(snippetRevision)
         context.coordinator.updateRemoteContextRetryHandler(onRemoteContextRetry)
         context.coordinator.updateFocusHandler(onFocus)
         context.coordinator.updateInputHandler(onInput)
@@ -214,7 +219,7 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
         private var onInput: (Data) -> Void
         private var onTabNavigation: (Int) -> Void
         private var onSmartLink: (TerminalSmartLink) -> Void
-        private var onSnippetRun: (String) -> TerminalSnippetRunResult
+        private var onSnippetRun: (TerminalCommandTemplate) -> TerminalSnippetRunResult
         private var historyVisible: Binding<Bool>
         private var snippetsVisible: Binding<Bool>
         private var appliedPanelMode: String?
@@ -222,6 +227,7 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
         private var pendingBase64: [String] = []
         private var writeInFlight = false
         private var navigationGeneration = 0
+        private var snippetRevision: Int
 
         init(
             session: TerminalSessionModel,
@@ -229,12 +235,13 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
             languageCode: String,
             historyContext: TerminalHistoryContext?,
             remoteContext: TerminalRemoteContextSnapshot,
+            snippetRevision: Int,
             onRemoteContextRetry: @escaping () -> Void,
             onFocus: @escaping () -> Void,
             onInput: @escaping (Data) -> Void,
             onTabNavigation: @escaping (Int) -> Void,
             onSmartLink: @escaping (TerminalSmartLink) -> Void,
-            onSnippetRun: @escaping (String) -> TerminalSnippetRunResult,
+            onSnippetRun: @escaping (TerminalCommandTemplate) -> TerminalSnippetRunResult,
             historyVisible: Binding<Bool>,
             snippetsVisible: Binding<Bool>
         ) {
@@ -243,6 +250,7 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
             self.languageCode = languageCode
             self.historyContext = historyContext
             self.remoteContext = remoteContext
+            self.snippetRevision = snippetRevision
             self.onRemoteContextRetry = onRemoteContextRetry
             self.onFocus = onFocus
             self.onInput = onInput
@@ -293,6 +301,12 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
             refreshHistory()
         }
 
+        func updateSnippetRevision(_ updated: Int) {
+            guard snippetRevision != updated else { return }
+            snippetRevision = updated
+            refreshHistory()
+        }
+
         func updateRemoteContextRetryHandler(_ updated: @escaping () -> Void) {
             onRemoteContextRetry = updated
         }
@@ -316,7 +330,7 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
         }
 
         func updateSnippetRunHandler(
-            _ updated: @escaping (String) -> TerminalSnippetRunResult
+            _ updated: @escaping (TerminalCommandTemplate) -> TerminalSnippetRunResult
         ) {
             onSnippetRun = updated
         }
@@ -566,7 +580,7 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
                 guard let value = payload["id"] as? String,
                       let id = UUID(uuidString: value)
                 else { return }
-                store.removeTemplate(id: id, profileID: context.profileID)
+                _ = store.removeTemplate(id: id)
                 refreshHistory()
             case "createSnippetGroup":
                 guard let name = payload["name"] as? String else { return }
@@ -610,13 +624,13 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
             case "runSnippet":
                 guard let value = payload["id"] as? String,
                       let id = UUID(uuidString: value),
-                      let snippet = store.template(id: id, profileID: context.profileID)
+                      var snippet = store.template(id: id)
                 else {
                     reportSnippetRun(.invalidSnippet)
                     return
                 }
-                let command = payload["command"] as? String ?? snippet.command
-                reportSnippetRun(onSnippetRun(command))
+                snippet.command = payload["command"] as? String ?? snippet.command
+                reportSnippetRun(onSnippetRun(snippet))
             case "visibility":
                 guard let visible = (payload["visible"] as? NSNumber)?.boolValue
                 else { return }
@@ -676,6 +690,7 @@ struct SSHTerminalView: View {
     @ObservedObject var workspace: TerminalWorkspaceModel
     @ObservedObject var appearance: TerminalAppearanceStore
     @ObservedObject var appAppearance: AppAppearanceStore
+    @ObservedObject var snippetStore = TerminalCommandHistoryStore.shared
     let workspaceTitle: String
     let defaultProfileID: UUID?
     let locksPrimaryConnection: Bool
@@ -687,6 +702,7 @@ struct SSHTerminalView: View {
     let toggleFocusMode: () -> Void
     let openSFTP: (TerminalWorkspaceTab) -> Void
     let openSFTPPath: (TerminalWorkspaceTab, String) -> Void
+    let executeSnippet: (TerminalCommandTemplate) -> TerminalSnippetRunResult
     let discoverContext: (TerminalWorkspaceTab) async throws -> TerminalRemoteContextSnapshot
 
     @State private var showsAppearance = false
@@ -1601,6 +1617,7 @@ struct SSHTerminalView: View {
                     profileID: historyContextID(for: tab)
                 ),
                 remoteContext: workspace.remoteContext(for: tab.id) ?? .empty,
+                snippetRevision: snippetStore.snippetRevision,
                 onRemoteContextRetry: {
                     selectTabIfNeeded(tab.id)
                     refreshRemoteContext(for: tab.id)
@@ -1633,9 +1650,7 @@ struct SSHTerminalView: View {
                         NSPasteboard.general.setString(link.value, forType: .string)
                     }
                 },
-                onSnippetRun: { command in
-                    runSnippet(command, in: tab.id)
-                },
+                onSnippetRun: executeSnippet,
                 historyVisible: Binding(
                     get: { showsHistory && tab.id == workspace.selectedTabID },
                     set: { visible in
@@ -2007,29 +2022,6 @@ struct SSHTerminalView: View {
                 for: tabID
             )
         }
-    }
-
-    private func runSnippet(
-        _ command: String,
-        in tabID: UUID
-    ) -> TerminalSnippetRunResult {
-        guard TerminalSnippetExecution.canRun(
-            originTabID: tabID,
-            selectedTabID: workspace.selectedTabID,
-            sessionIsRunning: workspace.tabs.first(where: { $0.id == tabID })?.session.isRunning
-                == true
-        ), let tab = workspace.tabs.first(where: { $0.id == tabID }),
-           let input = TerminalSnippetExecution.inputData(for: command)
-        else { return .inactiveSession }
-
-        _ = TerminalCommandHistoryStore.shared.record(
-            command: command,
-            profileID: historyContextID(for: tab)
-        )
-        // Snippets intentionally bypass broadcast mode: their scope is exactly
-        // the selected terminal session that originated the run request.
-        tab.session.sendInput(input)
-        return .success
     }
 
     private func runServerCommand(_ rawCommand: String, in tabID: UUID) {

--- a/Sources/SelectiveRemote/EmbeddedTerminalView.swift
+++ b/Sources/SelectiveRemote/EmbeddedTerminalView.swift
@@ -28,6 +28,7 @@ private enum TerminalResourceLocator {
 }
 
 struct EmbeddedTerminalWebView: NSViewRepresentable {
+    @Environment(\.locale) private var locale
     @ObservedObject var session: TerminalSessionModel
     let appearance: TerminalAppearanceSnapshot
     let historyContext: TerminalHistoryContext?
@@ -37,7 +38,9 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
     let onInput: (Data) -> Void
     let onTabNavigation: (Int) -> Void
     let onSmartLink: (TerminalSmartLink) -> Void
+    let onSnippetRun: (String) -> TerminalSnippetRunResult
     @Binding var historyVisible: Bool
+    @Binding var snippetsVisible: Bool
 
     init(
         session: TerminalSessionModel,
@@ -49,7 +52,11 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
         onInput: ((Data) -> Void)? = nil,
         onTabNavigation: @escaping (Int) -> Void = { _ in },
         onSmartLink: @escaping (TerminalSmartLink) -> Void = { _ in },
-        historyVisible: Binding<Bool> = .constant(false)
+        onSnippetRun: @escaping (String) -> TerminalSnippetRunResult = { _ in
+            .inactiveSession
+        },
+        historyVisible: Binding<Bool> = .constant(false),
+        snippetsVisible: Binding<Bool> = .constant(false)
     ) {
         self.session = session
         self.appearance = appearance
@@ -60,13 +67,16 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
         self.onInput = onInput ?? { _ in }
         self.onTabNavigation = onTabNavigation
         self.onSmartLink = onSmartLink
+        self.onSnippetRun = onSnippetRun
         _historyVisible = historyVisible
+        _snippetsVisible = snippetsVisible
     }
 
     func makeCoordinator() -> Coordinator {
         Coordinator(
             session: session,
             appearance: appearance,
+            languageCode: locale.identifier.lowercased().hasPrefix("en") ? "en" : "ru",
             historyContext: historyContext,
             remoteContext: remoteContext,
             onRemoteContextRetry: onRemoteContextRetry,
@@ -74,7 +84,9 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
             onInput: onInput,
             onTabNavigation: onTabNavigation,
             onSmartLink: onSmartLink,
-            historyVisible: _historyVisible
+            onSnippetRun: onSnippetRun,
+            historyVisible: _historyVisible,
+            snippetsVisible: _snippetsVisible
         )
     }
 
@@ -138,15 +150,22 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
 
     func updateNSView(_ webView: WKWebView, context: Context) {
         context.coordinator.updateHistoryContext(historyContext)
+        context.coordinator.updateLanguageCode(
+            locale.identifier.lowercased().hasPrefix("en") ? "en" : "ru"
+        )
         context.coordinator.updateRemoteContext(remoteContext)
         context.coordinator.updateRemoteContextRetryHandler(onRemoteContextRetry)
         context.coordinator.updateFocusHandler(onFocus)
         context.coordinator.updateInputHandler(onInput)
         context.coordinator.updateTabNavigationHandler(onTabNavigation)
         context.coordinator.updateSmartLinkHandler(onSmartLink)
+        context.coordinator.updateSnippetRunHandler(onSnippetRun)
         context.coordinator.updateSession(session)
         context.coordinator.updateAppearance(appearance)
-        context.coordinator.updateHistoryVisibility(historyVisible)
+        context.coordinator.updatePanelVisibility(
+            historyVisible: historyVisible,
+            snippetsVisible: snippetsVisible
+        )
     }
 
     static func dismantleNSView(_ webView: WKWebView, coordinator: Coordinator) {
@@ -187,6 +206,7 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
         private weak var webView: WKWebView?
         private var observerID: UUID?
         private var appearance: TerminalAppearanceSnapshot
+        private var languageCode: String
         private var historyContext: TerminalHistoryContext?
         private var remoteContext: TerminalRemoteContextSnapshot
         private var onRemoteContextRetry: () -> Void
@@ -194,8 +214,10 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
         private var onInput: (Data) -> Void
         private var onTabNavigation: (Int) -> Void
         private var onSmartLink: (TerminalSmartLink) -> Void
+        private var onSnippetRun: (String) -> TerminalSnippetRunResult
         private var historyVisible: Binding<Bool>
-        private var appliedHistoryVisibility: Bool?
+        private var snippetsVisible: Binding<Bool>
+        private var appliedPanelMode: String?
         private var pageReady = false
         private var pendingBase64: [String] = []
         private var writeInFlight = false
@@ -204,6 +226,7 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
         init(
             session: TerminalSessionModel,
             appearance: TerminalAppearanceSnapshot,
+            languageCode: String,
             historyContext: TerminalHistoryContext?,
             remoteContext: TerminalRemoteContextSnapshot,
             onRemoteContextRetry: @escaping () -> Void,
@@ -211,10 +234,13 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
             onInput: @escaping (Data) -> Void,
             onTabNavigation: @escaping (Int) -> Void,
             onSmartLink: @escaping (TerminalSmartLink) -> Void,
-            historyVisible: Binding<Bool>
+            onSnippetRun: @escaping (String) -> TerminalSnippetRunResult,
+            historyVisible: Binding<Bool>,
+            snippetsVisible: Binding<Bool>
         ) {
             self.session = session
             self.appearance = appearance
+            self.languageCode = languageCode
             self.historyContext = historyContext
             self.remoteContext = remoteContext
             self.onRemoteContextRetry = onRemoteContextRetry
@@ -222,7 +248,9 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
             self.onInput = onInput
             self.onTabNavigation = onTabNavigation
             self.onSmartLink = onSmartLink
+            self.onSnippetRun = onSnippetRun
             self.historyVisible = historyVisible
+            self.snippetsVisible = snippetsVisible
         }
 
         func attach(to webView: WKWebView) {
@@ -245,6 +273,12 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
             guard appearance != updated else { return }
             appearance = updated
             applyAppearance()
+        }
+
+        func updateLanguageCode(_ updated: String) {
+            guard languageCode != updated else { return }
+            languageCode = updated
+            applyLanguage()
         }
 
         func updateHistoryContext(_ updated: TerminalHistoryContext?) {
@@ -281,19 +315,26 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
             onSmartLink = updated
         }
 
-        func updateHistoryVisibility(_ visible: Bool) {
+        func updateSnippetRunHandler(
+            _ updated: @escaping (String) -> TerminalSnippetRunResult
+        ) {
+            onSnippetRun = updated
+        }
+
+        func updatePanelVisibility(historyVisible: Bool, snippetsVisible: Bool) {
             guard pageReady else {
-                appliedHistoryVisibility = nil
+                appliedPanelMode = nil
                 return
             }
-            guard appliedHistoryVisibility != visible else { return }
-            appliedHistoryVisibility = visible
+            let mode = snippetsVisible ? "snippets" : (historyVisible ? "history" : "hidden")
+            guard appliedPanelMode != mode else { return }
+            appliedPanelMode = mode
             webView?.evaluateJavaScript(
-                // Swift synchronizes history visibility when the active grid pane
-                // changes. Do not return focus to a pane merely because its history
-                // panel is being hidden programmatically: that focus event would
+                // Swift synchronizes quick-panel visibility when the active grid pane
+                // changes. Do not return focus to a pane merely because its panel
+                // is being hidden programmatically: that focus event would
                 // select the old pane again and make two panes bounce forever.
-                "window.selectiveTerminalSetHistoryVisible?.(\(visible ? "true" : "false"), false, false)"
+                "window.selectiveTerminalSetPanelMode?.('\(mode)', false, false)"
             )
         }
 
@@ -302,8 +343,8 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
             webView = nil
             pageReady = false
             writeInFlight = false
+            appliedPanelMode = nil
             pendingBase64.removeAll()
-            appliedHistoryVisibility = nil
         }
 
         func requestFit() {
@@ -362,10 +403,14 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             pageReady = true
             applyAppearance()
+            applyLanguage()
             requestFit()
             drainOutputQueue()
             refreshHistory()
-            updateHistoryVisibility(historyVisible.wrappedValue)
+            updatePanelVisibility(
+                historyVisible: historyVisible.wrappedValue,
+                snippetsVisible: snippetsVisible.wrappedValue
+            )
             webView.evaluateJavaScript("window.selectiveTerminalFocus?.()")
 
             // A host switch can recreate the WebView while the PTY keeps running.
@@ -390,7 +435,7 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
             navigationGeneration += 1
             pageReady = false
             writeInFlight = false
-            appliedHistoryVisibility = nil
+            appliedPanelMode = nil
             pendingBase64.removeAll(keepingCapacity: true)
             detachObserver()
             observeSession()
@@ -460,6 +505,13 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
             )
         }
 
+        private func applyLanguage() {
+            guard pageReady else { return }
+            webView?.evaluateJavaScript(
+                "window.selectiveTerminalSetLanguage?.('\(languageCode)')"
+            )
+        }
+
         private func handleHistoryMessage(_ body: Any) {
             guard let payload = body as? [String: Any],
                   let action = payload["action"] as? String
@@ -495,12 +547,13 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
                 guard let command = payload["command"] as? String else { return }
                 _ = store.toggleFavorite(command: command, profileID: context.profileID)
                 refreshHistory()
-            case "saveTemplate":
+            case "saveTemplate", "saveSnippet":
                 let id = (payload["id"] as? String).flatMap(UUID.init(uuidString:))
                 guard let title = payload["title"] as? String,
                       let command = payload["command"] as? String
                 else { return }
-                let category = payload["category"] as? String ?? "Мои команды"
+                let category = payload["category"] as? String
+                    ?? TerminalCommandHistoryStore.defaultSnippetGroupName
                 _ = store.saveTemplate(
                     id: id,
                     title: title,
@@ -509,20 +562,83 @@ struct EmbeddedTerminalWebView: NSViewRepresentable {
                     profileID: context.profileID
                 )
                 refreshHistory()
-            case "removeTemplate":
+            case "removeTemplate", "removeSnippet":
                 guard let value = payload["id"] as? String,
                       let id = UUID(uuidString: value)
                 else { return }
                 store.removeTemplate(id: id, profileID: context.profileID)
                 refreshHistory()
+            case "createSnippetGroup":
+                guard let name = payload["name"] as? String else { return }
+                _ = store.createSnippetGroup(name: name, profileID: context.profileID)
+                refreshHistory()
+            case "renameSnippetGroup":
+                guard let value = payload["id"] as? String,
+                      let id = UUID(uuidString: value),
+                      let name = payload["name"] as? String
+                else { return }
+                _ = store.renameSnippetGroup(
+                    id: id,
+                    name: name,
+                    profileID: context.profileID
+                )
+                refreshHistory()
+            case "removeSnippetGroup":
+                guard let value = payload["id"] as? String,
+                      let id = UUID(uuidString: value)
+                else { return }
+                _ = store.removeSnippetGroup(id: id, profileID: context.profileID)
+                refreshHistory()
+            case "duplicateSnippet":
+                guard let value = payload["id"] as? String,
+                      let id = UUID(uuidString: value)
+                else { return }
+                _ = store.duplicateTemplate(id: id, profileID: context.profileID)
+                refreshHistory()
+            case "moveSnippet":
+                guard let snippetValue = payload["id"] as? String,
+                      let snippetID = UUID(uuidString: snippetValue),
+                      let groupValue = payload["groupID"] as? String,
+                      let groupID = UUID(uuidString: groupValue)
+                else { return }
+                _ = store.moveTemplate(
+                    id: snippetID,
+                    toGroupID: groupID,
+                    profileID: context.profileID
+                )
+                refreshHistory()
+            case "runSnippet":
+                guard let value = payload["id"] as? String,
+                      let id = UUID(uuidString: value),
+                      let snippet = store.template(id: id, profileID: context.profileID)
+                else {
+                    reportSnippetRun(.invalidSnippet)
+                    return
+                }
+                let command = payload["command"] as? String ?? snippet.command
+                reportSnippetRun(onSnippetRun(command))
             case "visibility":
                 guard let visible = (payload["visible"] as? NSNumber)?.boolValue
                 else { return }
-                appliedHistoryVisibility = visible
+                appliedPanelMode = visible ? "history" : "hidden"
                 historyVisible.wrappedValue = visible
+                if visible { snippetsVisible.wrappedValue = false }
+            case "panelVisibility":
+                guard let mode = payload["mode"] as? String,
+                      ["hidden", "history", "snippets"].contains(mode)
+                else { return }
+                appliedPanelMode = mode
+                historyVisible.wrappedValue = mode == "history"
+                snippetsVisible.wrappedValue = mode == "snippets"
             default:
                 break
             }
+        }
+
+        private func reportSnippetRun(_ result: TerminalSnippetRunResult) {
+            webView?.evaluateJavaScript(
+                "window.selectiveTerminalReportSnippetRun?.('\(result.rawValue)')"
+            )
         }
 
         private func refreshHistory() {
@@ -556,6 +672,7 @@ private final class TerminalWKWebView: WKWebView {
 }
 
 struct SSHTerminalView: View {
+    @Environment(\.locale) private var locale
     @ObservedObject var workspace: TerminalWorkspaceModel
     @ObservedObject var appearance: TerminalAppearanceStore
     @ObservedObject var appAppearance: AppAppearanceStore
@@ -574,6 +691,7 @@ struct SSHTerminalView: View {
 
     @State private var showsAppearance = false
     @State private var showsHistory = false
+    @State private var showsSnippets = false
     @State private var showsServerCommands = false
     @State private var refreshingContextTabIDs: Set<UUID> = []
     @State private var remoteContextRequestIDs: [UUID: UUID] = [:]
@@ -843,6 +961,7 @@ struct SSHTerminalView: View {
             .help("Команды сервера")
 
             Button {
+                showsSnippets = false
                 showsHistory.toggle()
             } label: {
                 Image(systemName: "clock.arrow.circlepath")
@@ -850,6 +969,16 @@ struct SSHTerminalView: View {
             }
             .buttonStyle(.bordered)
             .help("История и подсказки")
+
+            Button {
+                showsHistory = false
+                showsSnippets.toggle()
+            } label: {
+                Image(systemName: "text.badge.plus")
+                    .font(.title3)
+            }
+            .buttonStyle(.bordered)
+            .help(locale.identifier.lowercased().hasPrefix("en") ? "Snippets" : "Сниппеты")
 
             if isFocusMode {
                 Button("Вернуть интерфейс", systemImage: "arrow.down.right.and.arrow.up.left") {
@@ -1504,6 +1633,9 @@ struct SSHTerminalView: View {
                         NSPasteboard.general.setString(link.value, forType: .string)
                     }
                 },
+                onSnippetRun: { command in
+                    runSnippet(command, in: tab.id)
+                },
                 historyVisible: Binding(
                     get: { showsHistory && tab.id == workspace.selectedTabID },
                     set: { visible in
@@ -1513,6 +1645,15 @@ struct SSHTerminalView: View {
                         // other while the history panel is open.
                         guard tab.id == workspace.selectedTabID else { return }
                         showsHistory = visible
+                        if visible { showsSnippets = false }
+                    }
+                ),
+                snippetsVisible: Binding(
+                    get: { showsSnippets && tab.id == workspace.selectedTabID },
+                    set: { visible in
+                        guard tab.id == workspace.selectedTabID else { return }
+                        showsSnippets = visible
+                        if visible { showsHistory = false }
                     }
                 )
             )
@@ -1866,6 +2007,29 @@ struct SSHTerminalView: View {
                 for: tabID
             )
         }
+    }
+
+    private func runSnippet(
+        _ command: String,
+        in tabID: UUID
+    ) -> TerminalSnippetRunResult {
+        guard TerminalSnippetExecution.canRun(
+            originTabID: tabID,
+            selectedTabID: workspace.selectedTabID,
+            sessionIsRunning: workspace.tabs.first(where: { $0.id == tabID })?.session.isRunning
+                == true
+        ), let tab = workspace.tabs.first(where: { $0.id == tabID }),
+           let input = TerminalSnippetExecution.inputData(for: command)
+        else { return .inactiveSession }
+
+        _ = TerminalCommandHistoryStore.shared.record(
+            command: command,
+            profileID: historyContextID(for: tab)
+        )
+        // Snippets intentionally bypass broadcast mode: their scope is exactly
+        // the selected terminal session that originated the run request.
+        tab.session.sendInput(input)
+        return .success
     }
 
     private func runServerCommand(_ rawCommand: String, in tabID: UUID) {

--- a/Sources/SelectiveRemote/TerminalCommandHistory.swift
+++ b/Sources/SelectiveRemote/TerminalCommandHistory.swift
@@ -3,6 +3,18 @@ import Foundation
 
 struct TerminalHistoryContext: Equatable {
     let profileID: UUID
+    let snippetTargets: [TerminalSnippetTargetOption]
+
+    init(profileID: UUID, snippetTargets: [TerminalSnippetTargetOption] = []) {
+        self.profileID = profileID
+        self.snippetTargets = snippetTargets
+    }
+}
+
+struct TerminalSnippetTargetOption: Encodable, Equatable, Identifiable {
+    let id: UUID
+    let title: String
+    let subtitle: String
 }
 
 struct TerminalHistoryEntry: Codable, Equatable, Identifiable {
@@ -84,6 +96,8 @@ private struct TerminalHistoryWebPayload: Encodable {
     let favorites: [String]
     let templates: [TerminalCommandTemplateWebEntry]
     let snippetGroups: [TerminalSnippetGroupWebEntry]
+    let snippetTargets: [TerminalSnippetTargetOption]
+    let defaultSnippetTargetID: String
     let remote: TerminalRemoteContextSnapshot
 }
 
@@ -477,6 +491,7 @@ final class TerminalCommandHistoryStore: ObservableObject {
 
     func webPayload(
         for profileID: UUID,
+        snippetTargets: [TerminalSnippetTargetOption] = [],
         remote: TerminalRemoteContextSnapshot = .empty
     ) -> String? {
         let payload = TerminalHistoryWebPayload(
@@ -503,6 +518,8 @@ final class TerminalCommandHistoryStore: ObservableObject {
             snippetGroups: snippetGroups().map {
                 TerminalSnippetGroupWebEntry(id: $0.id.uuidString, name: $0.name)
             },
+            snippetTargets: snippetTargets,
+            defaultSnippetTargetID: profileID.uuidString,
             remote: remote
         )
         guard let data = try? JSONEncoder().encode(payload) else { return nil }

--- a/Sources/SelectiveRemote/TerminalCommandHistory.swift
+++ b/Sources/SelectiveRemote/TerminalCommandHistory.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 
 struct TerminalHistoryContext: Equatable {
@@ -25,7 +26,42 @@ struct TerminalCommandTemplate: Codable, Equatable, Identifiable {
     var title: String
     var command: String
     var category: String
+    var targetProfileIDs: [UUID]
     var updatedAt: Date
+
+    init(
+        id: UUID,
+        profileID: UUID,
+        title: String,
+        command: String,
+        category: String,
+        targetProfileIDs: [UUID]? = nil,
+        updatedAt: Date
+    ) {
+        self.id = id
+        self.profileID = profileID
+        self.title = title
+        self.command = command
+        self.category = category
+        self.targetProfileIDs = targetProfileIDs ?? [profileID]
+        self.updatedAt = updatedAt
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, profileID, title, command, category, targetProfileIDs, updatedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        profileID = try container.decode(UUID.self, forKey: .profileID)
+        title = try container.decode(String.self, forKey: .title)
+        command = try container.decode(String.self, forKey: .command)
+        category = try container.decode(String.self, forKey: .category)
+        targetProfileIDs = try container.decodeIfPresent([UUID].self, forKey: .targetProfileIDs)
+            ?? [profileID]
+        updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+    }
 }
 
 struct TerminalSnippetGroup: Codable, Equatable, Identifiable {
@@ -56,6 +92,7 @@ private struct TerminalCommandTemplateWebEntry: Encodable {
     let title: String
     let command: String
     let category: String
+    let targetProfileIDs: [String]
     let updatedAt: Int64
 }
 
@@ -65,9 +102,14 @@ private struct TerminalSnippetGroupWebEntry: Encodable {
 }
 
 @MainActor
-final class TerminalCommandHistoryStore {
+final class TerminalCommandHistoryStore: ObservableObject {
     static let shared = TerminalCommandHistoryStore()
     static let defaultSnippetGroupName = "Мои команды"
+    static let globalSnippetLibraryID = UUID(
+        uuidString: "5A17407D-9F03-4F7B-80FB-BD06D3FA50B1"
+    )!
+
+    @Published private(set) var snippetRevision = 0
 
     private enum Key {
         static let entries = "SelectiveRemote.terminal.commandHistory.v1"
@@ -121,7 +163,7 @@ final class TerminalCommandHistoryStore {
             storedSnippetGroups = []
         }
         normalizeAndPersistIfNeeded()
-        migrateTemplatesToSnippetGroupsIfNeeded()
+        migrateTemplatesToGlobalLibraryIfNeeded()
     }
 
     @discardableResult
@@ -218,14 +260,22 @@ final class TerminalCommandHistoryStore {
     }
 
     func templates(for profileID: UUID) -> [TerminalCommandTemplate] {
+        _ = profileID
+        return templates()
+    }
+
+    func templates() -> [TerminalCommandTemplate] {
         storedTemplates
-            .filter { $0.profileID == profileID }
             .sorted { $0.updatedAt > $1.updatedAt }
     }
 
     func snippetGroups(for profileID: UUID) -> [TerminalSnippetGroup] {
+        _ = profileID
+        return snippetGroups()
+    }
+
+    func snippetGroups() -> [TerminalSnippetGroup] {
         storedSnippetGroups
-            .filter { $0.profileID == profileID }
             .sorted {
                 if $0.createdAt != $1.createdAt {
                     return $0.createdAt < $1.createdAt
@@ -241,12 +291,12 @@ final class TerminalCommandHistoryStore {
         now: Date = Date()
     ) -> TerminalSnippetGroup? {
         guard let name = normalizedSnippetGroupName(rawName),
-              !hasSnippetGroup(named: name, profileID: profileID)
+              !hasSnippetGroup(named: name)
         else { return nil }
 
         let group = TerminalSnippetGroup(
             id: UUID(),
-            profileID: profileID,
+            profileID: Self.globalSnippetLibraryID,
             name: name,
             createdAt: now
         )
@@ -263,14 +313,13 @@ final class TerminalCommandHistoryStore {
     ) -> Bool {
         guard let name = normalizedSnippetGroupName(rawName),
               let index = storedSnippetGroups.firstIndex(where: {
-                  $0.id == id && $0.profileID == profileID
+                  $0.id == id
               })
         else { return false }
 
         let oldName = storedSnippetGroups[index].name
         guard !storedSnippetGroups.contains(where: {
-            $0.profileID == profileID
-                && $0.id != id
+            $0.id != id
                 && $0.name.compare(name, options: [.caseInsensitive, .diacriticInsensitive])
                     == .orderedSame
         }) else {
@@ -278,8 +327,7 @@ final class TerminalCommandHistoryStore {
         }
         storedSnippetGroups[index].name = name
         for templateIndex in storedTemplates.indices where
-            storedTemplates[templateIndex].profileID == profileID
-                && storedTemplates[templateIndex].category == oldName {
+            storedTemplates[templateIndex].category == oldName {
             storedTemplates[templateIndex].category = name
         }
         persistSnippetGroups()
@@ -292,19 +340,18 @@ final class TerminalCommandHistoryStore {
     @discardableResult
     func removeSnippetGroup(id: UUID, profileID: UUID) -> Bool {
         guard let index = storedSnippetGroups.firstIndex(where: {
-            $0.id == id && $0.profileID == profileID
+            $0.id == id
         }) else { return false }
 
         let removedName = storedSnippetGroups[index].name
         storedSnippetGroups.remove(at: index)
         let affected = storedTemplates.indices.filter {
-            storedTemplates[$0].profileID == profileID
-                && storedTemplates[$0].category == removedName
+            storedTemplates[$0].category == removedName
         }
         if !affected.isEmpty {
             let defaultGroup = ensureSnippetGroup(
                 named: Self.defaultSnippetGroupName,
-                profileID: profileID
+                profileID: Self.globalSnippetLibraryID
             )
             for templateIndex in affected {
                 storedTemplates[templateIndex].category = defaultGroup.name
@@ -322,7 +369,8 @@ final class TerminalCommandHistoryStore {
         title rawTitle: String,
         command rawCommand: String,
         category rawCategory: String,
-        profileID: UUID
+        profileID: UUID,
+        targetProfileIDs: [UUID]? = nil
     ) -> Bool {
         let title = rawTitle.trimmingCharacters(in: .whitespacesAndNewlines)
         let category = rawCategory.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -335,16 +383,19 @@ final class TerminalCommandHistoryStore {
 
         let group = ensureSnippetGroup(
             named: category.isEmpty ? Self.defaultSnippetGroupName : category,
-            profileID: profileID
+            profileID: Self.globalSnippetLibraryID
         )
 
         if let id,
            let index = storedTemplates.firstIndex(where: {
-               $0.id == id && $0.profileID == profileID
+               $0.id == id
            }) {
             storedTemplates[index].title = title
             storedTemplates[index].command = command
             storedTemplates[index].category = group.name
+            if let targetProfileIDs {
+                storedTemplates[index].targetProfileIDs = normalizedTargetIDs(targetProfileIDs)
+            }
             storedTemplates[index].updatedAt = Date()
         } else {
             storedTemplates.append(
@@ -354,6 +405,7 @@ final class TerminalCommandHistoryStore {
                     title: title,
                     command: command,
                     category: group.name,
+                    targetProfileIDs: normalizedTargetIDs(targetProfileIDs ?? [profileID]),
                     updatedAt: Date()
                 )
             )
@@ -370,9 +422,9 @@ final class TerminalCommandHistoryStore {
     @discardableResult
     func moveTemplate(id: UUID, toGroupID groupID: UUID, profileID: UUID) -> Bool {
         guard let group = storedSnippetGroups.first(where: {
-            $0.id == groupID && $0.profileID == profileID
+            $0.id == groupID
         }), let index = storedTemplates.firstIndex(where: {
-            $0.id == id && $0.profileID == profileID
+            $0.id == id
         }) else { return false }
 
         storedTemplates[index].category = group.name
@@ -384,7 +436,7 @@ final class TerminalCommandHistoryStore {
     @discardableResult
     func duplicateTemplate(id: UUID, profileID: UUID) -> Bool {
         guard let template = storedTemplates.first(where: {
-            $0.id == id && $0.profileID == profileID
+            $0.id == id
         }) else { return false }
 
         let suffix = " — копия"
@@ -395,18 +447,32 @@ final class TerminalCommandHistoryStore {
             title: base + suffix,
             command: template.command,
             category: template.category,
-            profileID: profileID
+            profileID: Self.globalSnippetLibraryID,
+            targetProfileIDs: template.targetProfileIDs
         )
     }
 
     func template(id: UUID, profileID: UUID) -> TerminalCommandTemplate? {
-        storedTemplates.first { $0.id == id && $0.profileID == profileID }
+        _ = profileID
+        return template(id: id)
     }
 
-    func removeTemplate(id: UUID, profileID: UUID) {
+    func template(id: UUID) -> TerminalCommandTemplate? {
+        storedTemplates.first { $0.id == id }
+    }
+
+    @discardableResult
+    func removeTemplate(id: UUID, profileID: UUID) -> Bool {
+        _ = profileID
+        return removeTemplate(id: id)
+    }
+
+    @discardableResult
+    func removeTemplate(id: UUID) -> Bool {
         let oldCount = storedTemplates.count
-        storedTemplates.removeAll { $0.id == id && $0.profileID == profileID }
+        storedTemplates.removeAll { $0.id == id }
         if storedTemplates.count != oldCount { persistTemplates() }
+        return storedTemplates.count != oldCount
     }
 
     func webPayload(
@@ -424,16 +490,17 @@ final class TerminalCommandHistoryStore {
                 )
             },
             favorites: favorites(for: profileID).map(\.command),
-            templates: templates(for: profileID).map {
+            templates: templates().map {
                 TerminalCommandTemplateWebEntry(
                     id: $0.id.uuidString,
                     title: $0.title,
                     command: $0.command,
                     category: $0.category,
+                    targetProfileIDs: $0.targetProfileIDs.map(\.uuidString),
                     updatedAt: Int64($0.updatedAt.timeIntervalSince1970 * 1_000)
                 )
             },
-            snippetGroups: snippetGroups(for: profileID).map {
+            snippetGroups: snippetGroups().map {
                 TerminalSnippetGroupWebEntry(id: $0.id.uuidString, name: $0.name)
             },
             remote: remote
@@ -475,10 +542,9 @@ final class TerminalCommandHistoryStore {
         return name
     }
 
-    private func hasSnippetGroup(named name: String, profileID: UUID) -> Bool {
+    private func hasSnippetGroup(named name: String) -> Bool {
         storedSnippetGroups.contains {
-            $0.profileID == profileID
-                && $0.name.compare(name, options: [.caseInsensitive, .diacriticInsensitive])
+            $0.name.compare(name, options: [.caseInsensitive, .diacriticInsensitive])
                     == .orderedSame
         }
     }
@@ -491,15 +557,14 @@ final class TerminalCommandHistoryStore {
     ) -> TerminalSnippetGroup {
         let name = normalizedSnippetGroupName(rawName) ?? Self.defaultSnippetGroupName
         if let existing = storedSnippetGroups.first(where: {
-            $0.profileID == profileID
-                && $0.name.compare(name, options: [.caseInsensitive, .diacriticInsensitive])
+            $0.name.compare(name, options: [.caseInsensitive, .diacriticInsensitive])
                     == .orderedSame
         }) {
             return existing
         }
         let group = TerminalSnippetGroup(
             id: UUID(),
-            profileID: profileID,
+            profileID: Self.globalSnippetLibraryID,
             name: name,
             createdAt: now
         )
@@ -507,11 +572,37 @@ final class TerminalCommandHistoryStore {
         return group
     }
 
-    private func migrateTemplatesToSnippetGroupsIfNeeded() {
+    private func migrateTemplatesToGlobalLibraryIfNeeded() {
         var templatesChanged = false
         var groupsChanged = false
 
+        var uniqueGroups: [TerminalSnippetGroup] = []
+        for group in storedSnippetGroups.sorted(by: { $0.createdAt < $1.createdAt }) {
+            if !uniqueGroups.contains(where: {
+                $0.name.compare(group.name, options: [.caseInsensitive, .diacriticInsensitive])
+                    == .orderedSame
+            }) {
+                uniqueGroups.append(
+                    TerminalSnippetGroup(
+                        id: group.id,
+                        profileID: Self.globalSnippetLibraryID,
+                        name: group.name,
+                        createdAt: group.createdAt
+                    )
+                )
+            }
+        }
+        if uniqueGroups != storedSnippetGroups {
+            storedSnippetGroups = uniqueGroups
+            groupsChanged = true
+        }
+
         for index in storedTemplates.indices {
+            let targets = normalizedTargetIDs(storedTemplates[index].targetProfileIDs)
+            if targets != storedTemplates[index].targetProfileIDs {
+                storedTemplates[index].targetProfileIDs = targets
+                templatesChanged = true
+            }
             let trimmed = storedTemplates[index].category
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             let resolved = trimmed.isEmpty ? Self.defaultSnippetGroupName : trimmed
@@ -522,7 +613,7 @@ final class TerminalCommandHistoryStore {
             let beforeCount = storedSnippetGroups.count
             let group = ensureSnippetGroup(
                 named: resolved,
-                profileID: storedTemplates[index].profileID,
+                profileID: Self.globalSnippetLibraryID,
                 now: storedTemplates[index].updatedAt
             )
             groupsChanged = groupsChanged || storedSnippetGroups.count != beforeCount
@@ -534,6 +625,11 @@ final class TerminalCommandHistoryStore {
 
         if templatesChanged { persistTemplates() }
         if groupsChanged { persistSnippetGroups() }
+    }
+
+    private func normalizedTargetIDs(_ ids: [UUID]) -> [UUID] {
+        var seen = Set<UUID>()
+        return ids.filter { seen.insert($0).inserted }.prefix(8).map { $0 }
     }
 
     private func normalizeAndPersistIfNeeded() {
@@ -568,10 +664,12 @@ final class TerminalCommandHistoryStore {
     private func persistTemplates() {
         guard let data = try? JSONEncoder().encode(storedTemplates) else { return }
         defaults.set(data, forKey: Key.templates)
+        snippetRevision &+= 1
     }
 
     private func persistSnippetGroups() {
         guard let data = try? JSONEncoder().encode(storedSnippetGroups) else { return }
         defaults.set(data, forKey: Key.snippetGroups)
+        snippetRevision &+= 1
     }
 }

--- a/Sources/SelectiveRemote/TerminalCommandHistory.swift
+++ b/Sources/SelectiveRemote/TerminalCommandHistory.swift
@@ -28,6 +28,13 @@ struct TerminalCommandTemplate: Codable, Equatable, Identifiable {
     var updatedAt: Date
 }
 
+struct TerminalSnippetGroup: Codable, Equatable, Identifiable {
+    let id: UUID
+    let profileID: UUID
+    var name: String
+    var createdAt: Date
+}
+
 private struct TerminalHistoryWebEntry: Encodable {
     let id: String
     let command: String
@@ -40,6 +47,7 @@ private struct TerminalHistoryWebPayload: Encodable {
     let entries: [TerminalHistoryWebEntry]
     let favorites: [String]
     let templates: [TerminalCommandTemplateWebEntry]
+    let snippetGroups: [TerminalSnippetGroupWebEntry]
     let remote: TerminalRemoteContextSnapshot
 }
 
@@ -51,15 +59,22 @@ private struct TerminalCommandTemplateWebEntry: Encodable {
     let updatedAt: Int64
 }
 
+private struct TerminalSnippetGroupWebEntry: Encodable {
+    let id: String
+    let name: String
+}
+
 @MainActor
 final class TerminalCommandHistoryStore {
     static let shared = TerminalCommandHistoryStore()
+    static let defaultSnippetGroupName = "Мои команды"
 
     private enum Key {
         static let entries = "SelectiveRemote.terminal.commandHistory.v1"
         static let enabled = "SelectiveRemote.terminal.commandHistory.enabled.v1"
         static let favorites = "SelectiveRemote.terminal.commandFavorites.v1"
         static let templates = "SelectiveRemote.terminal.commandTemplates.v1"
+        static let snippetGroups = "SelectiveRemote.terminal.snippetGroups.v1"
     }
 
     private let defaults: UserDefaults
@@ -67,6 +82,7 @@ final class TerminalCommandHistoryStore {
     private var storedEntries: [TerminalHistoryEntry]
     private var storedFavorites: [TerminalCommandFavorite]
     private var storedTemplates: [TerminalCommandTemplate]
+    private var storedSnippetGroups: [TerminalSnippetGroup]
 
     var isEnabled: Bool {
         didSet { defaults.set(isEnabled, forKey: Key.enabled) }
@@ -98,7 +114,14 @@ final class TerminalCommandHistoryStore {
         } else {
             storedTemplates = []
         }
+        if let data = defaults.data(forKey: Key.snippetGroups),
+           let decoded = try? JSONDecoder().decode([TerminalSnippetGroup].self, from: data) {
+            storedSnippetGroups = decoded
+        } else {
+            storedSnippetGroups = []
+        }
         normalizeAndPersistIfNeeded()
+        migrateTemplatesToSnippetGroupsIfNeeded()
     }
 
     @discardableResult
@@ -200,6 +223,99 @@ final class TerminalCommandHistoryStore {
             .sorted { $0.updatedAt > $1.updatedAt }
     }
 
+    func snippetGroups(for profileID: UUID) -> [TerminalSnippetGroup] {
+        storedSnippetGroups
+            .filter { $0.profileID == profileID }
+            .sorted {
+                if $0.createdAt != $1.createdAt {
+                    return $0.createdAt < $1.createdAt
+                }
+                return $0.name.localizedStandardCompare($1.name) == .orderedAscending
+            }
+    }
+
+    @discardableResult
+    func createSnippetGroup(
+        name rawName: String,
+        profileID: UUID,
+        now: Date = Date()
+    ) -> TerminalSnippetGroup? {
+        guard let name = normalizedSnippetGroupName(rawName),
+              !hasSnippetGroup(named: name, profileID: profileID)
+        else { return nil }
+
+        let group = TerminalSnippetGroup(
+            id: UUID(),
+            profileID: profileID,
+            name: name,
+            createdAt: now
+        )
+        storedSnippetGroups.append(group)
+        persistSnippetGroups()
+        return group
+    }
+
+    @discardableResult
+    func renameSnippetGroup(
+        id: UUID,
+        name rawName: String,
+        profileID: UUID
+    ) -> Bool {
+        guard let name = normalizedSnippetGroupName(rawName),
+              let index = storedSnippetGroups.firstIndex(where: {
+                  $0.id == id && $0.profileID == profileID
+              })
+        else { return false }
+
+        let oldName = storedSnippetGroups[index].name
+        guard !storedSnippetGroups.contains(where: {
+            $0.profileID == profileID
+                && $0.id != id
+                && $0.name.compare(name, options: [.caseInsensitive, .diacriticInsensitive])
+                    == .orderedSame
+        }) else {
+            return false
+        }
+        storedSnippetGroups[index].name = name
+        for templateIndex in storedTemplates.indices where
+            storedTemplates[templateIndex].profileID == profileID
+                && storedTemplates[templateIndex].category == oldName {
+            storedTemplates[templateIndex].category = name
+        }
+        persistSnippetGroups()
+        persistTemplates()
+        return true
+    }
+
+    /// Removes a group without deleting its snippets. Snippets are moved to the
+    /// existing default group so a category operation cannot destroy commands.
+    @discardableResult
+    func removeSnippetGroup(id: UUID, profileID: UUID) -> Bool {
+        guard let index = storedSnippetGroups.firstIndex(where: {
+            $0.id == id && $0.profileID == profileID
+        }) else { return false }
+
+        let removedName = storedSnippetGroups[index].name
+        storedSnippetGroups.remove(at: index)
+        let affected = storedTemplates.indices.filter {
+            storedTemplates[$0].profileID == profileID
+                && storedTemplates[$0].category == removedName
+        }
+        if !affected.isEmpty {
+            let defaultGroup = ensureSnippetGroup(
+                named: Self.defaultSnippetGroupName,
+                profileID: profileID
+            )
+            for templateIndex in affected {
+                storedTemplates[templateIndex].category = defaultGroup.name
+                storedTemplates[templateIndex].updatedAt = Date()
+            }
+            persistTemplates()
+        }
+        persistSnippetGroups()
+        return true
+    }
+
     @discardableResult
     func saveTemplate(
         id: UUID?,
@@ -217,13 +333,18 @@ final class TerminalCommandHistoryStore {
               !isSensitive(command)
         else { return false }
 
+        let group = ensureSnippetGroup(
+            named: category.isEmpty ? Self.defaultSnippetGroupName : category,
+            profileID: profileID
+        )
+
         if let id,
            let index = storedTemplates.firstIndex(where: {
                $0.id == id && $0.profileID == profileID
            }) {
             storedTemplates[index].title = title
             storedTemplates[index].command = command
-            storedTemplates[index].category = category.isEmpty ? "Мои команды" : category
+            storedTemplates[index].category = group.name
             storedTemplates[index].updatedAt = Date()
         } else {
             storedTemplates.append(
@@ -232,17 +353,54 @@ final class TerminalCommandHistoryStore {
                     profileID: profileID,
                     title: title,
                     command: command,
-                    category: category.isEmpty ? "Мои команды" : category,
+                    category: group.name,
                     updatedAt: Date()
                 )
             )
         }
+        persistSnippetGroups()
         if storedTemplates.count > 500 {
             storedTemplates.sort { $0.updatedAt > $1.updatedAt }
             storedTemplates = Array(storedTemplates.prefix(500))
         }
         persistTemplates()
         return true
+    }
+
+    @discardableResult
+    func moveTemplate(id: UUID, toGroupID groupID: UUID, profileID: UUID) -> Bool {
+        guard let group = storedSnippetGroups.first(where: {
+            $0.id == groupID && $0.profileID == profileID
+        }), let index = storedTemplates.firstIndex(where: {
+            $0.id == id && $0.profileID == profileID
+        }) else { return false }
+
+        storedTemplates[index].category = group.name
+        storedTemplates[index].updatedAt = Date()
+        persistTemplates()
+        return true
+    }
+
+    @discardableResult
+    func duplicateTemplate(id: UUID, profileID: UUID) -> Bool {
+        guard let template = storedTemplates.first(where: {
+            $0.id == id && $0.profileID == profileID
+        }) else { return false }
+
+        let suffix = " — копия"
+        let base = String(template.title.prefix(max(1, 80 - suffix.count)))
+
+        return saveTemplate(
+            id: nil,
+            title: base + suffix,
+            command: template.command,
+            category: template.category,
+            profileID: profileID
+        )
+    }
+
+    func template(id: UUID, profileID: UUID) -> TerminalCommandTemplate? {
+        storedTemplates.first { $0.id == id && $0.profileID == profileID }
     }
 
     func removeTemplate(id: UUID, profileID: UUID) {
@@ -274,6 +432,9 @@ final class TerminalCommandHistoryStore {
                     category: $0.category,
                     updatedAt: Int64($0.updatedAt.timeIntervalSince1970 * 1_000)
                 )
+            },
+            snippetGroups: snippetGroups(for: profileID).map {
+                TerminalSnippetGroupWebEntry(id: $0.id.uuidString, name: $0.name)
             },
             remote: remote
         )
@@ -308,6 +469,73 @@ final class TerminalCommandHistoryStore {
         return markers.contains { lowered.contains($0) }
     }
 
+    private func normalizedSnippetGroupName(_ rawName: String) -> String? {
+        let name = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty, name.count <= 60 else { return nil }
+        return name
+    }
+
+    private func hasSnippetGroup(named name: String, profileID: UUID) -> Bool {
+        storedSnippetGroups.contains {
+            $0.profileID == profileID
+                && $0.name.compare(name, options: [.caseInsensitive, .diacriticInsensitive])
+                    == .orderedSame
+        }
+    }
+
+    @discardableResult
+    private func ensureSnippetGroup(
+        named rawName: String,
+        profileID: UUID,
+        now: Date = Date()
+    ) -> TerminalSnippetGroup {
+        let name = normalizedSnippetGroupName(rawName) ?? Self.defaultSnippetGroupName
+        if let existing = storedSnippetGroups.first(where: {
+            $0.profileID == profileID
+                && $0.name.compare(name, options: [.caseInsensitive, .diacriticInsensitive])
+                    == .orderedSame
+        }) {
+            return existing
+        }
+        let group = TerminalSnippetGroup(
+            id: UUID(),
+            profileID: profileID,
+            name: name,
+            createdAt: now
+        )
+        storedSnippetGroups.append(group)
+        return group
+    }
+
+    private func migrateTemplatesToSnippetGroupsIfNeeded() {
+        var templatesChanged = false
+        var groupsChanged = false
+
+        for index in storedTemplates.indices {
+            let trimmed = storedTemplates[index].category
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let resolved = trimmed.isEmpty ? Self.defaultSnippetGroupName : trimmed
+            if storedTemplates[index].category != resolved {
+                storedTemplates[index].category = resolved
+                templatesChanged = true
+            }
+            let beforeCount = storedSnippetGroups.count
+            let group = ensureSnippetGroup(
+                named: resolved,
+                profileID: storedTemplates[index].profileID,
+                now: storedTemplates[index].updatedAt
+            )
+            groupsChanged = groupsChanged || storedSnippetGroups.count != beforeCount
+            if storedTemplates[index].category != group.name {
+                storedTemplates[index].category = group.name
+                templatesChanged = true
+            }
+        }
+
+        if templatesChanged { persistTemplates() }
+        if groupsChanged { persistSnippetGroups() }
+    }
+
     private func normalizeAndPersistIfNeeded() {
         let normalized = storedEntries
             .filter { normalizedCommand($0.command) != nil }
@@ -340,5 +568,10 @@ final class TerminalCommandHistoryStore {
     private func persistTemplates() {
         guard let data = try? JSONEncoder().encode(storedTemplates) else { return }
         defaults.set(data, forKey: Key.templates)
+    }
+
+    private func persistSnippetGroups() {
+        guard let data = try? JSONEncoder().encode(storedSnippetGroups) else { return }
+        defaults.set(data, forKey: Key.snippetGroups)
     }
 }

--- a/Sources/SelectiveRemote/TerminalResources/terminal-host.css
+++ b/Sources/SelectiveRemote/TerminalResources/terminal-host.css
@@ -474,6 +474,21 @@ textarea {
     text-overflow: ellipsis;
 }
 
+.snippet-empty-group-add {
+    width: calc(100% - 20px);
+    margin: 7px 10px 10px;
+    padding: 8px 10px;
+    color: #36d399;
+    background: rgba(54, 211, 153, 0.08);
+    border: 1px dashed rgba(54, 211, 153, 0.32);
+    border-radius: 8px;
+    text-align: left;
+}
+
+.snippet-empty-group-add:hover {
+    background: rgba(54, 211, 153, 0.15);
+}
+
 .snippet-title {
     font-weight: 600;
 }
@@ -581,6 +596,65 @@ textarea {
 
 #snippet-form textarea {
     font-family: "SF Mono", SFMono-Regular, Menlo, monospace;
+}
+
+#snippet-targets-field {
+    min-width: 0;
+    margin: 0;
+    padding: 9px 10px 10px;
+    border: 1px solid rgba(255, 255, 255, 0.10);
+    border-radius: 9px;
+}
+
+#snippet-targets-field legend {
+    padding: 0 5px;
+}
+
+#snippet-targets-list {
+    display: grid;
+    gap: 4px;
+    max-height: 160px;
+    overflow: auto;
+}
+
+#snippet-targets-list label {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 9px;
+    align-items: center;
+    padding: 6px 7px;
+    border-radius: 7px;
+}
+
+#snippet-targets-list label:hover {
+    background: rgba(54, 211, 153, 0.10);
+}
+
+#snippet-targets-list input {
+    width: auto;
+    margin: 0;
+}
+
+.snippet-target-copy {
+    display: grid;
+    min-width: 0;
+}
+
+.snippet-target-copy small {
+    overflow: hidden;
+    color: #7f899e;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+#snippet-targets-error {
+    display: block;
+    margin-top: 7px;
+    color: #ff8787;
+}
+
+#snippet-targets-error[hidden] {
+    display: none;
 }
 
 #snippet-form menu,
@@ -720,6 +794,7 @@ textarea {
 .terminal-theme-light #snippet-form input,
 .terminal-theme-light #snippet-form select,
 .terminal-theme-light #snippet-form textarea,
+.terminal-theme-light #snippet-targets-field,
 .terminal-theme-light #snippet-form menu button,
 .terminal-theme-light #snippet-group-form input,
 .terminal-theme-light #snippet-group-form menu button,

--- a/Sources/SelectiveRemote/TerminalResources/terminal-host.css
+++ b/Sources/SelectiveRemote/TerminalResources/terminal-host.css
@@ -49,6 +49,12 @@ body,
     background: var(--terminal-background);
 }
 
+@media (min-width: 621px) {
+    #terminal-shell.command-panel-visible #terminal {
+        width: calc(100% - min(520px, calc(100% - 20px)) - (2 * var(--terminal-padding)) - 10px);
+    }
+}
+
 #terminal-input-highlight {
     position: absolute;
     inset: 0;
@@ -100,7 +106,9 @@ body,
 }
 
 button,
-input {
+input,
+select,
+textarea {
     font: inherit;
 }
 
@@ -269,7 +277,7 @@ input {
 
 #command-tabs {
     display: grid;
-    grid-template-columns: repeat(5, minmax(0, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: 4px;
     margin: 0 18px 12px;
     padding: 3px;
@@ -377,7 +385,8 @@ input {
     opacity: 1;
 }
 
-#template-add {
+#snippet-options button,
+#snippet-empty-add {
     padding: 6px 9px;
     color: #dce6f5;
     background: rgba(54, 211, 153, 0.18);
@@ -385,7 +394,134 @@ input {
     border-radius: 8px;
 }
 
-#template-dialog {
+#snippets-list {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 8px 10px 18px;
+    font: 13px -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+.snippet-group {
+    margin-bottom: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 11px;
+    overflow: hidden;
+}
+
+.snippet-group-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 9px 10px;
+    background: rgba(255, 255, 255, 0.045);
+}
+
+.snippet-group-title {
+    min-width: 0;
+    flex: 1;
+    overflow: hidden;
+    color: #cbd5e6;
+    font-weight: 600;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+.snippet-group-count {
+    color: #7f899e;
+    font-size: 11px;
+}
+
+.snippet-group-action,
+.snippet-row-menu {
+    width: 26px;
+    height: 26px;
+    padding: 0;
+    color: #8f9ab0;
+    background: transparent;
+    border: 0;
+    border-radius: 6px;
+}
+
+.snippet-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 8px;
+    padding: 9px 10px;
+    border-top: 1px solid rgba(255, 255, 255, 0.055);
+}
+
+.snippet-row:hover,
+.snippet-row.is-selected {
+    background: rgba(54, 211, 153, 0.12);
+}
+
+.snippet-select {
+    min-width: 0;
+    padding: 0;
+    color: inherit;
+    background: transparent;
+    border: 0;
+    text-align: left;
+}
+
+.snippet-title,
+.snippet-command {
+    display: block;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+.snippet-title {
+    font-weight: 600;
+}
+
+.snippet-command {
+    margin-top: 4px;
+    color: #7f899e;
+    font: 11px "SF Mono", SFMono-Regular, Menlo, monospace;
+}
+
+.snippet-context-menu {
+    z-index: 70;
+    width: 190px;
+    padding: 5px;
+    overflow: hidden;
+}
+
+.snippet-context-menu button {
+    display: block;
+    width: 100%;
+    padding: 7px 9px;
+    color: inherit;
+    background: transparent;
+    border: 0;
+    border-radius: 7px;
+    text-align: left;
+}
+
+.snippet-context-menu button:hover {
+    background: rgba(54, 211, 153, 0.14);
+}
+
+.snippet-context-menu button.destructive {
+    color: #ff8787;
+}
+
+#snippet-feedback {
+    margin: 0 18px 10px;
+    padding: 8px 10px;
+    color: #ffd1d1;
+    background: rgba(255, 91, 91, 0.12);
+    border-radius: 8px;
+    font: 12px -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+#snippet-dialog,
+#snippet-group-dialog,
+#snippet-move-dialog {
     width: min(560px, calc(100% - 36px));
     padding: 0;
     color: #dce6f5;
@@ -395,31 +531,43 @@ input {
     box-shadow: 0 24px 70px rgba(0, 0, 0, 0.52);
 }
 
-#template-dialog::backdrop {
+#snippet-dialog::backdrop,
+#snippet-group-dialog::backdrop,
+#snippet-move-dialog::backdrop {
     background: rgba(0, 0, 0, 0.52);
     backdrop-filter: blur(3px);
 }
 
-#template-form {
+#snippet-form,
+#snippet-group-form,
+#snippet-move-form {
     display: grid;
     gap: 13px;
     padding: 20px;
     font: 13px -apple-system, BlinkMacSystemFont, sans-serif;
 }
 
-#template-form h3,
-#template-form p,
-#template-form menu {
+#snippet-form h3,
+#snippet-form menu,
+#snippet-group-form h3,
+#snippet-group-form menu,
+#snippet-move-form h3,
+#snippet-move-form menu {
     margin: 0;
 }
 
-#template-form label {
+#snippet-form label,
+#snippet-group-form label,
+#snippet-move-form label {
     display: grid;
     gap: 6px;
 }
 
-#template-form input,
-#template-form textarea {
+#snippet-form input,
+#snippet-form select,
+#snippet-form textarea,
+#snippet-group-form input,
+#snippet-move-form select {
     box-sizing: border-box;
     width: 100%;
     padding: 9px 10px;
@@ -431,22 +579,22 @@ input {
     resize: vertical;
 }
 
-#template-form textarea {
+#snippet-form textarea {
     font-family: "SF Mono", SFMono-Regular, Menlo, monospace;
 }
 
-#template-form p {
-    color: #8f9ab0;
-}
-
-#template-form menu {
+#snippet-form menu,
+#snippet-group-form menu,
+#snippet-move-form menu {
     display: flex;
     justify-content: flex-end;
     gap: 8px;
     padding: 0;
 }
 
-#template-form menu button {
+#snippet-form menu button,
+#snippet-group-form menu button,
+#snippet-move-form menu button {
     padding: 8px 13px;
     color: inherit;
     background: rgba(255, 255, 255, 0.08);
@@ -454,7 +602,9 @@ input {
     border-radius: 9px;
 }
 
-#template-form menu button.primary {
+#snippet-form menu button.primary,
+#snippet-group-form menu button.primary,
+#snippet-move-form menu button.primary {
     background: #168bc0;
 }
 
@@ -476,7 +626,8 @@ input {
     font-size: 14px;
 }
 
-#remote-context-retry {
+#remote-context-retry,
+#snippet-empty-add {
     margin-top: 6px;
     padding: 7px 12px;
     color: #dce6f5;
@@ -487,7 +638,8 @@ input {
     cursor: pointer;
 }
 
-#remote-context-retry:hover {
+#remote-context-retry:hover,
+#snippet-empty-add:hover {
     background: rgba(54, 211, 153, 0.24);
 }
 
@@ -557,15 +709,22 @@ input {
     color: #6d7889;
 }
 
-.terminal-theme-light #template-dialog {
+.terminal-theme-light #snippet-dialog,
+.terminal-theme-light #snippet-group-dialog,
+.terminal-theme-light #snippet-move-dialog {
     color: #1f2a3a;
     background: color-mix(in srgb, var(--terminal-background) 88%, #e7edf5 12%);
     border-color: rgba(31, 42, 58, 0.15);
 }
 
-.terminal-theme-light #template-form input,
-.terminal-theme-light #template-form textarea,
-.terminal-theme-light #template-form menu button {
+.terminal-theme-light #snippet-form input,
+.terminal-theme-light #snippet-form select,
+.terminal-theme-light #snippet-form textarea,
+.terminal-theme-light #snippet-form menu button,
+.terminal-theme-light #snippet-group-form input,
+.terminal-theme-light #snippet-group-form menu button,
+.terminal-theme-light #snippet-move-form select,
+.terminal-theme-light #snippet-move-form menu button {
     background: rgba(31, 42, 58, 0.07);
     border-color: rgba(31, 42, 58, 0.12);
 }
@@ -577,6 +736,33 @@ input {
 
 .terminal-theme-light .history-row:hover {
     background: rgba(31, 42, 58, 0.055);
+}
+
+.terminal-theme-light .snippet-group {
+    border-color: rgba(31, 42, 58, 0.10);
+}
+
+.terminal-theme-light .snippet-group-header {
+    background: rgba(31, 42, 58, 0.045);
+}
+
+.terminal-theme-light .snippet-group-title,
+.terminal-theme-light .snippet-title {
+    color: #1f2a3a;
+}
+
+.terminal-theme-light .snippet-row {
+    border-color: rgba(31, 42, 58, 0.08);
+}
+
+.terminal-theme-light .snippet-row:hover,
+.terminal-theme-light .snippet-row.is-selected {
+    background: rgba(19, 133, 91, 0.11);
+}
+
+.terminal-theme-light .snippet-command,
+.terminal-theme-light .snippet-group-count {
+    color: #637083;
 }
 
 @media (max-width: 620px) {

--- a/Sources/SelectiveRemote/TerminalResources/terminal-host.js
+++ b/Sources/SelectiveRemote/TerminalResources/terminal-host.js
@@ -54,7 +54,7 @@
     const snippetStrings = {
         ru: {
             snippets: "Сниппеты",
-            subtitle: "Команды этого подключения",
+            subtitle: "Общая библиотека · запуск по Targets",
             search: "Поиск сниппетов",
             newSnippet: "Новый сниппет",
             newGroup: "Новая группа",
@@ -79,13 +79,15 @@
                 ? `Удалить группу «${name}»? ${count} сниппетов будут перемещены в «Мои команды».`
                 : `Удалить группу «${name}»?`,
             inactiveSession: "Сниппет не выполнен: активная SSH-сессия не подключена.",
+            connecting: "Подключаем SSH Targets. Сниппет выполнится сразу после подключения.",
+            noTargets: "Сниппет не выполнен: назначьте хотя бы один SSH Target.",
             alternateScreen: "Сниппет нельзя выполнить, пока терминал занят полноэкранной программой.",
             invalidSnippet: "Сниппет больше недоступен. Обновите список и повторите попытку.",
             footer: "Один клик выбирает. Двойной клик или Enter выполняет сниппет."
         },
         en: {
             snippets: "Snippets",
-            subtitle: "Commands for this connection",
+            subtitle: "Shared library · runs on assigned targets",
             search: "Search snippets",
             newSnippet: "New snippet",
             newGroup: "New group",
@@ -110,6 +112,8 @@
                 ? `Delete group “${name}”? ${count} snippets will move to “My commands”.`
                 : `Delete group “${name}”?`,
             inactiveSession: "Snippet was not run because the active SSH session is disconnected.",
+            connecting: "Connecting SSH targets. The snippet will run when they are ready.",
+            noTargets: "Snippet was not run because it has no SSH targets.",
             alternateScreen: "Exit the full-screen terminal program before running a snippet.",
             invalidSnippet: "This snippet is no longer available. Refresh and try again.",
             footer: "Single-click selects. Double-click or Enter runs the snippet."
@@ -1272,12 +1276,7 @@
             remove.textContent = "×";
             remove.title = snippetText("deleteGroup");
             remove.addEventListener("click", () => {
-                if (window.confirm(snippetText("deleteGroupConfirm")(
-                    displaySnippetGroupName(group.name),
-                    allEntries.length
-                ))) {
-                    postHistory({ action: "removeSnippetGroup", id: group.id });
-                }
+                postHistory({ action: "removeSnippetGroup", id: group.id });
             });
             header.append(title, count, rename, remove);
             section.append(header);
@@ -1297,7 +1296,10 @@
                 entryTitle.textContent = entry.title;
                 const command = document.createElement("span");
                 command.className = "snippet-command";
-                command.textContent = entry.command.replaceAll("\n", " ↵ ");
+                const targetCount = Array.isArray(entry.targetProfileIDs)
+                    ? entry.targetProfileIDs.length
+                    : 0;
+                command.textContent = `${entry.command.replaceAll("\n", " ↵ ")} · ${targetCount} Targets`;
                 select.append(entryTitle, command);
                 select.addEventListener("click", () => {
                     const decision = window.SelectiveTerminalSnippetInteractions.decision({
@@ -2062,9 +2064,10 @@
             showSnippetFeedback("");
             return;
         }
-        showSnippetFeedback(snippetText(
-            result === "invalidSnippet" ? "invalidSnippet" : "inactiveSession"
-        ));
+        const resultKey = ["invalidSnippet", "connecting", "noTargets"].includes(result)
+            ? result
+            : "inactiveSession";
+        showSnippetFeedback(snippetText(resultKey));
     };
 
     window.selectiveTerminalSetLanguage = (language) => {
@@ -2241,8 +2244,7 @@
             postHistory({ action: "duplicateSnippet", id: entry.id });
         } else if (action === "move") {
             openSnippetMove(entry);
-        } else if (action === "remove"
-            && window.confirm(snippetText("deleteSnippetConfirm")(entry.title))) {
+        } else if (action === "remove") {
             postHistory({ action: "removeSnippet", id: entry.id });
         }
     });

--- a/Sources/SelectiveRemote/TerminalResources/terminal-host.js
+++ b/Sources/SelectiveRemote/TerminalResources/terminal-host.js
@@ -19,21 +19,109 @@
     const historyClearButton = document.getElementById("history-clear");
     const historyCloseButton = document.getElementById("history-close");
     const historyOptions = document.getElementById("history-options");
-    const templateOptions = document.getElementById("template-options");
-    const templateAddButton = document.getElementById("template-add");
-    const templateDialog = document.getElementById("template-dialog");
-    const templateForm = document.getElementById("template-form");
-    const templateID = document.getElementById("template-id");
-    const templateTitle = document.getElementById("template-title");
-    const templateCategory = document.getElementById("template-category");
-    const templateCommand = document.getElementById("template-command");
-    const templateCancel = document.getElementById("template-cancel");
+    const snippetOptions = document.getElementById("snippet-options");
+    const snippetAddButton = document.getElementById("snippet-add");
+    const snippetGroupAddButton = document.getElementById("snippet-group-add");
+    const snippetEmptyAddButton = document.getElementById("snippet-empty-add");
+    const snippetsList = document.getElementById("snippets-list");
+    const snippetFeedback = document.getElementById("snippet-feedback");
+    const snippetDialog = document.getElementById("snippet-dialog");
+    const snippetForm = document.getElementById("snippet-form");
+    const snippetID = document.getElementById("snippet-id");
+    const snippetTitle = document.getElementById("snippet-title");
+    const snippetGroup = document.getElementById("snippet-group");
+    const snippetCommand = document.getElementById("snippet-command");
+    const snippetCancel = document.getElementById("snippet-cancel");
+    const snippetGroupDialog = document.getElementById("snippet-group-dialog");
+    const snippetGroupForm = document.getElementById("snippet-group-form");
+    const snippetGroupID = document.getElementById("snippet-group-id");
+    const snippetGroupName = document.getElementById("snippet-group-name");
+    const snippetGroupCancel = document.getElementById("snippet-group-cancel");
+    const snippetMoveDialog = document.getElementById("snippet-move-dialog");
+    const snippetMoveForm = document.getElementById("snippet-move-form");
+    const snippetMoveID = document.getElementById("snippet-move-id");
+    const snippetMoveGroup = document.getElementById("snippet-move-group");
+    const snippetMoveCancel = document.getElementById("snippet-move-cancel");
+    const snippetContextMenu = document.getElementById("snippet-context-menu");
     const commandPanelTitle = document.getElementById("command-panel-title");
     const commandPanelSubtitle = document.getElementById("command-panel-subtitle");
     const commandEmptyTitle = document.getElementById("command-empty-title");
     const commandEmptyMessage = document.getElementById("command-empty-message");
     const remoteContextRetryButton = document.getElementById("remote-context-retry");
+    const commandPanelFooter = document.getElementById("command-panel-footer");
     const commandTabs = Array.from(document.querySelectorAll("#command-tabs button"));
+
+    const snippetStrings = {
+        ru: {
+            snippets: "Сниппеты",
+            subtitle: "Команды этого подключения",
+            search: "Поиск сниппетов",
+            newSnippet: "Новый сниппет",
+            newGroup: "Новая группа",
+            editSnippet: "Изменить сниппет",
+            edit: "Изменить",
+            duplicate: "Дублировать",
+            move: "Переместить",
+            remove: "Удалить",
+            run: "Выполнить",
+            defaultGroup: "Мои команды",
+            group: "Группа",
+            command: "Команда или скрипт",
+            create: "Создать",
+            save: "Сохранить",
+            cancel: "Отмена",
+            renameGroup: "Переименовать группу",
+            deleteGroup: "Удалить группу",
+            noSnippets: "Сниппетов пока нет",
+            noSnippetsMessage: "Создайте сниппет для команд, которые используете регулярно.",
+            deleteSnippetConfirm: (title) => `Удалить сниппет «${title}»?`,
+            deleteGroupConfirm: (name, count) => count > 0
+                ? `Удалить группу «${name}»? ${count} сниппетов будут перемещены в «Мои команды».`
+                : `Удалить группу «${name}»?`,
+            inactiveSession: "Сниппет не выполнен: активная SSH-сессия не подключена.",
+            alternateScreen: "Сниппет нельзя выполнить, пока терминал занят полноэкранной программой.",
+            invalidSnippet: "Сниппет больше недоступен. Обновите список и повторите попытку.",
+            footer: "Один клик выбирает. Двойной клик или Enter выполняет сниппет."
+        },
+        en: {
+            snippets: "Snippets",
+            subtitle: "Commands for this connection",
+            search: "Search snippets",
+            newSnippet: "New snippet",
+            newGroup: "New group",
+            editSnippet: "Edit snippet",
+            edit: "Edit",
+            duplicate: "Duplicate",
+            move: "Move to",
+            remove: "Remove",
+            run: "Run",
+            defaultGroup: "My commands",
+            group: "Group",
+            command: "Command or script",
+            create: "Create",
+            save: "Save",
+            cancel: "Cancel",
+            renameGroup: "Rename group",
+            deleteGroup: "Delete group",
+            noSnippets: "No snippets yet",
+            noSnippetsMessage: "Create a snippet for commands you use regularly.",
+            deleteSnippetConfirm: (title) => `Remove snippet “${title}”?`,
+            deleteGroupConfirm: (name, count) => count > 0
+                ? `Delete group “${name}”? ${count} snippets will move to “My commands”.`
+                : `Delete group “${name}”?`,
+            inactiveSession: "Snippet was not run because the active SSH session is disconnected.",
+            alternateScreen: "Exit the full-screen terminal program before running a snippet.",
+            invalidSnippet: "This snippet is no longer available. Refresh and try again.",
+            footer: "Single-click selects. Double-click or Enter runs the snippet."
+        }
+    };
+    let snippetLanguage = "ru";
+    const snippetText = (key) => snippetStrings[snippetLanguage]?.[key]
+        ?? snippetStrings.ru[key]
+        ?? key;
+    const displaySnippetGroupName = (name) => name === "Мои команды"
+        ? snippetText("defaultGroup")
+        : name;
 
     const terminal = new Terminal({
         allowProposedApi: false,
@@ -195,6 +283,10 @@
     let historyEnabled = true;
     let favoriteCommands = new Set();
     let commandTemplates = [];
+    let snippetGroups = [];
+    let selectedSnippetID = null;
+    let contextSnippetID = null;
+    let panelMode = "hidden";
     let remoteCommandEntries = [];
     let remoteContextMessage = "Подключите SSH и обновите сведения о сервере";
     let remoteSystemLabel = "";
@@ -1036,16 +1128,242 @@
         }).format(date);
     };
 
-    const openTemplateEditor = (entry = null) => {
-        templateID.value = entry?.id || "";
-        templateTitle.value = entry?.title || "";
-        templateCategory.value = entry?.category || "Мои команды";
-        templateCommand.value = entry?.command || "";
-        templateDialog.showModal();
-        window.setTimeout(() => templateTitle.focus(), 0);
+    let pendingSnippetEditor = false;
+
+    const fillGroupSelect = (select, selectedName = "") => {
+        select.replaceChildren();
+        snippetGroups.forEach((group) => {
+            const option = document.createElement("option");
+            option.value = group.id;
+            option.textContent = displaySnippetGroupName(group.name);
+            option.selected = group.name === selectedName;
+            select.append(option);
+        });
+    };
+
+    const openSnippetEditor = (entry = null) => {
+        if (snippetGroups.length === 0) {
+            pendingSnippetEditor = true;
+            postHistory({ action: "createSnippetGroup", name: "Мои команды" });
+            return;
+        }
+        snippetID.value = entry?.id || "";
+        snippetTitle.value = entry?.title || "";
+        snippetCommand.value = entry?.command || "";
+        fillGroupSelect(snippetGroup, entry?.category || snippetGroups[0].name);
+        document.getElementById("snippet-dialog-title").textContent = entry
+            ? snippetText("editSnippet")
+            : snippetText("newSnippet");
+        snippetDialog.showModal();
+        window.setTimeout(() => snippetTitle.focus(), 0);
+    };
+
+    const openSnippetGroupEditor = (group = null) => {
+        snippetGroupID.value = group?.id || "";
+        snippetGroupName.value = group?.name || "";
+        document.getElementById("snippet-group-dialog-title").textContent = group
+            ? snippetText("renameGroup")
+            : snippetText("newGroup");
+        snippetGroupDialog.showModal();
+        window.setTimeout(() => snippetGroupName.focus(), 0);
+    };
+
+    const snippetByID = (id) => commandTemplates.find((entry) => entry.id === id);
+
+    const showSnippetFeedback = (message) => {
+        snippetFeedback.textContent = message;
+        snippetFeedback.hidden = !message;
+    };
+
+    const requestSnippetRun = (entry) => {
+        if (!entry) {
+            return;
+        }
+        if (isAlternateScreen()) {
+            showSnippetFeedback(snippetText("alternateScreen"));
+            return;
+        }
+        const command = /\$\{[A-Za-z][A-Za-z0-9_-]{0,39}\}/.test(entry.command)
+            ? resolveTemplate(entry.command)
+            : entry.command;
+        if (command === null) {
+            return;
+        }
+        showSnippetFeedback("");
+        postHistory({ action: "runSnippet", id: entry.id, command });
+    };
+
+    const hideSnippetContextMenu = () => {
+        snippetContextMenu.hidden = true;
+        contextSnippetID = null;
+    };
+
+    const showSnippetContextMenu = (entry, x, y) => {
+        contextSnippetID = entry.id;
+        selectedSnippetID = entry.id;
+        snippetsList.querySelectorAll(".snippet-row").forEach((row) => {
+            row.classList.toggle("is-selected", row.dataset.snippetId === entry.id);
+        });
+        snippetContextMenu.hidden = false;
+        const width = snippetContextMenu.offsetWidth;
+        const height = snippetContextMenu.offsetHeight;
+        snippetContextMenu.style.left = `${Math.max(6, Math.min(x, innerWidth - width - 6))}px`;
+        snippetContextMenu.style.top = `${Math.max(6, Math.min(y, innerHeight - height - 6))}px`;
+    };
+
+    const openSnippetMove = (entry) => {
+        snippetMoveID.value = entry.id;
+        fillGroupSelect(snippetMoveGroup, entry.category);
+        snippetMoveDialog.showModal();
+    };
+
+    const renderSnippetsPanel = () => {
+        const query = historyQuery.value.trim().toLocaleLowerCase();
+        commandPanelTitle.textContent = snippetText("snippets");
+        commandPanelSubtitle.textContent = snippetText("subtitle");
+        historyQuery.placeholder = snippetText("search");
+        commandTabs.forEach((button) => { button.hidden = true; });
+        document.getElementById("command-tabs").hidden = true;
+        historyOptions.hidden = true;
+        snippetOptions.hidden = false;
+        historyList.hidden = true;
+        snippetsList.hidden = false;
+        remoteContextRetryButton.hidden = true;
+        snippetEmptyAddButton.hidden = true;
+        commandPanelFooter.textContent = snippetText("footer");
+        snippetsList.replaceChildren();
+
+        let renderedSnippets = 0;
+        snippetGroups.forEach((group) => {
+            const allEntries = commandTemplates.filter((entry) => entry.category === group.name);
+            const groupMatches = `${group.name} ${displaySnippetGroupName(group.name)}`
+                .toLocaleLowerCase()
+                .includes(query);
+            const entries = allEntries.filter((entry) => !query || groupMatches
+                || entry.title.toLocaleLowerCase().includes(query)
+                || entry.command.toLocaleLowerCase().includes(query));
+            if (query && entries.length === 0 && !groupMatches) {
+                return;
+            }
+            renderedSnippets += entries.length;
+
+            const section = document.createElement("section");
+            section.className = "snippet-group";
+            section.dataset.groupId = group.id;
+            section.setAttribute("role", "group");
+
+            const header = document.createElement("div");
+            header.className = "snippet-group-header";
+            const title = document.createElement("span");
+            title.className = "snippet-group-title";
+            title.textContent = displaySnippetGroupName(group.name);
+            const count = document.createElement("span");
+            count.className = "snippet-group-count";
+            count.textContent = String(allEntries.length);
+            const rename = document.createElement("button");
+            rename.type = "button";
+            rename.className = "snippet-group-action";
+            rename.textContent = "✎";
+            rename.title = snippetText("renameGroup");
+            rename.addEventListener("click", () => openSnippetGroupEditor(group));
+            const remove = document.createElement("button");
+            remove.type = "button";
+            remove.className = "snippet-group-action";
+            remove.textContent = "×";
+            remove.title = snippetText("deleteGroup");
+            remove.addEventListener("click", () => {
+                if (window.confirm(snippetText("deleteGroupConfirm")(
+                    displaySnippetGroupName(group.name),
+                    allEntries.length
+                ))) {
+                    postHistory({ action: "removeSnippetGroup", id: group.id });
+                }
+            });
+            header.append(title, count, rename, remove);
+            section.append(header);
+
+            entries.forEach((entry) => {
+                const row = document.createElement("div");
+                row.className = "snippet-row";
+                row.classList.toggle("is-selected", selectedSnippetID === entry.id);
+                row.dataset.snippetId = entry.id;
+
+                const select = document.createElement("button");
+                select.type = "button";
+                select.className = "snippet-select";
+                select.dataset.snippetId = entry.id;
+                const entryTitle = document.createElement("span");
+                entryTitle.className = "snippet-title";
+                entryTitle.textContent = entry.title;
+                const command = document.createElement("span");
+                command.className = "snippet-command";
+                command.textContent = entry.command.replaceAll("\n", " ↵ ");
+                select.append(entryTitle, command);
+                select.addEventListener("click", () => {
+                    const decision = window.SelectiveTerminalSnippetInteractions.decision({
+                        eventType: "click",
+                        targetKind: "snippet"
+                    });
+                    if (decision === "select") {
+                        selectedSnippetID = entry.id;
+                        snippetsList.querySelectorAll(".snippet-row").forEach((item) => {
+                            item.classList.toggle(
+                                "is-selected",
+                                item.dataset.snippetId === entry.id
+                            );
+                        });
+                    }
+                });
+                select.addEventListener("dblclick", (event) => {
+                    event.preventDefault();
+                    const decision = window.SelectiveTerminalSnippetInteractions.decision({
+                        eventType: "dblclick",
+                        targetKind: "snippet"
+                    });
+                    if (decision === "run") {
+                        requestSnippetRun(entry);
+                    }
+                });
+                select.addEventListener("contextmenu", (event) => {
+                    event.preventDefault();
+                    showSnippetContextMenu(entry, event.clientX, event.clientY);
+                });
+
+                const menu = document.createElement("button");
+                menu.type = "button";
+                menu.className = "snippet-row-menu";
+                menu.textContent = "•••";
+                menu.setAttribute("aria-label", `${entry.title}: actions`);
+                menu.addEventListener("click", (event) => {
+                    const rect = event.currentTarget.getBoundingClientRect();
+                    showSnippetContextMenu(entry, rect.right - 190, rect.bottom + 4);
+                });
+                row.append(select, menu);
+                section.append(row);
+            });
+            snippetsList.append(section);
+        });
+
+        const noGroups = snippetGroups.length === 0;
+        const noMatches = Boolean(query) && renderedSnippets === 0;
+        const noSnippets = commandTemplates.length === 0;
+        const empty = noGroups || noMatches || noSnippets;
+        if (empty) {
+            commandEmptyTitle.textContent = snippetText("noSnippets");
+            commandEmptyMessage.textContent = snippetText("noSnippetsMessage");
+            historyEmpty.hidden = false;
+            snippetEmptyAddButton.hidden = false;
+            snippetsList.hidden = noGroups || noMatches;
+        } else {
+            historyEmpty.hidden = true;
+        }
     };
 
     const renderHistoryPanel = () => {
+        if (panelMode === "snippets") {
+            renderSnippetsPanel();
+            return;
+        }
         const query = historyQuery.value;
         const sections = {
             history: {
@@ -1075,21 +1393,20 @@
                 entries: matchingEntries(favoriteEntries(), query),
                 emptyTitle: "В избранном пока пусто",
                 emptyMessage: "Нажмите звезду рядом с любой командой."
-            },
-            templates: {
-                title: "Мои шаблоны",
-                subtitle: "Параметризованные команды этого подключения",
-                entries: matchingEntries(commandTemplates, query),
-                emptyTitle: "Шаблонов пока нет",
-                emptyMessage: "Создайте команду с параметрами вида ${service}."
             }
         };
         const section = sections[activePanelSection] || sections.history;
         const filtered = section.entries;
         commandPanelTitle.textContent = section.title;
         commandPanelSubtitle.textContent = section.subtitle;
+        historyQuery.placeholder = "Поиск команд";
+        document.getElementById("command-tabs").hidden = false;
+        commandTabs.forEach((button) => { button.hidden = false; });
         historyOptions.hidden = activePanelSection !== "history";
-        templateOptions.hidden = activePanelSection !== "templates";
+        snippetOptions.hidden = true;
+        snippetsList.hidden = true;
+        snippetFeedback.hidden = true;
+        commandPanelFooter.textContent = "Строки с пробелом в начале и признаками секретов не сохраняются.";
         commandTabs.forEach((button) => {
             button.classList.toggle(
                 "is-selected",
@@ -1115,8 +1432,6 @@
             if (activePanelSection === "history") {
                 const used = entry.useCount > 1 ? ` · запусков: ${entry.useCount}` : "";
                 meta.textContent = `${formatHistoryDate(entry.lastUsedAt)}${used}`;
-            } else if (activePanelSection === "templates") {
-                meta.textContent = `${entry.category} · ${entry.title}`;
             } else {
                 meta.textContent = `${entry.category} · ${entry.description}`;
             }
@@ -1148,24 +1463,6 @@
                     postHistory({ action: "remove", id: entry.id });
                 });
                 actions.append(removeButton);
-            } else if (activePanelSection === "templates") {
-                const editButton = document.createElement("button");
-                editButton.type = "button";
-                editButton.className = "history-action";
-                editButton.textContent = "✎";
-                editButton.title = "Изменить шаблон";
-                editButton.addEventListener("click", () => openTemplateEditor(entry));
-                const removeButton = document.createElement("button");
-                removeButton.type = "button";
-                removeButton.className = "history-action";
-                removeButton.textContent = "×";
-                removeButton.title = "Удалить шаблон";
-                removeButton.addEventListener("click", () => {
-                    if (window.confirm(`Удалить шаблон «${entry.title}»?`)) {
-                        postHistory({ action: "removeTemplate", id: entry.id });
-                    }
-                });
-                actions.append(editButton, removeButton);
             }
             row.append(useButton, actions);
             historyList.append(row);
@@ -1729,6 +2026,14 @@
                     keywords: `${entry.title || ""} ${entry.category || ""}`
                 }))
             : [];
+        snippetGroups = Array.isArray(payload.snippetGroups)
+            ? payload.snippetGroups.filter((group) => group
+                && typeof group.id === "string"
+                && typeof group.name === "string")
+            : [];
+        if (selectedSnippetID && !commandTemplates.some((entry) => entry.id === selectedSnippetID)) {
+            selectedSnippetID = null;
+        }
         const remote = payload.remote && typeof payload.remote === "object"
             ? payload.remote
             : {};
@@ -1746,16 +2051,66 @@
         remoteContextCanRetry = remote.canRetry === true;
         renderHistoryPanel();
         renderSuggestions();
+        if (pendingSnippetEditor && snippetGroups.length > 0) {
+            pendingSnippetEditor = false;
+            openSnippetEditor();
+        }
     };
 
-    window.selectiveTerminalSetHistoryVisible = (
-        visible,
+    window.selectiveTerminalReportSnippetRun = (result) => {
+        if (result === "success") {
+            showSnippetFeedback("");
+            return;
+        }
+        showSnippetFeedback(snippetText(
+            result === "invalidSnippet" ? "invalidSnippet" : "inactiveSession"
+        ));
+    };
+
+    window.selectiveTerminalSetLanguage = (language) => {
+        snippetLanguage = String(language || "").toLocaleLowerCase().startsWith("en")
+            ? "en"
+            : "ru";
+        document.documentElement.lang = snippetLanguage;
+        snippetAddButton.textContent = snippetText("newSnippet");
+        snippetGroupAddButton.textContent = snippetText("newGroup");
+        snippetEmptyAddButton.textContent = snippetText("newSnippet");
+        document.getElementById("snippet-title-label").textContent = snippetLanguage === "en"
+            ? "Title"
+            : "Название";
+        document.getElementById("snippet-group-label").textContent = snippetText("group");
+        document.getElementById("snippet-command-label").textContent = snippetText("command");
+        document.getElementById("snippet-group-name-label").textContent = snippetLanguage === "en"
+            ? "Group name"
+            : "Название группы";
+        document.getElementById("snippet-move-group-label").textContent = snippetText("group");
+        snippetCancel.textContent = snippetText("cancel");
+        snippetGroupCancel.textContent = snippetText("cancel");
+        snippetMoveCancel.textContent = snippetText("cancel");
+        document.getElementById("snippet-save").textContent = snippetText("save");
+        document.getElementById("snippet-group-save").textContent = snippetText("create");
+        document.getElementById("snippet-move-save").textContent = snippetText("move");
+        document.querySelectorAll("#snippet-context-menu [data-action]").forEach((button) => {
+            const key = button.dataset.action === "remove" ? "remove" : button.dataset.action;
+            button.textContent = snippetText(key);
+        });
+        if (panelMode === "snippets") {
+            renderSnippetsPanel();
+        }
+    };
+
+    window.selectiveTerminalSetPanelMode = (
+        mode,
         notifySwift = false,
         restoreTerminalFocus = true
     ) => {
-        const nextVisible = Boolean(visible);
+        const nextMode = ["history", "snippets"].includes(mode) ? mode : "hidden";
+        const nextVisible = nextMode !== "hidden";
+        panelMode = nextMode;
         historyPanel.hidden = !nextVisible;
+        terminalShell.classList.toggle("command-panel-visible", nextVisible);
         hideSuggestions();
+        hideSnippetContextMenu();
         if (nextVisible) {
             renderHistoryPanel();
             window.setTimeout(() => historyQuery.focus(), 0);
@@ -1763,9 +2118,21 @@
             terminal.focus();
         }
         if (notifySwift) {
-            postHistory({ action: "visibility", visible: nextVisible });
+            postHistory({ action: "panelVisibility", mode: nextMode });
         }
+        window.requestAnimationFrame(fitAndReport);
+        window.setTimeout(fitAndReport, 140);
     };
+
+    window.selectiveTerminalSetHistoryVisible = (
+        visible,
+        notifySwift = false,
+        restoreTerminalFocus = true
+    ) => window.selectiveTerminalSetPanelMode(
+        visible ? "history" : "hidden",
+        notifySwift,
+        restoreTerminalFocus
+    );
 
     terminalSearchQuery.addEventListener("input", () => refreshTerminalSearch(false));
     terminalSearchQuery.addEventListener("keydown", (event) => {
@@ -1801,18 +2168,88 @@
             postHistory({ action: "clear" });
         }
     });
-    templateAddButton.addEventListener("click", () => openTemplateEditor());
-    templateCancel.addEventListener("click", () => templateDialog.close());
-    templateForm.addEventListener("submit", (event) => {
+    snippetAddButton.addEventListener("click", () => openSnippetEditor());
+    snippetEmptyAddButton.addEventListener("click", () => openSnippetEditor());
+    snippetGroupAddButton.addEventListener("click", () => openSnippetGroupEditor());
+    snippetCancel.addEventListener("click", () => snippetDialog.close());
+    snippetForm.addEventListener("submit", (event) => {
+        event.preventDefault();
+        const group = snippetGroups.find((item) => item.id === snippetGroup.value);
+        if (!group) {
+            return;
+        }
+        postHistory({
+            action: "saveSnippet",
+            id: snippetID.value || null,
+            title: snippetTitle.value,
+            category: group.name,
+            command: snippetCommand.value
+        });
+        snippetDialog.close();
+    });
+    snippetGroupCancel.addEventListener("click", () => snippetGroupDialog.close());
+    snippetGroupForm.addEventListener("submit", (event) => {
         event.preventDefault();
         postHistory({
-            action: "saveTemplate",
-            id: templateID.value || null,
-            title: templateTitle.value,
-            category: templateCategory.value,
-            command: templateCommand.value
+            action: snippetGroupID.value ? "renameSnippetGroup" : "createSnippetGroup",
+            id: snippetGroupID.value || null,
+            name: snippetGroupName.value
         });
-        templateDialog.close();
+        snippetGroupDialog.close();
+    });
+    snippetMoveCancel.addEventListener("click", () => snippetMoveDialog.close());
+    snippetMoveForm.addEventListener("submit", (event) => {
+        event.preventDefault();
+        postHistory({
+            action: "moveSnippet",
+            id: snippetMoveID.value,
+            groupID: snippetMoveGroup.value
+        });
+        snippetMoveDialog.close();
+    });
+    snippetsList.addEventListener("keydown", (event) => {
+        if (event.key !== "Enter") {
+            return;
+        }
+        const button = event.target.closest(".snippet-select[data-snippet-id]");
+        const editorActive = snippetDialog.open
+            || snippetGroupDialog.open
+            || snippetMoveDialog.open;
+        const decision = window.SelectiveTerminalSnippetInteractions.decision({
+            eventType: "enter",
+            targetKind: button ? "snippet" : "group",
+            editorActive
+        });
+        if (decision === "run") {
+            event.preventDefault();
+            requestSnippetRun(snippetByID(button.dataset.snippetId));
+        }
+    });
+    snippetContextMenu.addEventListener("click", (event) => {
+        const button = event.target.closest("button[data-action]");
+        const entry = snippetByID(contextSnippetID);
+        if (!button || !entry) {
+            return;
+        }
+        const action = button.dataset.action;
+        hideSnippetContextMenu();
+        if (action === "run") {
+            requestSnippetRun(entry);
+        } else if (action === "edit") {
+            openSnippetEditor(entry);
+        } else if (action === "duplicate") {
+            postHistory({ action: "duplicateSnippet", id: entry.id });
+        } else if (action === "move") {
+            openSnippetMove(entry);
+        } else if (action === "remove"
+            && window.confirm(snippetText("deleteSnippetConfirm")(entry.title))) {
+            postHistory({ action: "removeSnippet", id: entry.id });
+        }
+    });
+    document.addEventListener("pointerdown", (event) => {
+        if (!snippetContextMenu.hidden && !snippetContextMenu.contains(event.target)) {
+            hideSnippetContextMenu();
+        }
     });
     historyCloseButton.addEventListener("click", () => {
         window.selectiveTerminalSetHistoryVisible(false, true);

--- a/Sources/SelectiveRemote/TerminalResources/terminal-host.js
+++ b/Sources/SelectiveRemote/TerminalResources/terminal-host.js
@@ -31,6 +31,8 @@
     const snippetTitle = document.getElementById("snippet-title");
     const snippetGroup = document.getElementById("snippet-group");
     const snippetCommand = document.getElementById("snippet-command");
+    const snippetTargetsList = document.getElementById("snippet-targets-list");
+    const snippetTargetsError = document.getElementById("snippet-targets-error");
     const snippetCancel = document.getElementById("snippet-cancel");
     const snippetGroupDialog = document.getElementById("snippet-group-dialog");
     const snippetGroupForm = document.getElementById("snippet-group-form");
@@ -67,6 +69,8 @@
             defaultGroup: "Мои команды",
             group: "Группа",
             command: "Команда или скрипт",
+            targets: "Targets · до 8 SSH-профилей",
+            targetRequired: "Выберите хотя бы один Target.",
             create: "Создать",
             save: "Сохранить",
             cancel: "Отмена",
@@ -100,6 +104,8 @@
             defaultGroup: "My commands",
             group: "Group",
             command: "Command or script",
+            targets: "Targets · up to 8 SSH profiles",
+            targetRequired: "Select at least one target.",
             create: "Create",
             save: "Save",
             cancel: "Cancel",
@@ -288,6 +294,8 @@
     let favoriteCommands = new Set();
     let commandTemplates = [];
     let snippetGroups = [];
+    let snippetTargetOptions = [];
+    let defaultSnippetTargetID = "";
     let selectedSnippetID = null;
     let contextSnippetID = null;
     let panelMode = "hidden";
@@ -1145,7 +1153,48 @@
         });
     };
 
-    const openSnippetEditor = (entry = null) => {
+    const selectedSnippetTargetIDs = () => Array.from(
+        snippetTargetsList.querySelectorAll('input[type="checkbox"]:checked')
+    ).map((input) => input.value);
+
+    const updateSnippetTargetAvailability = () => {
+        const selectedCount = selectedSnippetTargetIDs().length;
+        snippetTargetsList.querySelectorAll('input[type="checkbox"]').forEach((input) => {
+            input.disabled = !input.checked && selectedCount >= 8;
+        });
+        if (selectedCount > 0) {
+            snippetTargetsError.hidden = true;
+        }
+    };
+
+    const renderSnippetTargets = (selectedIDs = []) => {
+        const selected = new Set(
+            selectedIDs.filter((id) => typeof id === "string").slice(0, 8)
+        );
+        snippetTargetsList.replaceChildren();
+        snippetTargetsError.hidden = true;
+        snippetTargetOptions.forEach((target) => {
+            const row = document.createElement("label");
+            const input = document.createElement("input");
+            input.type = "checkbox";
+            input.value = target.id;
+            input.checked = selected.has(target.id);
+            input.addEventListener("change", updateSnippetTargetAvailability);
+
+            const copy = document.createElement("span");
+            copy.className = "snippet-target-copy";
+            const title = document.createElement("span");
+            title.textContent = target.title;
+            const subtitle = document.createElement("small");
+            subtitle.textContent = target.subtitle;
+            copy.append(title, subtitle);
+            row.append(input, copy);
+            snippetTargetsList.append(row);
+        });
+        updateSnippetTargetAvailability();
+    };
+
+    const openSnippetEditor = (entry = null, preferredGroup = "") => {
         if (snippetGroups.length === 0) {
             pendingSnippetEditor = true;
             postHistory({ action: "createSnippetGroup", name: "Мои команды" });
@@ -1154,7 +1203,15 @@
         snippetID.value = entry?.id || "";
         snippetTitle.value = entry?.title || "";
         snippetCommand.value = entry?.command || "";
-        fillGroupSelect(snippetGroup, entry?.category || snippetGroups[0].name);
+        fillGroupSelect(
+            snippetGroup,
+            entry?.category || preferredGroup || snippetGroups[0].name
+        );
+        renderSnippetTargets(
+            Array.isArray(entry?.targetProfileIDs)
+                ? entry.targetProfileIDs
+                : [defaultSnippetTargetID]
+        );
         document.getElementById("snippet-dialog-title").textContent = entry
             ? snippetText("editSnippet")
             : snippetText("newSnippet");
@@ -1343,6 +1400,14 @@
                 row.append(select, menu);
                 section.append(row);
             });
+            if (allEntries.length === 0 && !query) {
+                const addSnippet = document.createElement("button");
+                addSnippet.type = "button";
+                addSnippet.className = "snippet-empty-group-add";
+                addSnippet.textContent = `+ ${snippetText("newSnippet")}`;
+                addSnippet.addEventListener("click", () => openSnippetEditor(null, group.name));
+                section.append(addSnippet);
+            }
             snippetsList.append(section);
         });
 
@@ -2033,6 +2098,15 @@
                 && typeof group.id === "string"
                 && typeof group.name === "string")
             : [];
+        snippetTargetOptions = Array.isArray(payload.snippetTargets)
+            ? payload.snippetTargets.filter((target) => target
+                && typeof target.id === "string"
+                && typeof target.title === "string"
+                && typeof target.subtitle === "string")
+            : [];
+        defaultSnippetTargetID = typeof payload.defaultSnippetTargetID === "string"
+            ? payload.defaultSnippetTargetID
+            : "";
         if (selectedSnippetID && !commandTemplates.some((entry) => entry.id === selectedSnippetID)) {
             selectedSnippetID = null;
         }
@@ -2083,6 +2157,8 @@
             : "Название";
         document.getElementById("snippet-group-label").textContent = snippetText("group");
         document.getElementById("snippet-command-label").textContent = snippetText("command");
+        document.getElementById("snippet-targets-label").textContent = snippetText("targets");
+        snippetTargetsError.textContent = snippetText("targetRequired");
         document.getElementById("snippet-group-name-label").textContent = snippetLanguage === "en"
             ? "Group name"
             : "Название группы";
@@ -2094,7 +2170,9 @@
         document.getElementById("snippet-group-save").textContent = snippetText("create");
         document.getElementById("snippet-move-save").textContent = snippetText("move");
         document.querySelectorAll("#snippet-context-menu [data-action]").forEach((button) => {
-            const key = button.dataset.action === "remove" ? "remove" : button.dataset.action;
+            const key = button.dataset.action === "new"
+                ? "newSnippet"
+                : button.dataset.action;
             button.textContent = snippetText(key);
         });
         if (panelMode === "snippets") {
@@ -2178,7 +2256,9 @@
     snippetForm.addEventListener("submit", (event) => {
         event.preventDefault();
         const group = snippetGroups.find((item) => item.id === snippetGroup.value);
-        if (!group) {
+        const targetProfileIDs = selectedSnippetTargetIDs();
+        if (!group || targetProfileIDs.length === 0) {
+            snippetTargetsError.hidden = targetProfileIDs.length > 0;
             return;
         }
         postHistory({
@@ -2186,7 +2266,8 @@
             id: snippetID.value || null,
             title: snippetTitle.value,
             category: group.name,
-            command: snippetCommand.value
+            command: snippetCommand.value,
+            targetProfileIDs
         });
         snippetDialog.close();
     });
@@ -2242,6 +2323,8 @@
             openSnippetEditor(entry);
         } else if (action === "duplicate") {
             postHistory({ action: "duplicateSnippet", id: entry.id });
+        } else if (action === "new") {
+            openSnippetEditor(null, entry.category);
         } else if (action === "move") {
             openSnippetMove(entry);
         } else if (action === "remove") {

--- a/Sources/SelectiveRemote/TerminalResources/terminal-snippet-interactions.js
+++ b/Sources/SelectiveRemote/TerminalResources/terminal-snippet-interactions.js
@@ -1,0 +1,26 @@
+((root, factory) => {
+    const api = factory();
+    if (typeof module === "object" && module.exports) {
+        module.exports = api;
+    }
+    if (root) {
+        root.SelectiveTerminalSnippetInteractions = api;
+    }
+})(typeof globalThis === "object" ? globalThis : this, () => {
+    "use strict";
+
+    const decision = ({ eventType, targetKind, editorActive = false }) => {
+        if (editorActive || targetKind !== "snippet") {
+            return "none";
+        }
+        if (eventType === "click") {
+            return "select";
+        }
+        if (eventType === "dblclick" || eventType === "enter") {
+            return "run";
+        }
+        return "none";
+    };
+
+    return { decision };
+});

--- a/Sources/SelectiveRemote/TerminalResources/terminal.html
+++ b/Sources/SelectiveRemote/TerminalResources/terminal.html
@@ -69,9 +69,6 @@
                 <button type="button" data-section="favorites">
                     Избранное
                 </button>
-                <button type="button" data-section="templates">
-                    Шаблоны
-                </button>
             </nav>
             <div id="history-options" class="history-options">
                 <label>
@@ -80,49 +77,87 @@
                 </label>
                 <button id="history-clear" type="button">Очистить</button>
             </div>
-            <div id="template-options" class="history-options" hidden>
-                <span>Поля вида ${service} запрашиваются при вставке</span>
-                <button id="template-add" type="button">Добавить</button>
+            <div id="snippet-options" class="history-options" hidden>
+                <button id="snippet-group-add" type="button">Новая группа</button>
+                <button id="snippet-add" type="button" class="primary">Новый сниппет</button>
             </div>
             <div id="history-list" role="list"></div>
+            <div id="snippets-list" role="tree" hidden></div>
             <div id="history-empty" hidden>
                 <strong id="command-empty-title">История пока пуста</strong>
                 <span id="command-empty-message">
                     Выполненные команды появятся здесь автоматически.
                 </span>
                 <button id="remote-context-retry" type="button" hidden>Повторить</button>
+                <button id="snippet-empty-add" type="button" hidden>Новый сниппет</button>
             </div>
-            <footer>
+            <div id="snippet-feedback" role="status" hidden></div>
+            <footer id="command-panel-footer">
                 Строки с пробелом в начале и признаками секретов не сохраняются.
             </footer>
         </aside>
-        <dialog id="template-dialog" aria-labelledby="template-dialog-title">
-            <form id="template-form" method="dialog">
-                <h3 id="template-dialog-title">Шаблон команды</h3>
-                <input id="template-id" type="hidden">
+        <dialog id="snippet-dialog" aria-labelledby="snippet-dialog-title">
+            <form id="snippet-form" method="dialog">
+                <h3 id="snippet-dialog-title">Сниппет</h3>
+                <input id="snippet-id" type="hidden">
                 <label>
-                    <span>Название</span>
-                    <input id="template-title" maxlength="80" required autocomplete="off">
+                    <span id="snippet-title-label">Название</span>
+                    <input id="snippet-title" maxlength="80" required autocomplete="off">
                 </label>
                 <label>
-                    <span>Категория</span>
-                    <input id="template-category" maxlength="60" value="Мои команды" autocomplete="off">
+                    <span id="snippet-group-label">Группа</span>
+                    <select id="snippet-group" required></select>
                 </label>
                 <label>
-                    <span>Команда</span>
-                    <textarea id="template-command" maxlength="8192" rows="5" required spellcheck="false" placeholder="sudo systemctl restart ${service}"></textarea>
+                    <span id="snippet-command-label">Команда или скрипт</span>
+                    <textarea id="snippet-command" maxlength="8192" rows="7" required spellcheck="false" placeholder="docker ps"></textarea>
                 </label>
-                <p>Шаблон только подставляется в терминал и не запускается автоматически.</p>
                 <menu>
-                    <button id="template-cancel" type="button">Отмена</button>
-                    <button type="submit" class="primary">Сохранить</button>
+                    <button id="snippet-cancel" type="button">Отмена</button>
+                    <button id="snippet-save" type="submit" class="primary">Сохранить</button>
                 </menu>
             </form>
         </dialog>
+        <dialog id="snippet-group-dialog" aria-labelledby="snippet-group-dialog-title">
+            <form id="snippet-group-form" method="dialog">
+                <h3 id="snippet-group-dialog-title">Новая группа</h3>
+                <input id="snippet-group-id" type="hidden">
+                <label>
+                    <span id="snippet-group-name-label">Название группы</span>
+                    <input id="snippet-group-name" maxlength="60" required autocomplete="off">
+                </label>
+                <menu>
+                    <button id="snippet-group-cancel" type="button">Отмена</button>
+                    <button id="snippet-group-save" type="submit" class="primary">Создать</button>
+                </menu>
+            </form>
+        </dialog>
+        <dialog id="snippet-move-dialog" aria-labelledby="snippet-move-dialog-title">
+            <form id="snippet-move-form" method="dialog">
+                <h3 id="snippet-move-dialog-title">Переместить в группу</h3>
+                <input id="snippet-move-id" type="hidden">
+                <label>
+                    <span id="snippet-move-group-label">Группа</span>
+                    <select id="snippet-move-group" required></select>
+                </label>
+                <menu>
+                    <button id="snippet-move-cancel" type="button">Отмена</button>
+                    <button id="snippet-move-save" type="submit" class="primary">Переместить</button>
+                </menu>
+            </form>
+        </dialog>
+        <div id="snippet-context-menu" class="terminal-popover snippet-context-menu" hidden>
+            <button type="button" data-action="run">Выполнить</button>
+            <button type="button" data-action="edit">Изменить</button>
+            <button type="button" data-action="duplicate">Дублировать</button>
+            <button type="button" data-action="move">Переместить</button>
+            <button type="button" data-action="remove" class="destructive">Удалить</button>
+        </div>
     </main>
     <script src="xterm.js"></script>
     <script src="addon-fit.js"></script>
     <script src="terminal-command-catalog.js"></script>
+    <script src="terminal-snippet-interactions.js"></script>
     <script src="terminal-host.js"></script>
 </body>
 </html>

--- a/Sources/SelectiveRemote/TerminalResources/terminal.html
+++ b/Sources/SelectiveRemote/TerminalResources/terminal.html
@@ -112,6 +112,11 @@
                     <span id="snippet-command-label">Команда или скрипт</span>
                     <textarea id="snippet-command" maxlength="8192" rows="7" required spellcheck="false" placeholder="docker ps"></textarea>
                 </label>
+                <fieldset id="snippet-targets-field">
+                    <legend id="snippet-targets-label">Targets · до 8 SSH-профилей</legend>
+                    <div id="snippet-targets-list"></div>
+                    <span id="snippet-targets-error" role="alert" hidden>Выберите хотя бы один Target.</span>
+                </fieldset>
                 <menu>
                     <button id="snippet-cancel" type="button">Отмена</button>
                     <button id="snippet-save" type="submit" class="primary">Сохранить</button>
@@ -150,6 +155,7 @@
             <button type="button" data-action="run">Выполнить</button>
             <button type="button" data-action="edit">Изменить</button>
             <button type="button" data-action="duplicate">Дублировать</button>
+            <button type="button" data-action="new">Новый сниппет</button>
             <button type="button" data-action="move">Переместить</button>
             <button type="button" data-action="remove" class="destructive">Удалить</button>
         </div>

--- a/Sources/SelectiveRemote/TerminalSnippets.swift
+++ b/Sources/SelectiveRemote/TerminalSnippets.swift
@@ -8,6 +8,28 @@ enum TerminalSnippetRunResult: String, Encodable, Equatable {
     case invalidSnippet
 }
 
+enum TerminalSnippetTargetRunState: Equatable {
+    case connecting
+    case sent
+    case failed(String)
+}
+
+struct TerminalSnippetTargetRunStatus: Identifiable, Equatable {
+    let profileID: UUID
+    let name: String
+    var state: TerminalSnippetTargetRunState
+
+    var id: UUID { profileID }
+}
+
+struct TerminalSnippetRunSummary: Identifiable, Equatable {
+    let id: UUID
+    let snippetID: UUID
+    let title: String
+    let startedAt: Date
+    var targets: [TerminalSnippetTargetRunStatus]
+}
+
 enum TerminalSnippetExecution {
     static func canRun(
         originTabID: UUID,

--- a/Sources/SelectiveRemote/TerminalSnippets.swift
+++ b/Sources/SelectiveRemote/TerminalSnippets.swift
@@ -2,6 +2,8 @@ import Foundation
 
 enum TerminalSnippetRunResult: String, Encodable, Equatable {
     case success
+    case connecting
+    case noTargets
     case inactiveSession
     case invalidSnippet
 }

--- a/Sources/SelectiveRemote/TerminalSnippets.swift
+++ b/Sources/SelectiveRemote/TerminalSnippets.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+enum TerminalSnippetRunResult: String, Encodable, Equatable {
+    case success
+    case inactiveSession
+    case invalidSnippet
+}
+
+enum TerminalSnippetExecution {
+    static func canRun(
+        originTabID: UUID,
+        selectedTabID: UUID,
+        sessionIsRunning: Bool
+    ) -> Bool {
+        originTabID == selectedTabID && sessionIsRunning
+    }
+
+    static func inputData(for rawCommand: String) -> Data? {
+        let command = rawCommand.trimmingCharacters(in: .newlines)
+        guard !command.isEmpty,
+              !command.contains("\0"),
+              command.count <= 8_192
+        else { return nil }
+        return Data((command + "\n").utf8)
+    }
+}

--- a/Sources/SelectiveRemote/TerminalSnippetsLibraryView.swift
+++ b/Sources/SelectiveRemote/TerminalSnippetsLibraryView.swift
@@ -1,0 +1,454 @@
+import SwiftUI
+
+struct TerminalSnippetsLibraryView: View {
+    @ObservedObject var store: TerminalCommandHistoryStore
+    let profiles: [ConnectionProfile]
+    let onRun: (TerminalCommandTemplate) -> TerminalSnippetRunResult
+
+    @State private var query = ""
+    @State private var selectedSnippetID: UUID?
+    @State private var editorSnippet: TerminalCommandTemplate?
+    @State private var editorPresented = false
+    @State private var groupEditor: TerminalSnippetGroup?
+    @State private var groupEditorPresented = false
+    @State private var deleteSnippet: TerminalCommandTemplate?
+
+    private var selectedSnippet: TerminalCommandTemplate? {
+        guard let selectedSnippetID else { return nil }
+        return store.template(id: selectedSnippetID)
+    }
+
+    private var sortedProfiles: [ConnectionProfile] {
+        profiles
+            .filter { $0.connectionType == .ssh }
+            .sorted {
+                $0.friendlyName.localizedStandardCompare($1.friendlyName)
+                    == .orderedAscending
+            }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            HSplitView {
+                libraryList
+                    .frame(minWidth: 430, idealWidth: 620)
+                inspector
+                    .frame(minWidth: 320, idealWidth: 420)
+            }
+        }
+        .sheet(isPresented: $editorPresented) {
+            TerminalSnippetEditorView(
+                snippet: editorSnippet,
+                groups: store.snippetGroups(),
+                profiles: sortedProfiles
+            ) { draft in
+                let profileID = draft.targetProfileIDs.first
+                    ?? TerminalCommandHistoryStore.globalSnippetLibraryID
+                if store.saveTemplate(
+                    id: draft.id,
+                    title: draft.title,
+                    command: draft.command,
+                    category: draft.category,
+                    profileID: profileID,
+                    targetProfileIDs: draft.targetProfileIDs
+                ) {
+                    selectedSnippetID = draft.id ?? store.templates().first?.id
+                }
+            }
+        }
+        .sheet(isPresented: $groupEditorPresented) {
+            TerminalSnippetGroupEditorView(group: groupEditor) { name in
+                if let groupEditor {
+                    _ = store.renameSnippetGroup(
+                        id: groupEditor.id,
+                        name: name,
+                        profileID: TerminalCommandHistoryStore.globalSnippetLibraryID
+                    )
+                } else {
+                    _ = store.createSnippetGroup(
+                        name: name,
+                        profileID: TerminalCommandHistoryStore.globalSnippetLibraryID
+                    )
+                }
+            }
+        }
+        .alert(
+            "Удалить сниппет?",
+            isPresented: Binding(
+                get: { deleteSnippet != nil },
+                set: { if !$0 { deleteSnippet = nil } }
+            ),
+            presenting: deleteSnippet
+        ) { snippet in
+            Button("Удалить", role: .destructive) {
+                if store.removeTemplate(id: snippet.id), selectedSnippetID == snippet.id {
+                    selectedSnippetID = store.templates().first?.id
+                }
+                deleteSnippet = nil
+            }
+            Button("Отмена", role: .cancel) { deleteSnippet = nil }
+        } message: { snippet in
+            Text("«\(snippet.title)» будет удалён из общей библиотеки Snippets.")
+        }
+        .onAppear {
+            if selectedSnippetID == nil { selectedSnippetID = store.templates().first?.id }
+        }
+        .onChange(of: store.snippetRevision) { _, _ in
+            if let selectedSnippetID, store.template(id: selectedSnippetID) == nil {
+                self.selectedSnippetID = store.templates().first?.id
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 5) {
+                Text("Сниппеты")
+                    .font(.system(size: 30, weight: .bold, design: .rounded))
+                Text("Общая библиотека команд · один сниппет может запускаться на нескольких SSH Targets")
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button {
+                groupEditor = nil
+                groupEditorPresented = true
+            } label: {
+                Label("Новая группа", systemImage: "folder.badge.plus")
+            }
+            Button {
+                presentEditor(nil)
+            } label: {
+                Label("Новый сниппет", systemImage: "plus")
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(sortedProfiles.isEmpty)
+        }
+        .padding(.horizontal, 28)
+        .padding(.vertical, 22)
+    }
+
+    private var libraryList: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField("Поиск сниппетов", text: $query)
+                    .textFieldStyle(.plain)
+            }
+            .padding(10)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
+            .padding(14)
+
+            List(selection: $selectedSnippetID) {
+                ForEach(store.snippetGroups()) { group in
+                    Section {
+                        ForEach(filteredSnippets(in: group)) { snippet in
+                            snippetRow(snippet)
+                                .tag(snippet.id)
+                                .contextMenu {
+                                    Button("Изменить", systemImage: "pencil") {
+                                        presentEditor(snippet)
+                                    }
+                                    Button("Дублировать", systemImage: "doc.on.doc") {
+                                        _ = store.duplicateTemplate(
+                                            id: snippet.id,
+                                            profileID: TerminalCommandHistoryStore.globalSnippetLibraryID
+                                        )
+                                    }
+                                    Divider()
+                                    Button("Удалить", systemImage: "trash", role: .destructive) {
+                                        deleteSnippet = snippet
+                                    }
+                                }
+                        }
+                    } header: {
+                        HStack {
+                            Text(group.name)
+                            Spacer()
+                            Text("\(store.templates().filter { $0.category == group.name }.count)")
+                                .foregroundStyle(.secondary)
+                            Menu {
+                                Button("Переименовать", systemImage: "pencil") {
+                                    groupEditor = group
+                                    groupEditorPresented = true
+                                }
+                                Button("Удалить группу", systemImage: "trash", role: .destructive) {
+                                    _ = store.removeSnippetGroup(
+                                        id: group.id,
+                                        profileID: TerminalCommandHistoryStore.globalSnippetLibraryID
+                                    )
+                                }
+                            } label: {
+                                Image(systemName: "ellipsis")
+                            }
+                            .menuStyle(.borderlessButton)
+                            .frame(width: 28)
+                        }
+                    }
+                }
+            }
+            .listStyle(.inset)
+            .overlay {
+                if store.templates().isEmpty {
+                    ContentUnavailableView(
+                        "Сниппетов пока нет",
+                        systemImage: "curlybraces",
+                        description: Text("Создайте общую команду и назначьте ей один или несколько SSH Targets.")
+                    )
+                }
+            }
+        }
+    }
+
+    private func snippetRow(_ snippet: TerminalCommandTemplate) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: "curlybraces")
+                .font(.title3.bold())
+                .foregroundStyle(Color.accentColor)
+                .frame(width: 34, height: 34)
+                .background(Color.accentColor.opacity(0.12), in: RoundedRectangle(cornerRadius: 9))
+            VStack(alignment: .leading, spacing: 3) {
+                Text(snippet.title)
+                    .font(.headline)
+                Text(snippet.command.replacingOccurrences(of: "\n", with: " ↵ "))
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer()
+            Label("\(snippet.targetProfileIDs.count)", systemImage: "server.rack")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 5)
+    }
+
+    @ViewBuilder
+    private var inspector: some View {
+        if let snippet = selectedSnippet {
+            VStack(alignment: .leading, spacing: 18) {
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(snippet.title).font(.title2.bold())
+                        Text(snippet.category).foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    Button { presentEditor(snippet) } label: {
+                        Image(systemName: "pencil")
+                    }
+                    Button(role: .destructive) { deleteSnippet = snippet } label: {
+                        Image(systemName: "trash")
+                    }
+                }
+
+                GroupBox("Script") {
+                    ScrollView {
+                        Text(snippet.command)
+                            .font(.body.monospaced())
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(8)
+                    }
+                    .frame(minHeight: 130)
+                }
+
+                GroupBox("Targets") {
+                    VStack(alignment: .leading, spacing: 8) {
+                        ForEach(targetProfiles(for: snippet)) { profile in
+                            Label {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(profile.friendlyName.isEmpty ? profile.host : profile.friendlyName)
+                                    Text(profile.host)
+                                        .font(.caption.monospaced())
+                                        .foregroundStyle(.secondary)
+                                }
+                            } icon: {
+                                Image(systemName: "server.rack")
+                            }
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(8)
+                }
+
+                Spacer()
+                Button {
+                    _ = onRun(snippet)
+                } label: {
+                    Label("Запустить на \(snippet.targetProfileIDs.count) Targets", systemImage: "play.fill")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .disabled(targetProfiles(for: snippet).isEmpty)
+            }
+            .padding(22)
+        } else {
+            ContentUnavailableView("Выберите сниппет", systemImage: "curlybraces")
+        }
+    }
+
+    private func filteredSnippets(in group: TerminalSnippetGroup) -> [TerminalCommandTemplate] {
+        let normalized = query.trimmingCharacters(in: .whitespacesAndNewlines)
+            .localizedLowercase
+        return store.templates().filter { snippet in
+            guard snippet.category == group.name else { return false }
+            return normalized.isEmpty
+                || snippet.title.localizedLowercase.contains(normalized)
+                || snippet.command.localizedLowercase.contains(normalized)
+                || group.name.localizedLowercase.contains(normalized)
+        }
+    }
+
+    private func targetProfiles(for snippet: TerminalCommandTemplate) -> [ConnectionProfile] {
+        let ids = Set(snippet.targetProfileIDs)
+        return sortedProfiles.filter { ids.contains($0.id) }
+    }
+
+    private func presentEditor(_ snippet: TerminalCommandTemplate?) {
+        if store.snippetGroups().isEmpty {
+            _ = store.createSnippetGroup(
+                name: TerminalCommandHistoryStore.defaultSnippetGroupName,
+                profileID: TerminalCommandHistoryStore.globalSnippetLibraryID
+            )
+        }
+        editorSnippet = snippet
+        editorPresented = true
+    }
+}
+
+private struct TerminalSnippetDraft {
+    let id: UUID?
+    let title: String
+    let command: String
+    let category: String
+    let targetProfileIDs: [UUID]
+}
+
+private struct TerminalSnippetEditorView: View {
+    @Environment(\.dismiss) private var dismiss
+    let snippet: TerminalCommandTemplate?
+    let groups: [TerminalSnippetGroup]
+    let profiles: [ConnectionProfile]
+    let onSave: (TerminalSnippetDraft) -> Void
+
+    @State private var title: String
+    @State private var command: String
+    @State private var category: String
+    @State private var targetIDs: Set<UUID>
+
+    init(
+        snippet: TerminalCommandTemplate?,
+        groups: [TerminalSnippetGroup],
+        profiles: [ConnectionProfile],
+        onSave: @escaping (TerminalSnippetDraft) -> Void
+    ) {
+        self.snippet = snippet
+        self.groups = groups
+        self.profiles = profiles
+        self.onSave = onSave
+        _title = State(initialValue: snippet?.title ?? "")
+        _command = State(initialValue: snippet?.command ?? "")
+        _category = State(initialValue: snippet?.category ?? groups.first?.name ?? TerminalCommandHistoryStore.defaultSnippetGroupName)
+        _targetIDs = State(initialValue: Set(snippet?.targetProfileIDs ?? profiles.first.map { [$0.id] } ?? []))
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                TextField("Название", text: $title)
+                Picker("Группа", selection: $category) {
+                    ForEach(groups) { group in Text(group.name).tag(group.name) }
+                }
+                TextEditor(text: $command)
+                    .font(.body.monospaced())
+                    .frame(minHeight: 150)
+
+                Section("Targets · до 8 SSH-профилей") {
+                    ForEach(profiles) { profile in
+                        Toggle(isOn: targetBinding(profile.id)) {
+                            VStack(alignment: .leading) {
+                                Text(profile.friendlyName.isEmpty ? profile.host : profile.friendlyName)
+                                Text(profile.host)
+                                    .font(.caption.monospaced())
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .disabled(!targetIDs.contains(profile.id) && targetIDs.count >= 8)
+                    }
+                }
+            }
+            .formStyle(.grouped)
+            .navigationTitle(snippet == nil ? "Новый сниппет" : "Изменить сниппет")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Отмена") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Сохранить") {
+                        onSave(
+                            TerminalSnippetDraft(
+                                id: snippet?.id,
+                                title: title,
+                                command: command,
+                                category: category,
+                                targetProfileIDs: profiles.map(\.id).filter(targetIDs.contains)
+                            )
+                        )
+                        dismiss()
+                    }
+                    .disabled(
+                        title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                            || command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                            || targetIDs.isEmpty
+                    )
+                }
+            }
+        }
+        .frame(width: 620, height: 650)
+    }
+
+    private func targetBinding(_ id: UUID) -> Binding<Bool> {
+        Binding(
+            get: { targetIDs.contains(id) },
+            set: { selected in
+                if selected { targetIDs.insert(id) } else { targetIDs.remove(id) }
+            }
+        )
+    }
+}
+
+private struct TerminalSnippetGroupEditorView: View {
+    @Environment(\.dismiss) private var dismiss
+    let group: TerminalSnippetGroup?
+    let onSave: (String) -> Void
+    @State private var name: String
+
+    init(group: TerminalSnippetGroup?, onSave: @escaping (String) -> Void) {
+        self.group = group
+        self.onSave = onSave
+        _name = State(initialValue: group?.name ?? "")
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Text(group == nil ? "Новая группа" : "Переименовать группу")
+                .font(.title2.bold())
+            TextField("Название группы", text: $name)
+            HStack {
+                Spacer()
+                Button("Отмена") { dismiss() }
+                Button("Сохранить") {
+                    onSave(name)
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding(24)
+        .frame(width: 420)
+    }
+}

--- a/Sources/SelectiveRemote/TerminalSnippetsLibraryView.swift
+++ b/Sources/SelectiveRemote/TerminalSnippetsLibraryView.swift
@@ -2,16 +2,15 @@ import SwiftUI
 
 struct TerminalSnippetsLibraryView: View {
     @ObservedObject var store: TerminalCommandHistoryStore
-    let profiles: [ConnectionProfile]
-    let onRun: (TerminalCommandTemplate) -> TerminalSnippetRunResult
+    @ObservedObject var model: AppModel
 
     @State private var query = ""
     @State private var selectedSnippetID: UUID?
-    @State private var editorSnippet: TerminalCommandTemplate?
-    @State private var editorPresented = false
+    @State private var editorRequest: TerminalSnippetEditorRequest?
     @State private var groupEditor: TerminalSnippetGroup?
     @State private var groupEditorPresented = false
     @State private var deleteSnippet: TerminalCommandTemplate?
+    @State private var showsDisconnectConfirmation = false
 
     private var selectedSnippet: TerminalCommandTemplate? {
         guard let selectedSnippetID else { return nil }
@@ -19,7 +18,7 @@ struct TerminalSnippetsLibraryView: View {
     }
 
     private var sortedProfiles: [ConnectionProfile] {
-        profiles
+        model.profiles
             .filter { $0.connectionType == .ssh }
             .sorted {
                 $0.friendlyName.localizedStandardCompare($1.friendlyName)
@@ -30,6 +29,9 @@ struct TerminalSnippetsLibraryView: View {
     var body: some View {
         VStack(spacing: 0) {
             header
+            if let summary = model.latestSnippetRun {
+                runStatus(summary)
+            }
             Divider()
             HSplitView {
                 libraryList
@@ -38,9 +40,10 @@ struct TerminalSnippetsLibraryView: View {
                     .frame(minWidth: 320, idealWidth: 420)
             }
         }
-        .sheet(isPresented: $editorPresented) {
+        .sheet(item: $editorRequest) { request in
             TerminalSnippetEditorView(
-                snippet: editorSnippet,
+                snippet: request.snippet,
+                preferredGroup: request.preferredGroup,
                 groups: store.snippetGroups(),
                 profiles: sortedProfiles
             ) { draft in
@@ -91,6 +94,16 @@ struct TerminalSnippetsLibraryView: View {
             Button("Отмена", role: .cancel) { deleteSnippet = nil }
         } message: { snippet in
             Text("«\(snippet.title)» будет удалён из общей библиотеки Snippets.")
+        }
+        .alert("Отключить SSH Targets?", isPresented: $showsDisconnectConfirmation) {
+            Button("Отключить", role: .destructive) {
+                model.disconnectTerminalSnippetTargets(
+                    model.latestSnippetRun?.targets.map(\.profileID) ?? []
+                )
+            }
+            Button("Отмена", role: .cancel) {}
+        } message: {
+            Text("Активные SSH-сессии Targets последнего запуска будут завершены. Выполняющаяся команда может быть прервана.")
         }
         .onAppear {
             if selectedSnippetID == nil { selectedSnippetID = store.templates().first?.id }
@@ -144,10 +157,20 @@ struct TerminalSnippetsLibraryView: View {
             List(selection: $selectedSnippetID) {
                 ForEach(store.snippetGroups()) { group in
                     Section {
-                        ForEach(filteredSnippets(in: group)) { snippet in
+                        let snippets = filteredSnippets(in: group)
+                        ForEach(snippets) { snippet in
                             snippetRow(snippet)
                                 .tag(snippet.id)
+                                .simultaneousGesture(
+                                    TapGesture(count: 2).onEnded {
+                                        _ = model.runTerminalSnippet(snippet)
+                                    }
+                                )
                                 .contextMenu {
+                                    Button("Запустить", systemImage: "play.fill") {
+                                        _ = model.runTerminalSnippet(snippet)
+                                    }
+                                    Divider()
                                     Button("Изменить", systemImage: "pencil") {
                                         presentEditor(snippet)
                                     }
@@ -157,11 +180,27 @@ struct TerminalSnippetsLibraryView: View {
                                             profileID: TerminalCommandHistoryStore.globalSnippetLibraryID
                                         )
                                     }
+                                    Button("Новый сниппет", systemImage: "plus") {
+                                        presentEditor(nil, preferredGroup: group.name)
+                                    }
                                     Divider()
                                     Button("Удалить", systemImage: "trash", role: .destructive) {
                                         deleteSnippet = snippet
                                     }
                                 }
+                        }
+                        if snippets.isEmpty
+                            && query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                            Button {
+                                presentEditor(nil, preferredGroup: group.name)
+                            } label: {
+                                Label("Новый сниппет", systemImage: "plus")
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                            .buttonStyle(.plain)
+                            .foregroundStyle(Color.accentColor)
+                            .padding(.vertical, 7)
+                            .disabled(sortedProfiles.isEmpty)
                         }
                     } header: {
                         HStack {
@@ -191,7 +230,7 @@ struct TerminalSnippetsLibraryView: View {
             }
             .listStyle(.inset)
             .overlay {
-                if store.templates().isEmpty {
+                if store.snippetGroups().isEmpty {
                     ContentUnavailableView(
                         "Сниппетов пока нет",
                         systemImage: "curlybraces",
@@ -273,9 +312,22 @@ struct TerminalSnippetsLibraryView: View {
                     .padding(8)
                 }
 
+                if let summary = model.latestSnippetRun,
+                   summary.snippetID == snippet.id {
+                    GroupBox("Последний запуск") {
+                        VStack(alignment: .leading, spacing: 8) {
+                            ForEach(summary.targets) { target in
+                                targetRunStatusRow(target)
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(8)
+                    }
+                }
+
                 Spacer()
                 Button {
-                    _ = onRun(snippet)
+                    _ = model.runTerminalSnippet(snippet)
                 } label: {
                     Label("Запустить на \(snippet.targetProfileIDs.count) Targets", systemImage: "play.fill")
                         .frame(maxWidth: .infinity)
@@ -307,16 +359,96 @@ struct TerminalSnippetsLibraryView: View {
         return sortedProfiles.filter { ids.contains($0.id) }
     }
 
-    private func presentEditor(_ snippet: TerminalCommandTemplate?) {
+    private func presentEditor(
+        _ snippet: TerminalCommandTemplate?,
+        preferredGroup: String? = nil
+    ) {
         if store.snippetGroups().isEmpty {
             _ = store.createSnippetGroup(
                 name: TerminalCommandHistoryStore.defaultSnippetGroupName,
                 profileID: TerminalCommandHistoryStore.globalSnippetLibraryID
             )
         }
-        editorSnippet = snippet
-        editorPresented = true
+        editorRequest = TerminalSnippetEditorRequest(
+            snippet: snippet,
+            preferredGroup: preferredGroup
+        )
     }
+
+    private func runStatus(_ summary: TerminalSnippetRunSummary) -> some View {
+        let sent = summary.targets.filter { $0.state == .sent }.count
+        let connecting = summary.targets.filter { $0.state == .connecting }.count
+        let failed = summary.targets.filter {
+            if case .failed = $0.state { return true }
+            return false
+        }.count
+
+        return HStack(spacing: 14) {
+            Image(
+                systemName: failed > 0
+                    ? "exclamationmark.triangle.fill"
+                    : (connecting > 0 ? "arrow.triangle.2.circlepath" : "checkmark.circle.fill")
+            )
+            .foregroundStyle(failed > 0 ? Color.orange : (connecting > 0 ? Color.blue : Color.green))
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Последний запуск · \(summary.title)")
+                    .font(.subheadline.weight(.semibold))
+                Text(summary.startedAt, style: .time)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            if sent > 0 {
+                Label("Отправлено: \(sent)", systemImage: "paperplane.fill")
+                    .foregroundStyle(.green)
+            }
+            if connecting > 0 {
+                Label("Подключение: \(connecting)", systemImage: "arrow.triangle.2.circlepath")
+                    .foregroundStyle(.blue)
+            }
+            if failed > 0 {
+                Label("Ошибки: \(failed)", systemImage: "xmark.octagon.fill")
+                    .foregroundStyle(.orange)
+            }
+            Button("Отключить SSH Targets") {
+                showsDisconnectConfirmation = true
+            }
+            .disabled(summary.targets.isEmpty)
+        }
+        .font(.caption)
+        .padding(.horizontal, 28)
+        .padding(.vertical, 10)
+        .background(Color.accentColor.opacity(0.07))
+    }
+
+    private func targetRunStatusRow(_ target: TerminalSnippetTargetRunStatus) -> some View {
+        let details: (text: String, icon: String, color: Color) = switch target.state {
+        case .connecting:
+            ("Подключение…", "arrow.triangle.2.circlepath", .blue)
+        case .sent:
+            ("Команда отправлена", "paperplane.fill", .green)
+        case .failed(let message):
+            ("Ошибка: \(message)", "xmark.octagon.fill", .orange)
+        }
+
+        return HStack(spacing: 8) {
+            Image(systemName: details.icon)
+                .foregroundStyle(details.color)
+            Text(target.name)
+                .lineLimit(1)
+            Spacer()
+            Text(details.text)
+                .font(.caption)
+                .foregroundStyle(details.color)
+                .lineLimit(2)
+        }
+    }
+}
+
+private struct TerminalSnippetEditorRequest: Identifiable {
+    let id = UUID()
+    let snippet: TerminalCommandTemplate?
+    let preferredGroup: String?
 }
 
 private struct TerminalSnippetDraft {
@@ -330,6 +462,7 @@ private struct TerminalSnippetDraft {
 private struct TerminalSnippetEditorView: View {
     @Environment(\.dismiss) private var dismiss
     let snippet: TerminalCommandTemplate?
+    let preferredGroup: String?
     let groups: [TerminalSnippetGroup]
     let profiles: [ConnectionProfile]
     let onSave: (TerminalSnippetDraft) -> Void
@@ -341,17 +474,24 @@ private struct TerminalSnippetEditorView: View {
 
     init(
         snippet: TerminalCommandTemplate?,
+        preferredGroup: String?,
         groups: [TerminalSnippetGroup],
         profiles: [ConnectionProfile],
         onSave: @escaping (TerminalSnippetDraft) -> Void
     ) {
         self.snippet = snippet
+        self.preferredGroup = preferredGroup
         self.groups = groups
         self.profiles = profiles
         self.onSave = onSave
         _title = State(initialValue: snippet?.title ?? "")
         _command = State(initialValue: snippet?.command ?? "")
-        _category = State(initialValue: snippet?.category ?? groups.first?.name ?? TerminalCommandHistoryStore.defaultSnippetGroupName)
+        _category = State(
+            initialValue: snippet?.category
+                ?? preferredGroup
+                ?? groups.first?.name
+                ?? TerminalCommandHistoryStore.defaultSnippetGroupName
+        )
         _targetIDs = State(initialValue: Set(snippet?.targetProfileIDs ?? profiles.first.map { [$0.id] } ?? []))
     }
 

--- a/Tests/SelectiveRemoteTests/TerminalInteractionRegressionTests.swift
+++ b/Tests/SelectiveRemoteTests/TerminalInteractionRegressionTests.swift
@@ -82,3 +82,29 @@ func terminalHistoryProgrammaticHideDoesNotRefocusOldPane() throws {
     #expect(hostScript.contains("restoreTerminalFocus = true"))
     #expect(hostScript.contains("else if (restoreTerminalFocus)"))
 }
+
+@Test("Глобальные Snippets расположены перед диагностикой и поддерживают быстрый запуск")
+func globalSnippetsHaveExpectedNavigationAndActions() throws {
+    let projectRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    let contentSource = try String(
+        contentsOf: projectRoot.appendingPathComponent("Sources/SelectiveRemote/ContentView.swift"),
+        encoding: .utf8
+    )
+    let snippetsSource = try String(
+        contentsOf: projectRoot.appendingPathComponent(
+            "Sources/SelectiveRemote/TerminalSnippetsLibraryView.swift"
+        ),
+        encoding: .utf8
+    )
+
+    let snippetsRange = try #require(contentSource.range(of: "case snippets = \"Сниппеты\""))
+    let diagnosticsRange = try #require(contentSource.range(of: "case diagnostics = \"Диагностика\""))
+    #expect(snippetsRange.lowerBound < diagnosticsRange.lowerBound)
+    #expect(snippetsSource.contains("TapGesture(count: 2)"))
+    #expect(snippetsSource.contains("Button(\"Запустить\", systemImage: \"play.fill\")"))
+    #expect(snippetsSource.contains("Последний запуск"))
+    #expect(snippetsSource.contains("sheet(item: $editorRequest)"))
+}

--- a/Tests/SelectiveRemoteTests/TerminalInteractionRegressionTests.swift
+++ b/Tests/SelectiveRemoteTests/TerminalInteractionRegressionTests.swift
@@ -76,7 +76,7 @@ func terminalHistoryProgrammaticHideDoesNotRefocusOldPane() throws {
 
     #expect(
         swiftSource.contains(
-            "selectiveTerminalSetHistoryVisible?.(\\(visible ? \"true\" : \"false\"), false, false)"
+            "selectiveTerminalSetPanelMode?.('\\(mode)', false, false)"
         )
     )
     #expect(hostScript.contains("restoreTerminalFocus = true"))

--- a/Tests/SelectiveRemoteTests/TerminalSmartWorkspaceTests.swift
+++ b/Tests/SelectiveRemoteTests/TerminalSmartWorkspaceTests.swift
@@ -251,6 +251,204 @@ func scopesFavoritesAndTemplatesToProfile() throws {
     ))
 }
 
+@Test("Группы сниппетов и команды переживают перезапуск хранилища")
+@MainActor
+func persistsSnippetGroupsAndCRUD() throws {
+    let suiteName = "TerminalSnippetPersistenceTests.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let profileID = UUID()
+
+    var store = TerminalCommandHistoryStore(defaults: defaults)
+    let docker = try #require(store.createSnippetGroup(
+        name: "Docker",
+        profileID: profileID,
+        now: Date(timeIntervalSince1970: 1)
+    ))
+    let system = try #require(store.createSnippetGroup(
+        name: "System",
+        profileID: profileID,
+        now: Date(timeIntervalSince1970: 2)
+    ))
+    #expect(store.saveTemplate(
+        id: nil,
+        title: "Show containers",
+        command: "docker ps",
+        category: docker.name,
+        profileID: profileID
+    ))
+    let snippet = try #require(store.templates(for: profileID).first)
+    #expect(store.moveTemplate(id: snippet.id, toGroupID: system.id, profileID: profileID))
+    #expect(store.renameSnippetGroup(id: system.id, name: "Host", profileID: profileID))
+    #expect(store.templates(for: profileID).first?.category == "Host")
+    #expect(store.duplicateTemplate(id: snippet.id, profileID: profileID))
+    #expect(store.templates(for: profileID).count == 2)
+
+    store = TerminalCommandHistoryStore(defaults: defaults)
+    #expect(store.snippetGroups(for: profileID).map(\.name).contains("Docker"))
+    #expect(store.snippetGroups(for: profileID).map(\.name).contains("Host"))
+    #expect(store.templates(for: profileID).count == 2)
+
+    #expect(store.removeSnippetGroup(id: system.id, profileID: profileID))
+    #expect(store.templates(for: profileID).allSatisfy {
+        $0.category == TerminalCommandHistoryStore.defaultSnippetGroupName
+    })
+    for item in store.templates(for: profileID) {
+        store.removeTemplate(id: item.id, profileID: profileID)
+    }
+    #expect(store.templates(for: profileID).isEmpty)
+}
+
+@Test("Legacy Templates становятся profile-scoped Snippets без потери данных")
+@MainActor
+func migratesLegacyTemplatesToSnippetGroups() throws {
+    let suiteName = "TerminalSnippetMigrationTests.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let firstProfile = UUID()
+    let secondProfile = UUID()
+    let firstID = UUID()
+    let secondID = UUID()
+    let legacy = [
+        TerminalCommandTemplate(
+            id: firstID,
+            profileID: firstProfile,
+            title: "Disk usage",
+            command: "df -h",
+            category: "",
+            updatedAt: Date(timeIntervalSince1970: 10)
+        ),
+        TerminalCommandTemplate(
+            id: secondID,
+            profileID: secondProfile,
+            title: "nginx errors",
+            command: "tail -n 100 /var/log/nginx/error.log",
+            category: "Logs",
+            updatedAt: Date(timeIntervalSince1970: 20)
+        )
+    ]
+    defaults.set(
+        try JSONEncoder().encode(legacy),
+        forKey: "SelectiveRemote.terminal.commandTemplates.v1"
+    )
+
+    var store = TerminalCommandHistoryStore(defaults: defaults)
+    let migrated = try #require(store.template(id: firstID, profileID: firstProfile))
+    #expect(migrated.title == "Disk usage")
+    #expect(migrated.command == "df -h")
+    #expect(migrated.profileID == firstProfile)
+    #expect(migrated.category == TerminalCommandHistoryStore.defaultSnippetGroupName)
+    #expect(store.snippetGroups(for: firstProfile).map(\.name) == [
+        TerminalCommandHistoryStore.defaultSnippetGroupName
+    ])
+    #expect(store.snippetGroups(for: secondProfile).map(\.name) == ["Logs"])
+    #expect(store.templates(for: firstProfile).count == 1)
+    #expect(store.templates(for: secondProfile).count == 1)
+
+    // Migration is idempotent and persists the normalized legacy value.
+    store = TerminalCommandHistoryStore(defaults: defaults)
+    #expect(store.snippetGroups(for: firstProfile).count == 1)
+    #expect(store.template(id: firstID, profileID: firstProfile)?.category
+        == TerminalCommandHistoryStore.defaultSnippetGroupName)
+}
+
+@Test("Группы сниппетов валидируются и изолированы по SSH-профилям")
+@MainActor
+func validatesAndScopesSnippetGroups() throws {
+    let suiteName = "TerminalSnippetGroupScopeTests.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let store = TerminalCommandHistoryStore(defaults: defaults)
+    let first = UUID()
+    let second = UUID()
+
+    #expect(store.createSnippetGroup(name: "", profileID: first) == nil)
+    #expect(store.createSnippetGroup(name: String(repeating: "x", count: 61), profileID: first) == nil)
+    #expect(store.createSnippetGroup(name: "Docker", profileID: first) != nil)
+    #expect(store.createSnippetGroup(name: "docker", profileID: first) == nil)
+    #expect(store.createSnippetGroup(name: "Docker", profileID: second) != nil)
+    #expect(store.snippetGroups(for: first).count == 1)
+    #expect(store.snippetGroups(for: second).count == 1)
+    #expect(!store.saveTemplate(
+        id: nil,
+        title: "",
+        command: "whoami",
+        category: "Docker",
+        profileID: first
+    ))
+    #expect(!store.saveTemplate(
+        id: nil,
+        title: "Secret",
+        command: "export token=abc",
+        category: "Docker",
+        profileID: first
+    ))
+}
+
+@Test("Web payload содержит Snippets и стабильные идентификаторы групп")
+@MainActor
+func serializesSnippetGroupsForTerminalBridge() throws {
+    let suiteName = "TerminalSnippetPayloadTests.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let store = TerminalCommandHistoryStore(defaults: defaults)
+    let profileID = UUID()
+    let group = try #require(store.createSnippetGroup(name: "Docker", profileID: profileID))
+    #expect(store.saveTemplate(
+        id: nil,
+        title: "Containers",
+        command: "docker ps",
+        category: group.name,
+        profileID: profileID
+    ))
+
+    let json = try #require(store.webPayload(for: profileID))
+    let data = try #require(json.data(using: .utf8))
+    let payload = try #require(
+        JSONSerialization.jsonObject(with: data) as? [String: Any]
+    )
+    let groups = try #require(payload["snippetGroups"] as? [[String: Any]])
+    let templates = try #require(payload["templates"] as? [[String: Any]])
+    #expect(groups.first?["id"] as? String == group.id.uuidString)
+    #expect(groups.first?["name"] as? String == "Docker")
+    #expect(templates.first?["title"] as? String == "Containers")
+    #expect(templates.first?["command"] as? String == "docker ps")
+    #expect(templates.first?["category"] as? String == "Docker")
+}
+
+@Test("Snippet выполняется только в выбранной активной Terminal session")
+func routesSnippetOnlyToActiveRunningSession() {
+    let active = UUID()
+    let background = UUID()
+
+    #expect(TerminalSnippetExecution.canRun(
+        originTabID: active,
+        selectedTabID: active,
+        sessionIsRunning: true
+    ))
+    #expect(!TerminalSnippetExecution.canRun(
+        originTabID: background,
+        selectedTabID: active,
+        sessionIsRunning: true
+    ))
+    #expect(!TerminalSnippetExecution.canRun(
+        originTabID: active,
+        selectedTabID: active,
+        sessionIsRunning: false
+    ))
+}
+
+@Test("Multi-line Snippet сохраняет строки и получает ровно один завершающий Enter")
+func preparesMultilineSnippetPTYInput() throws {
+    let script = "cd /var/www\ngit pull\nsystemctl restart nginx\n\n"
+    let data = try #require(TerminalSnippetExecution.inputData(for: script))
+    let value = try #require(String(data: data, encoding: .utf8))
+
+    #expect(value == "cd /var/www\ngit pull\nsystemctl restart nginx\n")
+    #expect(TerminalSnippetExecution.inputData(for: "\n\n") == nil)
+    #expect(TerminalSnippetExecution.inputData(for: "echo ok\0") == nil)
+}
+
 @Test("Контекст сервера создаёт подсказки для служб и контейнеров")
 func buildsRemoteServiceAndContainerSuggestions() throws {
     var profile = ConnectionProfile()

--- a/Tests/SelectiveRemoteTests/TerminalSmartWorkspaceTests.swift
+++ b/Tests/SelectiveRemoteTests/TerminalSmartWorkspaceTests.swift
@@ -419,19 +419,32 @@ func serializesSnippetGroupsForTerminalBridge() throws {
         targetProfileIDs: [profileID, UUID()]
     ))
 
-    let json = try #require(store.webPayload(for: profileID))
+    let target = TerminalSnippetTargetOption(
+        id: profileID,
+        title: "Production",
+        subtitle: "server.example.com"
+    )
+    let json = try #require(store.webPayload(
+        for: profileID,
+        snippetTargets: [target]
+    ))
     let data = try #require(json.data(using: .utf8))
     let payload = try #require(
         JSONSerialization.jsonObject(with: data) as? [String: Any]
     )
     let groups = try #require(payload["snippetGroups"] as? [[String: Any]])
     let templates = try #require(payload["templates"] as? [[String: Any]])
+    let targets = try #require(payload["snippetTargets"] as? [[String: Any]])
     #expect(groups.first?["id"] as? String == group.id.uuidString)
     #expect(groups.first?["name"] as? String == "Docker")
     #expect(templates.first?["title"] as? String == "Containers")
     #expect(templates.first?["command"] as? String == "docker ps")
     #expect(templates.first?["category"] as? String == "Docker")
     #expect((templates.first?["targetProfileIDs"] as? [String])?.count == 2)
+    #expect(payload["defaultSnippetTargetID"] as? String == profileID.uuidString)
+    #expect(targets.first?["id"] as? String == profileID.uuidString)
+    #expect(targets.first?["title"] as? String == "Production")
+    #expect(targets.first?["subtitle"] as? String == "server.example.com")
 }
 
 @Test("Multi-line Snippet сохраняет строки и получает ровно один завершающий Enter")

--- a/Tests/SelectiveRemoteTests/TerminalSmartWorkspaceTests.swift
+++ b/Tests/SelectiveRemoteTests/TerminalSmartWorkspaceTests.swift
@@ -219,9 +219,9 @@ func persistsIndependentForwardingTarget() throws {
     #expect(restored.connection.port == 2222)
 }
 
-@Test("Избранное и шаблоны команд изолированы по SSH-профилям")
+@Test("Избранное остаётся profile-scoped, а Snippets образуют общую библиотеку Targets")
 @MainActor
-func scopesFavoritesAndTemplatesToProfile() throws {
+func exposesGlobalSnippetsWithMultipleTargets() throws {
     let suiteName = "TerminalCommandLibraryTests.\(UUID().uuidString)"
     let defaults = try #require(UserDefaults(suiteName: suiteName))
     defer { defaults.removePersistentDomain(forName: suiteName) }
@@ -235,13 +235,15 @@ func scopesFavoritesAndTemplatesToProfile() throws {
         title: "Перезапустить службу",
         command: "sudo systemctl restart ${service}",
         category: "Службы",
-        profileID: first
+        profileID: first,
+        targetProfileIDs: [first, second]
     ))
 
     #expect(store.favorites(for: first).map(\.command) == ["systemctl status ssh"])
     #expect(store.templates(for: first).count == 1)
     #expect(store.favorites(for: second).isEmpty)
-    #expect(store.templates(for: second).isEmpty)
+    #expect(store.templates(for: second).count == 1)
+    #expect(store.templates().first?.targetProfileIDs == [first, second])
     #expect(!store.saveTemplate(
         id: nil,
         title: "Секрет",
@@ -277,29 +279,31 @@ func persistsSnippetGroupsAndCRUD() throws {
         category: docker.name,
         profileID: profileID
     ))
-    let snippet = try #require(store.templates(for: profileID).first)
+    let snippet = try #require(store.templates().first)
     #expect(store.moveTemplate(id: snippet.id, toGroupID: system.id, profileID: profileID))
     #expect(store.renameSnippetGroup(id: system.id, name: "Host", profileID: profileID))
-    #expect(store.templates(for: profileID).first?.category == "Host")
+    #expect(store.templates().first?.category == "Host")
     #expect(store.duplicateTemplate(id: snippet.id, profileID: profileID))
-    #expect(store.templates(for: profileID).count == 2)
+    #expect(store.templates().count == 2)
 
     store = TerminalCommandHistoryStore(defaults: defaults)
-    #expect(store.snippetGroups(for: profileID).map(\.name).contains("Docker"))
-    #expect(store.snippetGroups(for: profileID).map(\.name).contains("Host"))
-    #expect(store.templates(for: profileID).count == 2)
+    #expect(store.snippetGroups().map(\.name).contains("Docker"))
+    #expect(store.snippetGroups().map(\.name).contains("Host"))
+    #expect(store.templates().count == 2)
 
     #expect(store.removeSnippetGroup(id: system.id, profileID: profileID))
-    #expect(store.templates(for: profileID).allSatisfy {
+    #expect(store.templates().allSatisfy {
         $0.category == TerminalCommandHistoryStore.defaultSnippetGroupName
     })
-    for item in store.templates(for: profileID) {
-        store.removeTemplate(id: item.id, profileID: profileID)
+    for item in store.templates() {
+        #expect(store.removeTemplate(id: item.id))
     }
-    #expect(store.templates(for: profileID).isEmpty)
+    #expect(store.templates().isEmpty)
+    store = TerminalCommandHistoryStore(defaults: defaults)
+    #expect(store.templates().isEmpty)
 }
 
-@Test("Legacy Templates становятся profile-scoped Snippets без потери данных")
+@Test("Legacy Templates становятся глобальными Snippets с исходным профилем как Target")
 @MainActor
 func migratesLegacyTemplatesToSnippetGroups() throws {
     let suiteName = "TerminalSnippetMigrationTests.\(UUID().uuidString)"
@@ -337,24 +341,25 @@ func migratesLegacyTemplatesToSnippetGroups() throws {
     #expect(migrated.title == "Disk usage")
     #expect(migrated.command == "df -h")
     #expect(migrated.profileID == firstProfile)
+    #expect(migrated.targetProfileIDs == [firstProfile])
     #expect(migrated.category == TerminalCommandHistoryStore.defaultSnippetGroupName)
-    #expect(store.snippetGroups(for: firstProfile).map(\.name) == [
-        TerminalCommandHistoryStore.defaultSnippetGroupName
-    ])
-    #expect(store.snippetGroups(for: secondProfile).map(\.name) == ["Logs"])
-    #expect(store.templates(for: firstProfile).count == 1)
-    #expect(store.templates(for: secondProfile).count == 1)
+    #expect(Set(store.snippetGroups().map(\.name)) == Set([
+        TerminalCommandHistoryStore.defaultSnippetGroupName, "Logs"
+    ]))
+    #expect(store.templates(for: firstProfile).count == 2)
+    #expect(store.templates(for: secondProfile).count == 2)
+    #expect(store.template(id: secondID)?.targetProfileIDs == [secondProfile])
 
     // Migration is idempotent and persists the normalized legacy value.
     store = TerminalCommandHistoryStore(defaults: defaults)
-    #expect(store.snippetGroups(for: firstProfile).count == 1)
+    #expect(store.snippetGroups().count == 2)
     #expect(store.template(id: firstID, profileID: firstProfile)?.category
         == TerminalCommandHistoryStore.defaultSnippetGroupName)
 }
 
-@Test("Группы сниппетов валидируются и изолированы по SSH-профилям")
+@Test("Группы Snippets глобальны, а Targets дедуплицируются и ограничены восемью")
 @MainActor
-func validatesAndScopesSnippetGroups() throws {
+func validatesGlobalSnippetGroupsAndTargets() throws {
     let suiteName = "TerminalSnippetGroupScopeTests.\(UUID().uuidString)"
     let defaults = try #require(UserDefaults(suiteName: suiteName))
     defer { defaults.removePersistentDomain(forName: suiteName) }
@@ -366,9 +371,20 @@ func validatesAndScopesSnippetGroups() throws {
     #expect(store.createSnippetGroup(name: String(repeating: "x", count: 61), profileID: first) == nil)
     #expect(store.createSnippetGroup(name: "Docker", profileID: first) != nil)
     #expect(store.createSnippetGroup(name: "docker", profileID: first) == nil)
-    #expect(store.createSnippetGroup(name: "Docker", profileID: second) != nil)
+    #expect(store.createSnippetGroup(name: "Docker", profileID: second) == nil)
     #expect(store.snippetGroups(for: first).count == 1)
     #expect(store.snippetGroups(for: second).count == 1)
+    let extraTargets = (0..<10).map { _ in UUID() }
+    #expect(store.saveTemplate(
+        id: nil,
+        title: "Targets",
+        command: "hostname",
+        category: "Docker",
+        profileID: first,
+        targetProfileIDs: [first, second, first] + extraTargets
+    ))
+    #expect(store.templates().first?.targetProfileIDs.count == 8)
+    #expect(Array(store.templates().first?.targetProfileIDs.prefix(2) ?? []) == [first, second])
     #expect(!store.saveTemplate(
         id: nil,
         title: "",
@@ -399,7 +415,8 @@ func serializesSnippetGroupsForTerminalBridge() throws {
         title: "Containers",
         command: "docker ps",
         category: group.name,
-        profileID: profileID
+        profileID: profileID,
+        targetProfileIDs: [profileID, UUID()]
     ))
 
     let json = try #require(store.webPayload(for: profileID))
@@ -414,28 +431,7 @@ func serializesSnippetGroupsForTerminalBridge() throws {
     #expect(templates.first?["title"] as? String == "Containers")
     #expect(templates.first?["command"] as? String == "docker ps")
     #expect(templates.first?["category"] as? String == "Docker")
-}
-
-@Test("Snippet выполняется только в выбранной активной Terminal session")
-func routesSnippetOnlyToActiveRunningSession() {
-    let active = UUID()
-    let background = UUID()
-
-    #expect(TerminalSnippetExecution.canRun(
-        originTabID: active,
-        selectedTabID: active,
-        sessionIsRunning: true
-    ))
-    #expect(!TerminalSnippetExecution.canRun(
-        originTabID: background,
-        selectedTabID: active,
-        sessionIsRunning: true
-    ))
-    #expect(!TerminalSnippetExecution.canRun(
-        originTabID: active,
-        selectedTabID: active,
-        sessionIsRunning: false
-    ))
+    #expect((templates.first?["targetProfileIDs"] as? [String])?.count == 2)
 }
 
 @Test("Multi-line Snippet сохраняет строки и получает ровно один завершающий Enter")

--- a/Tests/SelectiveRemoteTests/TerminalTests.swift
+++ b/Tests/SelectiveRemoteTests/TerminalTests.swift
@@ -207,6 +207,10 @@ func terminalIncludesHistoryInterface() throws {
         contentsOf: resources.appendingPathComponent("terminal-command-catalog.js"),
         encoding: .utf8
     )
+    let snippetInteractions = try String(
+        contentsOf: resources.appendingPathComponent("terminal-snippet-interactions.js"),
+        encoding: .utf8
+    )
 
     #expect(html.contains("id=\"terminal-suggestions\""))
     #expect(html.contains("id=\"terminal-history\""))
@@ -214,8 +218,10 @@ func terminalIncludesHistoryInterface() throws {
     #expect(html.contains("data-section=\"catalog\""))
     #expect(html.contains("data-section=\"remote\""))
     #expect(html.contains("data-section=\"favorites\""))
-    #expect(html.contains("data-section=\"templates\""))
-    #expect(html.contains("id=\"template-dialog\""))
+    #expect(html.contains("id=\"snippets-list\""))
+    #expect(html.contains("id=\"snippet-dialog\""))
+    #expect(html.contains("id=\"snippet-group-dialog\""))
+    #expect(html.contains("id=\"snippet-context-menu\""))
     #expect(html.contains("id=\"remote-context-retry\""))
     #expect(html.contains("terminal-command-catalog.js"))
     #expect(script.contains("selectiveTerminalSetHistory"))
@@ -229,6 +235,12 @@ func terminalIncludesHistoryInterface() throws {
     #expect(script.contains("fuzzyTokenMatch"))
     #expect(script.contains("toggleFavorite"))
     #expect(script.contains("resolveTemplate"))
+    #expect(script.contains("selectiveTerminalSetPanelMode"))
+    #expect(script.contains("runSnippet"))
+    #expect(script.contains("panelVisibility"))
+    #expect(snippetInteractions.contains("eventType === \"click\""))
+    #expect(snippetInteractions.contains("eventType === \"dblclick\""))
+    #expect(snippetInteractions.contains("eventType === \"enter\""))
     #expect(catalog.contains("sudo systemctl restart "))
     #expect(catalog.contains("nano /etc/ssh/sshd_config"))
     #expect(catalog.contains("nano ~/.ssh/authorized_keys"))

--- a/Tests/TerminalResourcesTests/terminal-snippet-global.test.js
+++ b/Tests/TerminalResourcesTests/terminal-snippet-global.test.js
@@ -17,6 +17,20 @@ test("terminal Snippets panel describes the shared Targets library", () => {
     assert.match(hostScript, /Connecting SSH targets/);
 });
 
+test("terminal snippet editor renders and submits assigned SSH targets", () => {
+    assert.match(hostScript, /const renderSnippetTargets = \(selectedIDs = \[\]\)/);
+    assert.match(hostScript, /snippetTargetOptions = Array\.isArray\(payload\.snippetTargets\)/);
+    assert.match(hostScript, /const targetProfileIDs = selectedSnippetTargetIDs\(\)/);
+    assert.match(hostScript, /command: snippetCommand\.value,\s*targetProfileIDs/);
+});
+
+test("empty groups and snippet context menu can create in the current group", () => {
+    assert.match(hostScript, /className = "snippet-empty-group-add"/);
+    assert.match(hostScript, /openSnippetEditor\(null, group\.name\)/);
+    assert.match(hostScript, /action === "new"/);
+    assert.match(hostScript, /openSnippetEditor\(null, entry\.category\)/);
+});
+
 test("snippet deletion posts the command without an unsupported WKWebView confirm", () => {
     assert.match(
         hostScript,

--- a/Tests/TerminalResourcesTests/terminal-snippet-global.test.js
+++ b/Tests/TerminalResourcesTests/terminal-snippet-global.test.js
@@ -1,0 +1,29 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const hostScript = fs.readFileSync(
+    path.join(
+        __dirname,
+        "../../Sources/SelectiveRemote/TerminalResources/terminal-host.js"
+    ),
+    "utf8"
+);
+
+test("terminal Snippets panel describes the shared Targets library", () => {
+    assert.match(hostScript, /Общая библиотека · запуск по Targets/);
+    assert.match(hostScript, /targetProfileIDs/);
+    assert.match(hostScript, /Connecting SSH targets/);
+});
+
+test("snippet deletion posts the command without an unsupported WKWebView confirm", () => {
+    assert.match(
+        hostScript,
+        /action === "remove"\) \{\s*postHistory\(\{ action: "removeSnippet", id: entry\.id \}\)/
+    );
+    assert.doesNotMatch(
+        hostScript,
+        /window\.confirm\(snippetText\("deleteSnippetConfirm"\)/
+    );
+});

--- a/Tests/TerminalResourcesTests/terminal-snippet-interactions.test.js
+++ b/Tests/TerminalResourcesTests/terminal-snippet-interactions.test.js
@@ -1,0 +1,38 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const interactions = require(
+    "../../Sources/SelectiveRemote/TerminalResources/terminal-snippet-interactions.js"
+);
+
+test("single click selects without running", () => {
+    assert.equal(interactions.decision({
+        eventType: "click",
+        targetKind: "snippet"
+    }), "select");
+});
+
+test("double click produces exactly one run decision", () => {
+    const browserEvents = ["click", "click", "dblclick"];
+    const decisions = browserEvents.map((eventType) => interactions.decision({
+        eventType,
+        targetKind: "snippet"
+    }));
+    assert.deepEqual(decisions, ["select", "select", "run"]);
+    assert.equal(decisions.filter((value) => value === "run").length, 1);
+});
+
+test("Enter runs a selected snippet but not a group or editor", () => {
+    assert.equal(interactions.decision({
+        eventType: "enter",
+        targetKind: "snippet"
+    }), "run");
+    assert.equal(interactions.decision({
+        eventType: "enter",
+        targetKind: "group"
+    }), "none");
+    assert.equal(interactions.decision({
+        eventType: "enter",
+        targetKind: "snippet",
+        editorActive: true
+    }), "none");
+});


### PR DESCRIPTION
## Summary

- add a separate global Snippets library in the main navigation
- migrate existing profile-scoped Terminal Templates without deleting legacy data; each source profile becomes the migrated snippet's first Target
- let one snippet target up to eight saved SSH profiles
- keep the Snippets quick panel shared and synchronized across all Terminal workspaces
- run snippets on all assigned Targets, reuse an already connected matching session, or start the saved SSH session and queue the command until the remote shell is ready
- preserve multiline scripts, parameter resolution in the terminal panel, sensitive-command validation, search, groups, duplicate, move, and empty states
- fix snippet/group deletion in WKWebView by removing the unsupported `window.confirm` dependency; the global library uses a native destructive confirmation
- add persistence, global migration, Targets, deletion, bridge, and DOM interaction regressions

Closes #9

## Scope

- global Terminal/SSH Snippets and saved SSH Targets
- no SFTP feature changes
- no RDP changes
- no sharing/cloud sync/packages/team vault features
- no production release, tag, or version bump

## Validation

- [x] Node interaction and deletion tests pass locally (5/5)
- [x] JavaScript syntax and diff checks pass locally
- [x] Swift tests, web tests, and release build on macOS/Xcode CI for exact PR HEAD `f959d6c2970407443582a279da67333fe9f041d4`
- [x] GitHub-built ARM64 test DMG from the same exact PR HEAD
- [ ] Manual acceptance of the new GitHub-built DMG

CI: https://github.com/PastFly/Selective-Remote/actions/runs/32345752372

Test DMG run: https://github.com/PastFly/Selective-Remote/actions/runs/32345752348

Artifact: `SelectiveRemote-snippets-test-10-f959d6c2970407443582a279da67333fe9f041d4` (ID `9398089565`, SHA-256 digest `829a8ffbd617bb3e5b86bfa9e4e0508539a1678c8a2862a87bc03d22a3e0de2d`)

The previous `dd26af7` artifact predates the global-library/Targets revision and is obsolete. The temporary exact-HEAD test-DMG workflow remains until manual acceptance.