### PR TITLE
v0.30.0: protected reveal for saved host passwords

### DIFF
--- a/Sources/SelectiveRemote/AdaptiveWorkspaceLayout.swift
+++ b/Sources/SelectiveRemote/AdaptiveWorkspaceLayout.swift
@@ -1,0 +1,24 @@
+import CoreGraphics
+
+enum AdaptiveWorkspaceLayout {
+    static let singleColumnProfileWidth: CGFloat = 900
+    static let stackedSFTPPanesWidth: CGFloat = 1_100
+    static let detailNavigationWidth: CGFloat = 1_180
+    static let profileInspectorWidth: CGFloat = 1_120
+
+    static func usesSingleColumnProfileEditor(width: CGFloat) -> Bool {
+        width < singleColumnProfileWidth
+    }
+
+    static func usesStackedSFTPPanes(width: CGFloat) -> Bool {
+        width < stackedSFTPPanesWidth
+    }
+
+    static func usesDetailNavigation(width: CGFloat) -> Bool {
+        width < detailNavigationWidth
+    }
+
+    static func showsProfileInspector(width: CGFloat) -> Bool {
+        width >= profileInspectorWidth
+    }
+}

--- a/Sources/SelectiveRemote/AppModel.swift
+++ b/Sources/SelectiveRemote/AppModel.swift
@@ -2225,6 +2225,40 @@ final class AppModel: NSObject, ObservableObject {
         deleteCredential(kind: .gateway)
     }
 
+    @MainActor
+    func revealSelectedCredential(kind: KeychainCredentialKind) async -> String? {
+        let profileID = selectedProfile.id
+        let profileName = selectedProfile.friendlyName
+        do {
+            let value = try await KeychainService.revealPassword(
+                profileID: profileID,
+                kind: kind,
+                reason: UpdateLocalization.text(
+                    ru: "Показать сохранённый пароль для «\(profileName)»",
+                    en: "Reveal the saved password for “\(profileName)”"
+                )
+            )
+            guard selectedProfile.id == profileID else { return nil }
+            guard let value, !value.isEmpty else {
+                errorMessage = UpdateLocalization.text(
+                    ru: "Сохранённый пароль не найден в Keychain.",
+                    en: "The saved password was not found in Keychain."
+                )
+                return nil
+            }
+            statusMessage = UpdateLocalization.text(
+                ru: "Пароль показан на 30 секунд",
+                en: "Password revealed for 30 seconds"
+            )
+            errorMessage = nil
+            return value
+        } catch {
+            guard selectedProfile.id == profileID else { return nil }
+            errorMessage = error.localizedDescription
+            return nil
+        }
+    }
+
     func saveSSHPassword() {
         saveCredential(
             sshPassword,

--- a/Sources/SelectiveRemote/ConnectionCenter.swift
+++ b/Sources/SelectiveRemote/ConnectionCenter.swift
@@ -343,28 +343,47 @@ struct ConnectionCenterView: View {
             let snapshot = model.connectionCenterSnapshot(now: timeline.date)
             let items = sortedItems(filteredItems(snapshot.items))
 
-            HStack(spacing: 0) {
-                VStack(alignment: .leading, spacing: 16) {
-                    header(snapshot: snapshot)
-                    summary(snapshot: snapshot)
-                    toolbar
-                    connectionTable(items: items, now: timeline.date)
-                    footer(items: items)
+            GeometryReader { proxy in
+                let compact = proxy.size.width < 900
+                if compact {
+                    VSplitView {
+                        centerContent(
+                            snapshot: snapshot,
+                            items: items,
+                            now: timeline.date,
+                            compact: true
+                        )
+                        .frame(minHeight: 360)
+
+                        inspector(
+                            item: selectedItem(from: items),
+                            now: timeline.date
+                        )
+                        .frame(minHeight: 220, idealHeight: 300)
+                        .id(selectedItemID)
+                    }
+                } else {
+                    HStack(spacing: 0) {
+                        centerContent(
+                            snapshot: snapshot,
+                            items: items,
+                            now: timeline.date,
+                            compact: false
+                        )
+
+                        Divider()
+
+                        inspector(
+                            item: selectedItem(from: items),
+                            now: timeline.date
+                        )
+                        .frame(minWidth: 300, idealWidth: 330, maxWidth: 360)
+                        .id(selectedItemID)
+                    }
                 }
-                .padding(24)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-
-                Divider()
-
-                inspector(
-                    item: selectedItem(from: items),
-                    now: timeline.date
-                )
-                .frame(width: 340)
-                .id(selectedItemID)
-                .transition(.opacity)
-                .animation(reduceMotion ? nil : .easeInOut(duration: 0.18), value: selectedItemID)
             }
+            .transition(.opacity)
+            .animation(reduceMotion ? nil : .easeInOut(duration: 0.18), value: selectedItemID)
             .onAppear {
                 normalizeSelection(items: items)
             }
@@ -389,6 +408,34 @@ struct ConnectionCenterView: View {
         }
     }
 
+    private func centerContent(
+        snapshot: ConnectionCenterSnapshot,
+        items: [ConnectionCenterItem],
+        now: Date,
+        compact: Bool
+    ) -> some View {
+        VStack(alignment: .leading, spacing: compact ? 12 : 16) {
+            header(snapshot: snapshot)
+            summary(snapshot: snapshot, compact: compact)
+            if compact {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    toolbar
+                        .frame(minWidth: 720)
+                }
+            } else {
+                toolbar
+            }
+            if compact {
+                compactConnectionList(items: items, now: now)
+            } else {
+                connectionTable(items: items, now: now)
+            }
+            footer(items: items)
+        }
+        .padding(compact ? 16 : 24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
     private func header(snapshot: ConnectionCenterSnapshot) -> some View {
         HStack(alignment: .center, spacing: 12) {
             VStack(alignment: .leading, spacing: 4) {
@@ -396,6 +443,8 @@ struct ConnectionCenterView: View {
                     .font(.system(size: 30, weight: .bold, design: .rounded))
                 Text("Единое состояние активных RDP, SSH, SFTP и Forwarding-подключений")
                     .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             Spacer()
             Button(action: onRefresh) {
@@ -405,9 +454,9 @@ struct ConnectionCenterView: View {
         }
     }
 
-    private func summary(snapshot: ConnectionCenterSnapshot) -> some View {
+    private func summary(snapshot: ConnectionCenterSnapshot, compact: Bool) -> some View {
         LazyVGrid(
-            columns: [GridItem(.adaptive(minimum: 150), spacing: 12)],
+            columns: [GridItem(.adaptive(minimum: compact ? 120 : 150), spacing: 12)],
             alignment: .leading,
             spacing: 12
         ) {
@@ -604,6 +653,61 @@ struct ConnectionCenterView: View {
                     columnCustomization = TableColumnCustomization<ConnectionCenterItem>()
                 }
             }
+        }
+    }
+
+    private func compactConnectionList(
+        items: [ConnectionCenterItem],
+        now: Date
+    ) -> some View {
+        List(items, selection: $selectedItemID) { item in
+            HStack(spacing: 10) {
+                Image(systemName: item.kind.systemImage)
+                    .foregroundStyle(kindColor(item.kind))
+                    .frame(width: 20)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(item.profileName)
+                        .font(.subheadline.weight(.semibold))
+                        .lineLimit(1)
+                    Text(item.userHost)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 8)
+
+                VStack(alignment: .trailing, spacing: 3) {
+                    HStack(spacing: 5) {
+                        Circle()
+                            .fill(item.state.color)
+                            .frame(width: 7, height: 7)
+                        Text(LocalizedStringKey(item.state.title))
+                            .font(.caption)
+                    }
+                    Text(item.uptimeText(now: now))
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.vertical, 4)
+            .contentShape(Rectangle())
+            .tag(item.id)
+            .onTapGesture {
+                selectedItemID = item.id
+            }
+            .contextMenu {
+                connectionContextMenu(item)
+            }
+        }
+        .listStyle(.inset)
+        .frame(minHeight: 220)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .strokeBorder(Color.primary.opacity(0.07))
+                .allowsHitTesting(false)
         }
     }
 

--- a/Sources/SelectiveRemote/ConnectionCenter.swift
+++ b/Sources/SelectiveRemote/ConnectionCenter.swift
@@ -334,6 +334,7 @@ struct ConnectionCenterView: View {
     @State private var filter = ConnectionCenterPreferences.restoredTypeFilter()
     @State private var stateFilter = ConnectionCenterPreferences.restoredStateFilter()
     @State private var searchText = ""
+    @State private var compactDetailPresented = false
     @State private var sortOrder = ConnectionCenterPreferences.restoredSortOrder()
     @SceneStorage("SelectiveRemote.connectionCenter.columns.v1")
     private var columnCustomization: TableColumnCustomization<ConnectionCenterItem>
@@ -344,23 +345,23 @@ struct ConnectionCenterView: View {
             let items = sortedItems(filteredItems(snapshot.items))
 
             GeometryReader { proxy in
-                let compact = proxy.size.width < 900
+                let compact = AdaptiveWorkspaceLayout.usesDetailNavigation(
+                    width: proxy.size.width
+                )
                 if compact {
-                    VSplitView {
+                    if compactDetailPresented {
+                        compactInspector(
+                            item: selectedItem(from: items),
+                            now: timeline.date
+                        )
+                        .id(selectedItemID)
+                    } else {
                         centerContent(
                             snapshot: snapshot,
                             items: items,
                             now: timeline.date,
                             compact: true
                         )
-                        .frame(minHeight: 360)
-
-                        inspector(
-                            item: selectedItem(from: items),
-                            now: timeline.date
-                        )
-                        .frame(minHeight: 220, idealHeight: 300)
-                        .id(selectedItemID)
                     }
                 } else {
                     HStack(spacing: 0) {
@@ -406,6 +407,27 @@ struct ConnectionCenterView: View {
                 ConnectionCenterPreferences.persistSortOrder(sortOrder)
             }
         }
+    }
+
+    private func compactInspector(
+        item: ConnectionCenterItem?,
+        now: Date
+    ) -> some View {
+        VStack(spacing: 0) {
+            HStack {
+                Button("Назад к подключениям", systemImage: "chevron.left") {
+                    compactDetailPresented = false
+                }
+                .buttonStyle(.bordered)
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+
+            Divider()
+            inspector(item: item, now: now)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private func centerContent(
@@ -696,6 +718,7 @@ struct ConnectionCenterView: View {
             .tag(item.id)
             .onTapGesture {
                 selectedItemID = item.id
+                compactDetailPresented = true
             }
             .contextMenu {
                 connectionContextMenu(item)

--- a/Sources/SelectiveRemote/ContentView.swift
+++ b/Sources/SelectiveRemote/ContentView.swift
@@ -2561,6 +2561,7 @@ struct ContentView: View {
                             Text("Пароль")
                             credentialEditor(
                                 value: $model.gatewayPassword,
+                                kind: .gateway,
                                 hasSavedValue: model.selectedProfileHasSavedGatewayPassword,
                                 placeholder: "Отдельный пароль RD Gateway",
                                 savedText: "Пароль RD Gateway сохранён отдельно в Keychain",
@@ -2645,6 +2646,7 @@ struct ContentView: View {
                 Text(UpdateLocalization.text(ru: "Пароль", en: "Password"))
                 credentialEditor(
                     value: $model.password,
+                    kind: .rdp,
                     hasSavedValue: model.selectedProfileHasSavedPassword,
                     placeholder: "Введите пароль RDP",
                     savedText: "RDP-пароль сохранён в Keychain",
@@ -2877,13 +2879,14 @@ struct ContentView: View {
                             }
                         }
                         HStack(spacing: 8) {
-                            SecureField(
-                                model.selectedProfileHasSavedSSHPassword
-                                    ? "Сохранён — введите новый для замены"
-                                    : "Пароль SSH-сервера",
-                                text: $model.sshPassword
+                            CredentialDisclosureField(
+                                draftValue: $model.sshPassword,
+                                hasSavedValue: model.selectedProfileHasSavedSSHPassword,
+                                placeholder: "Пароль SSH-сервера",
+                                savedPlaceholder: "Сохранён — введите новый для замены",
+                                identity: "\(profile.id.uuidString):ssh",
+                                reveal: { await model.revealSelectedCredential(kind: .ssh) }
                             )
-                            .textFieldStyle(.roundedBorder)
                             Button("Сохранить") { model.saveSSHPassword() }
                                 .buttonStyle(.borderedProminent)
                                 .disabled(model.sshPassword.isEmpty)
@@ -3114,13 +3117,14 @@ struct ContentView: View {
                     TextField("Имя пользователя прокси (необязательно)", text: profileBinding.sshProxyUsername)
                         .textFieldStyle(.roundedBorder)
                     HStack(spacing: 10) {
-                        SecureField(
-                            model.selectedProfileHasSavedProxyPassword
-                                ? "Сохранён в Keychain — введите новый для замены"
-                                : "Пароль прокси (необязательно)",
-                            text: $model.proxyPassword
+                        CredentialDisclosureField(
+                            draftValue: $model.proxyPassword,
+                            hasSavedValue: model.selectedProfileHasSavedProxyPassword,
+                            placeholder: "Пароль прокси (необязательно)",
+                            savedPlaceholder: "Сохранён в Keychain — введите новый для замены",
+                            identity: "\(profile.id.uuidString):proxy",
+                            reveal: { await model.revealSelectedCredential(kind: .proxy) }
                         )
-                        .textFieldStyle(.roundedBorder)
                         Button("Сохранить") { model.saveProxyPassword() }
                             .disabled(model.proxyPassword.isEmpty)
                         if model.selectedProfileHasSavedProxyPassword {
@@ -3208,6 +3212,7 @@ struct ContentView: View {
 
     private func credentialEditor(
         value: Binding<String>,
+        kind: KeychainCredentialKind,
         hasSavedValue: Bool,
         placeholder: String,
         savedText: String,
@@ -3216,11 +3221,14 @@ struct ContentView: View {
     ) -> some View {
         VStack(alignment: .leading, spacing: 5) {
             HStack {
-                SecureField(
-                    hasSavedValue ? "Пустое поле использует сохранённый пароль" : placeholder,
-                    text: value
+                CredentialDisclosureField(
+                    draftValue: value,
+                    hasSavedValue: hasSavedValue,
+                    placeholder: placeholder,
+                    savedPlaceholder: "Пустое поле использует сохранённый пароль",
+                    identity: "\(profile.id.uuidString):\(kind.rawValue)",
+                    reveal: { await model.revealSelectedCredential(kind: kind) }
                 )
-                .textFieldStyle(.roundedBorder)
                 Button("Сохранить", action: onSave)
                     .disabled(value.wrappedValue.isEmpty)
                 Button("Удалить", role: .destructive, action: onDelete)

--- a/Sources/SelectiveRemote/ContentView.swift
+++ b/Sources/SelectiveRemote/ContentView.swift
@@ -955,27 +955,45 @@ struct ContentView: View {
                     VStack(alignment: .leading, spacing: 18) {
                         sshWorkspaceHeader
 
-                        HStack(alignment: .top, spacing: 16) {
-                            sshSectionRail
-                                .frame(width: 205)
-
-                            ScrollView {
-                                VStack(alignment: .leading, spacing: 18) {
-                                    sshSectionHeading
-                                    sshQuickFacts
-                                    selectedSettingsContent
+                        if AdaptiveWorkspaceLayout.usesSingleColumnProfileEditor(
+                            width: proxy.size.width
+                        ) {
+                            VStack(alignment: .leading, spacing: 12) {
+                                compactProfileSectionPicker
+                                ScrollView {
+                                    VStack(alignment: .leading, spacing: 18) {
+                                        sshSectionHeading
+                                        sshQuickFacts
+                                        selectedSettingsContent
+                                    }
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(.bottom, 20)
                                 }
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.bottom, 20)
                             }
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
-
-                            if proxy.size.width >= 1120 {
-                                sshProfileInspector
-                                    .frame(width: 270)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                        } else {
+                            HStack(alignment: .top, spacing: 16) {
+                                sshSectionRail
+                                    .frame(width: 205)
+                                ScrollView {
+                                    VStack(alignment: .leading, spacing: 18) {
+                                        sshSectionHeading
+                                        sshQuickFacts
+                                        selectedSettingsContent
+                                    }
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(.bottom, 20)
+                                }
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                if AdaptiveWorkspaceLayout.showsProfileInspector(
+                                    width: proxy.size.width
+                                ) {
+                                    sshProfileInspector
+                                        .frame(width: 270)
+                                }
                             }
+                            .frame(maxWidth: 1380, maxHeight: .infinity, alignment: .topLeading)
                         }
-                        .frame(maxWidth: 1380, maxHeight: .infinity, alignment: .topLeading)
                     }
                     .padding(.horizontal, 24)
                     .padding(.top, 24)
@@ -1506,33 +1524,78 @@ struct ContentView: View {
     }
 
 
+    private var compactProfileSectionPicker: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 7) {
+                ForEach(availableTabs) { tab in
+                    Button {
+                        selectedTab = tab
+                    } label: {
+                        Label(rdpTabTitle(tab), systemImage: tab.systemImage)
+                            .font(.subheadline.weight(.semibold))
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 8)
+                            .foregroundStyle(
+                                selectedTab == tab ? Color.accentColor : Color.primary
+                            )
+                            .background(
+                                selectedTab == tab
+                                    ? Color.accentColor.opacity(0.12)
+                                    : Color.primary.opacity(0.04),
+                                in: RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
     private var rdpProfileWorkspace: some View {
         VStack(spacing: 0) {
             GeometryReader { proxy in
                 VStack(alignment: .leading, spacing: 18) {
                     rdpWorkspaceHeader
 
-                    HStack(alignment: .top, spacing: 16) {
-                        rdpSectionRail
-                            .frame(width: 205)
-
-                        ScrollView {
-                            VStack(alignment: .leading, spacing: 18) {
-                                rdpSectionHeading
-                                rdpQuickFacts
-                                selectedSettingsContent
+                    if AdaptiveWorkspaceLayout.usesSingleColumnProfileEditor(
+                        width: proxy.size.width
+                    ) {
+                        VStack(alignment: .leading, spacing: 12) {
+                            compactProfileSectionPicker
+                            ScrollView {
+                                VStack(alignment: .leading, spacing: 18) {
+                                    rdpSectionHeading
+                                    rdpQuickFacts
+                                    selectedSettingsContent
+                                }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.bottom, 20)
                             }
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.bottom, 20)
                         }
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-
-                        if proxy.size.width >= 1120 {
-                            rdpProfileInspector
-                                .frame(width: 270)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    } else {
+                        HStack(alignment: .top, spacing: 16) {
+                            rdpSectionRail
+                                .frame(width: 205)
+                            ScrollView {
+                                VStack(alignment: .leading, spacing: 18) {
+                                    rdpSectionHeading
+                                    rdpQuickFacts
+                                    selectedSettingsContent
+                                }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.bottom, 20)
+                            }
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            if AdaptiveWorkspaceLayout.showsProfileInspector(
+                                width: proxy.size.width
+                            ) {
+                                rdpProfileInspector
+                                    .frame(width: 270)
+                            }
                         }
+                        .frame(maxWidth: 1380, maxHeight: .infinity, alignment: .topLeading)
                     }
-                    .frame(maxWidth: 1380, maxHeight: .infinity, alignment: .topLeading)
                 }
                 .padding(.horizontal, 24)
                 .padding(.top, 24)

--- a/Sources/SelectiveRemote/CredentialDisclosureField.swift
+++ b/Sources/SelectiveRemote/CredentialDisclosureField.swift
@@ -1,0 +1,183 @@
+import AppKit
+import SwiftUI
+
+enum CredentialDisclosurePolicy {
+    static let visibleNanoseconds: UInt64 = 30_000_000_000
+    static let clipboardNanoseconds: UInt64 = 30_000_000_000
+}
+
+struct CredentialDisclosureField: View {
+    @Binding var draftValue: String
+
+    let hasSavedValue: Bool
+    let placeholder: String
+    let savedPlaceholder: String
+    let identity: String
+    let reveal: @MainActor () async -> String?
+
+    @State private var showsDraft = false
+    @State private var revealedValue: String?
+    @State private var isAuthorizing = false
+    @State private var copied = false
+    @State private var revealTask: Task<Void, Never>?
+    @State private var hideTask: Task<Void, Never>?
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Group {
+                if let revealedValue {
+                    Text(revealedValue)
+                        .font(.body.monospaced())
+                        .lineLimit(1)
+                        .textSelection(.enabled)
+                        .privacySensitive()
+                        .frame(maxWidth: .infinity, minHeight: 22, alignment: .leading)
+                        .padding(.horizontal, 7)
+                        .background(
+                            Color(nsColor: .textBackgroundColor),
+                            in: RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        )
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 5, style: .continuous)
+                                .strokeBorder(Color.primary.opacity(0.18))
+                        }
+                        .accessibilityLabel(
+                            UpdateLocalization.text(
+                                ru: "Сохранённый пароль показан",
+                                en: "Saved password revealed"
+                            )
+                        )
+                } else if showsDraft {
+                    TextField(
+                        hasSavedValue ? savedPlaceholder : placeholder,
+                        text: $draftValue
+                    )
+                    .textFieldStyle(.roundedBorder)
+                } else {
+                    SecureField(
+                        hasSavedValue ? savedPlaceholder : placeholder,
+                        text: $draftValue
+                    )
+                    .textFieldStyle(.roundedBorder)
+                }
+            }
+
+            if !draftValue.isEmpty {
+                Button {
+                    showsDraft.toggle()
+                } label: {
+                    Image(systemName: showsDraft ? "eye.slash" : "eye")
+                }
+                .buttonStyle(.borderless)
+                .help(
+                    showsDraft
+                        ? UpdateLocalization.text(ru: "Скрыть введённый пароль", en: "Hide entered password")
+                        : UpdateLocalization.text(ru: "Показать введённый пароль", en: "Reveal entered password")
+                )
+            } else if hasSavedValue {
+                Button {
+                    toggleSavedCredential()
+                } label: {
+                    if isAuthorizing {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Image(systemName: revealedValue == nil ? "eye" : "eye.slash")
+                    }
+                }
+                .buttonStyle(.borderless)
+                .disabled(isAuthorizing)
+                .help(
+                    revealedValue == nil
+                        ? UpdateLocalization.text(
+                            ru: "Показать после системной аутентификации",
+                            en: "Reveal after system authentication"
+                        )
+                        : UpdateLocalization.text(ru: "Скрыть пароль", en: "Hide password")
+                )
+            }
+
+            if let revealedValue {
+                Button {
+                    copyToClipboard(revealedValue)
+                } label: {
+                    Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                }
+                .buttonStyle(.borderless)
+                .help(
+                    UpdateLocalization.text(
+                        ru: "Копировать; буфер будет очищен через 30 секунд",
+                        en: "Copy; the clipboard will be cleared after 30 seconds"
+                    )
+                )
+            }
+        }
+        .onChange(of: identity) { _, _ in conceal() }
+        .onChange(of: draftValue) { _, newValue in
+            if !newValue.isEmpty { conceal() }
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(
+                for: NSApplication.didResignActiveNotification
+            )
+        ) { _ in
+            conceal()
+        }
+        .onDisappear {
+            revealTask?.cancel()
+            conceal()
+        }
+    }
+
+    private func toggleSavedCredential() {
+        if revealedValue != nil {
+            conceal()
+            return
+        }
+        revealTask?.cancel()
+        isAuthorizing = true
+        revealTask = Task { @MainActor in
+            let secret = await reveal()
+            guard !Task.isCancelled else { return }
+            isAuthorizing = false
+            guard let secret, !secret.isEmpty else { return }
+            revealedValue = secret
+            scheduleConceal()
+        }
+    }
+
+    private func scheduleConceal() {
+        hideTask?.cancel()
+        hideTask = Task { @MainActor in
+            do {
+                try await Task.sleep(nanoseconds: CredentialDisclosurePolicy.visibleNanoseconds)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            conceal()
+        }
+    }
+
+    private func conceal() {
+        hideTask?.cancel()
+        hideTask = nil
+        revealedValue = nil
+        isAuthorizing = false
+        copied = false
+    }
+
+    private func copyToClipboard(_ secret: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        guard pasteboard.setString(secret, forType: .string) else { return }
+        copied = true
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: CredentialDisclosurePolicy.clipboardNanoseconds)
+            if NSPasteboard.general.string(forType: .string) == secret {
+                NSPasteboard.general.clearContents()
+            }
+            copied = false
+        }
+    }
+}

--- a/Sources/SelectiveRemote/ForwardingManager.swift
+++ b/Sources/SelectiveRemote/ForwardingManager.swift
@@ -327,25 +327,41 @@ struct ForwardingManagerView: View {
         TimelineView(.periodic(from: .now, by: 3)) { timeline in
             let snapshot = makeSnapshot()
             let items = filteredItems(snapshot.items)
-            HStack(spacing: 0) {
-                VStack(alignment: .leading, spacing: 16) {
-                    header
-                    summary(snapshot)
-                    toolbar(items: items)
-                    tunnelTable(items: items, now: timeline.date)
-                    footer(items: items)
+            GeometryReader { proxy in
+                let compact = proxy.size.width < 940
+                if compact {
+                    VSplitView {
+                        managerContent(
+                            snapshot: snapshot,
+                            items: items,
+                            now: timeline.date,
+                            compact: true
+                        )
+                        .frame(minHeight: 360)
+
+                        inspector(item: selectedItem(from: items), now: timeline.date)
+                            .frame(minHeight: 240, idealHeight: 320)
+                            .id(selectedItemID)
+                    }
+                } else {
+                    HStack(spacing: 0) {
+                        managerContent(
+                            snapshot: snapshot,
+                            items: items,
+                            now: timeline.date,
+                            compact: false
+                        )
+
+                        Divider()
+
+                        inspector(item: selectedItem(from: items), now: timeline.date)
+                            .frame(minWidth: 340, idealWidth: 400, maxWidth: 460)
+                            .id(selectedItemID)
+                    }
                 }
-                .padding(24)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-
-                Divider()
-
-                inspector(item: selectedItem(from: items), now: timeline.date)
-                    .frame(minWidth: 380, idealWidth: 430, maxWidth: 500)
-                    .id(selectedItemID)
-                    .transition(.opacity)
-                    .animation(reduceMotion ? nil : .easeInOut(duration: 0.18), value: selectedItemID)
             }
+            .transition(.opacity)
+            .animation(reduceMotion ? nil : .easeInOut(duration: 0.18), value: selectedItemID)
             .onAppear {
                 normalizeSelection(items: items)
                 refreshLog(for: selectedItem(from: items))
@@ -381,6 +397,31 @@ struct ForwardingManagerView: View {
         }
     }
 
+    private func managerContent(
+        snapshot: ForwardingManagerSnapshot,
+        items: [ForwardingManagerItem],
+        now: Date,
+        compact: Bool
+    ) -> some View {
+        VStack(alignment: .leading, spacing: compact ? 12 : 16) {
+            header
+            summary(snapshot, compact: compact)
+            if compact {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    toolbar(items: items)
+                        .frame(minWidth: 760)
+                }
+                compactTunnelList(items: items, now: now)
+            } else {
+                toolbar(items: items)
+                tunnelTable(items: items, now: now)
+            }
+            footer(items: items)
+        }
+        .padding(compact ? 16 : 24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
     private var header: some View {
         HStack(alignment: .center, spacing: 12) {
             VStack(alignment: .leading, spacing: 4) {
@@ -388,6 +429,8 @@ struct ForwardingManagerView: View {
                     .font(.system(size: 30, weight: .bold, design: .rounded))
                 Text("Менеджер SSH-туннелей · Local / Remote / Dynamic")
                     .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             Spacer()
             newTunnelMenu
@@ -441,9 +484,12 @@ struct ForwardingManagerView: View {
         .buttonStyle(.borderedProminent)
     }
 
-    private func summary(_ snapshot: ForwardingManagerSnapshot) -> some View {
+    private func summary(
+        _ snapshot: ForwardingManagerSnapshot,
+        compact: Bool
+    ) -> some View {
         LazyVGrid(
-            columns: [GridItem(.adaptive(minimum: 155), spacing: 12)],
+            columns: [GridItem(.adaptive(minimum: compact ? 125 : 155), spacing: 12)],
             alignment: .leading,
             spacing: 12
         ) {
@@ -611,6 +657,69 @@ struct ForwardingManagerView: View {
             .frame(width: 230)
         }
         .controlSize(.small)
+    }
+
+    private func compactTunnelList(
+        items: [ForwardingManagerItem],
+        now: Date
+    ) -> some View {
+        List(items, selection: $selectedItemID) { item in
+            HStack(spacing: 10) {
+                Image(systemName: item.rule.kind.systemImage)
+                    .foregroundStyle(item.ownership.color)
+                    .frame(width: 20)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(item.rule.name)
+                        .font(.subheadline.weight(.semibold))
+                        .lineLimit(1)
+                    Text(item.localAddress + " → " + item.destination)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 8)
+
+                VStack(alignment: .trailing, spacing: 3) {
+                    HStack(spacing: 5) {
+                        Circle()
+                            .fill(item.state.color)
+                            .frame(width: 7, height: 7)
+                        Text(LocalizedStringKey(item.state.title))
+                            .font(.caption)
+                    }
+                    Text(item.uptimeText(now: now))
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.vertical, 4)
+            .contentShape(Rectangle())
+            .tag(item.id)
+            .onTapGesture {
+                selectForAction(item)
+            }
+            .simultaneousGesture(
+                TapGesture(count: 2).onEnded {
+                    selectForAction(item)
+                    if item.state.canStart {
+                        start(item)
+                    }
+                }
+            )
+            .contextMenu {
+                forwardingContextMenu(item)
+            }
+        }
+        .listStyle(.inset)
+        .frame(minHeight: 220)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .strokeBorder(Color.primary.opacity(0.07))
+                .allowsHitTesting(false)
+        }
     }
 
     private func tunnelTable(items: [ForwardingManagerItem], now: Date) -> some View {

--- a/Sources/SelectiveRemote/ForwardingManager.swift
+++ b/Sources/SelectiveRemote/ForwardingManager.swift
@@ -311,6 +311,7 @@ struct ForwardingManagerView: View {
     @State private var filter = ForwardingManagerFilter.all
     @State private var searchText = ""
     @State private var inspectorTab = ForwardingInspectorTab.overview
+    @State private var compactDetailPresented = false
     @State private var connectionRequest: ForwardingConnectionRequest?
     @State private var passwordInputs: [UUID: String] = [:]
     @State private var logText = ""
@@ -328,20 +329,23 @@ struct ForwardingManagerView: View {
             let snapshot = makeSnapshot()
             let items = filteredItems(snapshot.items)
             GeometryReader { proxy in
-                let compact = proxy.size.width < 940
+                let compact = AdaptiveWorkspaceLayout.usesDetailNavigation(
+                    width: proxy.size.width
+                )
                 if compact {
-                    VSplitView {
+                    if compactDetailPresented {
+                        compactInspector(
+                            item: selectedItem(from: items),
+                            now: timeline.date
+                        )
+                        .id(selectedItemID)
+                    } else {
                         managerContent(
                             snapshot: snapshot,
                             items: items,
                             now: timeline.date,
                             compact: true
                         )
-                        .frame(minHeight: 360)
-
-                        inspector(item: selectedItem(from: items), now: timeline.date)
-                            .frame(minHeight: 240, idealHeight: 320)
-                            .id(selectedItemID)
                     }
                 } else {
                     HStack(spacing: 0) {
@@ -395,6 +399,27 @@ struct ForwardingManagerView: View {
                 }
             )
         }
+    }
+
+    private func compactInspector(
+        item: ForwardingManagerItem?,
+        now: Date
+    ) -> some View {
+        VStack(spacing: 0) {
+            HStack {
+                Button("Назад к туннелям", systemImage: "chevron.left") {
+                    compactDetailPresented = false
+                }
+                .buttonStyle(.bordered)
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+
+            Divider()
+            inspector(item: item, now: now)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private func managerContent(
@@ -699,10 +724,12 @@ struct ForwardingManagerView: View {
             .tag(item.id)
             .onTapGesture {
                 selectForAction(item)
+                compactDetailPresented = true
             }
             .simultaneousGesture(
                 TapGesture(count: 2).onEnded {
                     selectForAction(item)
+                    compactDetailPresented = true
                     if item.state.canStart {
                         start(item)
                     }

--- a/Sources/SelectiveRemote/KeychainService.swift
+++ b/Sources/SelectiveRemote/KeychainService.swift
@@ -59,7 +59,7 @@ enum KeychainError: LocalizedError {
     }
 }
 
-enum KeychainCredentialKind: String {
+enum KeychainCredentialKind: String, Sendable {
     case rdp
     case gateway
     case ssh
@@ -188,6 +188,62 @@ enum KeychainService {
             } ?? outcome.error?.localizedDescription ?? "Touch ID не подтвердил доступ."
             throw KeychainError.biometricAuthenticationFailed(message)
         }
+    }
+
+    static func revealPassword(
+        profileID: UUID,
+        kind: KeychainCredentialKind,
+        reason: String
+    ) async throws -> String? {
+        let context = LAContext()
+        context.localizedCancelTitle = UpdateLocalization.text(ru: "Отмена", en: "Cancel")
+        var availabilityError: NSError?
+        guard context.canEvaluatePolicy(
+            .deviceOwnerAuthentication,
+            error: &availabilityError
+        ) else {
+            throw KeychainError.touchIDUnavailable(
+                availabilityError?.localizedDescription
+                    ?? UpdateLocalization.text(
+                        ru: "Системная аутентификация macOS недоступна.",
+                        en: "macOS system authentication is unavailable."
+                    )
+            )
+        }
+
+        do {
+            let succeeded = try await context.evaluatePolicy(
+                .deviceOwnerAuthentication,
+                localizedReason: reason
+            )
+            guard succeeded else {
+                throw KeychainError.biometricAuthenticationFailed(
+                    UpdateLocalization.text(
+                        ru: "Системная аутентификация не подтверждена. Пароль не раскрыт.",
+                        en: "System authentication was not confirmed. The password was not revealed."
+                    )
+                )
+            }
+        } catch let error as LAError {
+            let message: String
+            switch error.code {
+            case .userCancel, .appCancel, .systemCancel:
+                message = UpdateLocalization.text(
+                    ru: "Системная аутентификация отменена. Пароль не раскрыт.",
+                    en: "System authentication was cancelled. The password was not revealed."
+                )
+            case .biometryLockout:
+                message = UpdateLocalization.text(
+                    ru: "Touch ID временно заблокирован. Используйте пароль macOS или повторите позже.",
+                    en: "Touch ID is temporarily locked. Use your macOS password or try again later."
+                )
+            default:
+                message = error.localizedDescription
+            }
+            throw KeychainError.biometricAuthenticationFailed(message)
+        }
+
+        return try readPassword(profileID: profileID, kind: kind)
     }
 
     static func passwordExists(reference: KeychainCredentialReference) -> Bool {

--- a/Sources/SelectiveRemote/SFTPWorkspace.swift
+++ b/Sources/SelectiveRemote/SFTPWorkspace.swift
@@ -298,58 +298,13 @@ struct SFTPWorkspaceView: View {
             workspaceTabBar
 
             let tab = workspace.selectedTab
-            HSplitView {
-                SFTPWorkspacePaneView(
-                    pane: tab.left,
-                    opposite: tab.right,
-                    profiles: sshProfiles,
-                    selectLocal: { tab.left.setLocal() },
-                    selectSavedProfile: { profileID in
-                        connect(
-                            pane: tab.left,
-                            connection: .savedProfile(profileID),
-                            path: nil
-                        )
-                    },
-                    selectCustom: {
-                        connectionRequest = SFTPWorkspaceConnectionRequest(
-                            paneID: tab.left.id,
-                            initialConnection: tab.left.connection
-                                ?? sshProfiles.first.map { .savedProfile($0.id) }
-                                ?? .custom(host: "", username: ""),
-                            path: nil
-                        )
-                    },
-                    disconnect: { tab.left.clear() },
-                    copyToOpposite: { copy(from: tab.left, to: tab.right) }
+            GeometryReader { proxy in
+                workspacePanes(
+                    tab,
+                    stacked: AdaptiveWorkspaceLayout.usesStackedSFTPPanes(
+                        width: proxy.size.width
+                    )
                 )
-                .frame(minWidth: 390)
-
-                SFTPWorkspacePaneView(
-                    pane: tab.right,
-                    opposite: tab.left,
-                    profiles: sshProfiles,
-                    selectLocal: { tab.right.setLocal() },
-                    selectSavedProfile: { profileID in
-                        connect(
-                            pane: tab.right,
-                            connection: .savedProfile(profileID),
-                            path: nil
-                        )
-                    },
-                    selectCustom: {
-                        connectionRequest = SFTPWorkspaceConnectionRequest(
-                            paneID: tab.right.id,
-                            initialConnection: tab.right.connection
-                                ?? sshProfiles.first.map { .savedProfile($0.id) }
-                                ?? .custom(host: "", username: ""),
-                            path: nil
-                        )
-                    },
-                    disconnect: { tab.right.clear() },
-                    copyToOpposite: { copy(from: tab.right, to: tab.left) }
-                )
-                .frame(minWidth: 390)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .layoutPriority(1)
@@ -411,16 +366,90 @@ struct SFTPWorkspaceView: View {
         }
     }
 
-    private var workspaceToolbar: some View {
-        HStack(spacing: 10) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text("SFTP Workspace")
-                    .font(.headline)
-                Text("Каждая панель может быть этим Mac или отдельным SSH/SFTP-сервером")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+    @ViewBuilder
+    private func workspacePanes(
+        _ tab: SFTPWorkspaceTab,
+        stacked: Bool
+    ) -> some View {
+        if stacked {
+            VSplitView {
+                workspacePane(tab.left, opposite: tab.right)
+                    .frame(minHeight: 280)
+                workspacePane(tab.right, opposite: tab.left)
+                    .frame(minHeight: 280)
             }
-            Spacer()
+        } else {
+            HSplitView {
+                workspacePane(tab.left, opposite: tab.right)
+                    .frame(minWidth: 420)
+                workspacePane(tab.right, opposite: tab.left)
+                    .frame(minWidth: 420)
+            }
+        }
+    }
+
+    private func workspacePane(
+        _ pane: SFTPWorkspacePane,
+        opposite: SFTPWorkspacePane
+    ) -> some View {
+        SFTPWorkspacePaneView(
+            pane: pane,
+            opposite: opposite,
+            profiles: sshProfiles,
+            selectLocal: { pane.setLocal() },
+            selectSavedProfile: { profileID in
+                connect(
+                    pane: pane,
+                    connection: .savedProfile(profileID),
+                    path: nil
+                )
+            },
+            selectCustom: {
+                connectionRequest = SFTPWorkspaceConnectionRequest(
+                    paneID: pane.id,
+                    initialConnection: pane.connection
+                        ?? sshProfiles.first.map { .savedProfile($0.id) }
+                        ?? .custom(host: "", username: ""),
+                    path: nil
+                )
+            },
+            disconnect: { pane.clear() },
+            copyToOpposite: { copy(from: pane, to: opposite) }
+        )
+    }
+
+    private var workspaceToolbar: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 10) {
+                workspaceToolbarTitle
+                Spacer()
+                workspaceToolbarActions
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                workspaceToolbarTitle
+                HStack {
+                    Spacer()
+                    workspaceToolbarActions
+                }
+            }
+        }
+    }
+
+    private var workspaceToolbarTitle: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("SFTP Workspace")
+                .font(.headline)
+            Text("Каждая панель может быть этим Mac или отдельным SSH/SFTP-сервером")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var workspaceToolbarActions: some View {
+        HStack(spacing: 10) {
             if workspace.activeRemoteCount > 0 {
                 Label(
                     "Серверов: \(workspace.activeRemoteCount)",

--- a/Sources/SelectiveRemote/TerminalCommandHistory.swift
+++ b/Sources/SelectiveRemote/TerminalCommandHistory.swift
@@ -154,6 +154,34 @@ struct TerminalSnippetGroup: Codable, Equatable, Identifiable {
     let profileID: UUID
     var name: String
     var createdAt: Date
+    var updatedAt: Date
+
+    init(
+        id: UUID,
+        profileID: UUID,
+        name: String,
+        createdAt: Date,
+        updatedAt: Date? = nil
+    ) {
+        self.id = id
+        self.profileID = profileID
+        self.name = name
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt ?? createdAt
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, profileID, name, createdAt, updatedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        profileID = try container.decode(UUID.self, forKey: .profileID)
+        name = try container.decode(String.self, forKey: .name)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt) ?? createdAt
+    }
 }
 
 private struct TerminalHistoryWebEntry: Encodable {
@@ -409,7 +437,8 @@ final class TerminalCommandHistoryStore: ObservableObject {
     func renameSnippetGroup(
         id: UUID,
         name rawName: String,
-        profileID: UUID
+        profileID: UUID,
+        now: Date = Date()
     ) -> Bool {
         guard let name = normalizedSnippetGroupName(rawName),
               let index = storedSnippetGroups.firstIndex(where: {
@@ -425,9 +454,11 @@ final class TerminalCommandHistoryStore: ObservableObject {
             return false
         }
         storedSnippetGroups[index].name = name
+        storedSnippetGroups[index].updatedAt = now
         for templateIndex in storedTemplates.indices where
             storedTemplates[templateIndex].groupID == id {
             storedTemplates[templateIndex].category = name
+            storedTemplates[templateIndex].updatedAt = now
         }
         persistSnippetGroups()
         persistTemplates()
@@ -473,6 +504,7 @@ final class TerminalCommandHistoryStore: ObservableObject {
         targetProfileIDs: [UUID]? = nil,
         targets: [TerminalSnippetTarget]? = nil
     ) -> Bool {
+        let now = Date()
         let title = rawTitle.trimmingCharacters(in: .whitespacesAndNewlines)
         let category = rawCategory.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !title.isEmpty,
@@ -503,7 +535,7 @@ final class TerminalCommandHistoryStore: ObservableObject {
             storedTemplates[index].groupID = group?.id ?? TerminalCommandTemplate.legacyUnassignedGroupID
             storedTemplates[index].isExplicitlyUngrouped = group == nil
             storedTemplates[index].targets = resolvedTargets
-            storedTemplates[index].updatedAt = Date()
+            storedTemplates[index].updatedAt = now
         } else {
             storedTemplates.append(
                 TerminalCommandTemplate(
@@ -516,9 +548,13 @@ final class TerminalCommandHistoryStore: ObservableObject {
                     targetProfileIDs: normalizedTargetIDs(targetProfileIDs ?? [profileID]),
                     targets: resolvedTargets,
                     isExplicitlyUngrouped: group == nil,
-                    updatedAt: Date()
+                    updatedAt: now
                 )
             )
+        }
+        if let groupID = group?.id,
+           let groupIndex = storedSnippetGroups.firstIndex(where: { $0.id == groupID }) {
+            storedSnippetGroups[groupIndex].updatedAt = now
         }
         persistSnippetGroups()
         if storedTemplates.count > 500 {

--- a/Sources/SelectiveRemote/TerminalSnippetsLibraryView.swift
+++ b/Sources/SelectiveRemote/TerminalSnippetsLibraryView.swift
@@ -15,6 +15,44 @@ private enum SnippetLibrarySort: String, CaseIterable, Identifiable {
     var title: String { self == .name ? "Имя" : "Последнее изменение" }
 }
 
+enum TerminalSnippetRootGroupSorter {
+    static func sorted(
+        _ groups: [TerminalSnippetGroup],
+        templates: [TerminalCommandTemplate],
+        byModifiedDate: Bool,
+        ascending: Bool
+    ) -> [TerminalSnippetGroup] {
+        let templatesByGroup = Dictionary(grouping: templates, by: \.groupID)
+        return groups.sorted { lhs, rhs in
+            let comparison: ComparisonResult
+            if byModifiedDate {
+                let lhsDate = modifiedAt(lhs, templates: templatesByGroup[lhs.id] ?? [])
+                let rhsDate = modifiedAt(rhs, templates: templatesByGroup[rhs.id] ?? [])
+                comparison = lhsDate == rhsDate
+                    ? lhs.name.localizedStandardCompare(rhs.name)
+                    : (lhsDate < rhsDate ? .orderedAscending : .orderedDescending)
+            } else {
+                comparison = lhs.name.localizedStandardCompare(rhs.name)
+            }
+            if comparison == .orderedSame {
+                return ascending
+                    ? lhs.id.uuidString < rhs.id.uuidString
+                    : lhs.id.uuidString > rhs.id.uuidString
+            }
+            return ascending
+                ? comparison == .orderedAscending
+                : comparison == .orderedDescending
+        }
+    }
+
+    static func modifiedAt(
+        _ group: TerminalSnippetGroup,
+        templates: [TerminalCommandTemplate]
+    ) -> Date {
+        max(group.updatedAt, templates.map(\.updatedAt).max() ?? group.updatedAt)
+    }
+}
+
 struct TerminalSnippetsLibraryView: View {
     @ObservedObject var store: TerminalCommandHistoryStore
     @ObservedObject var model: AppModel
@@ -605,11 +643,12 @@ struct TerminalSnippetsLibraryView: View {
     }
 
     private var sortedGroups: [TerminalSnippetGroup] {
-        let groups = store.snippetGroups()
-        return groups.sorted {
-            let result = $0.name.localizedStandardCompare($1.name)
-            return sortAscending ? result == .orderedAscending : result == .orderedDescending
-        }
+        TerminalSnippetRootGroupSorter.sorted(
+            store.snippetGroups(),
+            templates: store.templates(),
+            byModifiedDate: SnippetLibrarySort(rawValue: sortRaw) == .modified,
+            ascending: sortAscending
+        )
     }
 
     private var ungroupedSnippets: [TerminalCommandTemplate] {

--- a/Tests/SelectiveRemoteTests/CredentialDisclosureTests.swift
+++ b/Tests/SelectiveRemoteTests/CredentialDisclosureTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+@testable import SelectiveRemote
+
+@Test("Saved host passwords require macOS authentication before disclosure")
+func savedCredentialDisclosureUsesSystemAuthentication() throws {
+    let root = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    let keychain = try String(
+        contentsOf: root.appendingPathComponent("Sources/SelectiveRemote/KeychainService.swift"),
+        encoding: .utf8
+    )
+    let appModel = try String(
+        contentsOf: root.appendingPathComponent("Sources/SelectiveRemote/AppModel.swift"),
+        encoding: .utf8
+    )
+
+    #expect(keychain.contains("static func revealPassword("))
+    #expect(keychain.contains(".deviceOwnerAuthentication"))
+    #expect(keychain.contains("try await context.evaluatePolicy"))
+    #expect(appModel.contains("revealSelectedCredential"))
+    #expect(!appModel.contains("@Published var revealed"))
+}
+
+@Test("Credential disclosure is temporary and clears only its own clipboard value")
+func credentialDisclosurePolicyIsSafe() throws {
+    #expect(CredentialDisclosurePolicy.visibleNanoseconds == 30_000_000_000)
+    #expect(CredentialDisclosurePolicy.clipboardNanoseconds == 30_000_000_000)
+
+    let root = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    let source = try String(
+        contentsOf: root.appendingPathComponent(
+            "Sources/SelectiveRemote/CredentialDisclosureField.swift"
+        ),
+        encoding: .utf8
+    )
+    #expect(source.contains("NSApplication.didResignActiveNotification"))
+    #expect(source.contains("if NSPasteboard.general.string(forType: .string) == secret"))
+    #expect(source.contains(".privacySensitive()"))
+    #expect(!source.contains("UserDefaults"))
+}
+
+@Test("RDP, Gateway, SSH and Proxy editors expose the protected reveal control")
+func allSavedHostCredentialEditorsUseDisclosureField() throws {
+    let root = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    let source = try String(
+        contentsOf: root.appendingPathComponent("Sources/SelectiveRemote/ContentView.swift"),
+        encoding: .utf8
+    )
+
+    #expect(source.components(separatedBy: "CredentialDisclosureField(").count == 4)
+    #expect(source.contains("kind: .rdp"))
+    #expect(source.contains("kind: .gateway"))
+    #expect(source.contains("revealSelectedCredential(kind: .ssh)"))
+    #expect(source.contains("revealSelectedCredential(kind: .proxy)"))
+}

--- a/Tests/SelectiveRemoteTests/ResponsiveLayoutAndSnippetSortTests.swift
+++ b/Tests/SelectiveRemoteTests/ResponsiveLayoutAndSnippetSortTests.swift
@@ -86,10 +86,24 @@ func narrowManagerLayoutsAreAdaptive() throws {
         encoding: .utf8
     )
 
-    #expect(center.contains("proxy.size.width < 900"))
-    #expect(center.contains("VSplitView"))
+    #expect(center.contains("AdaptiveWorkspaceLayout.usesDetailNavigation"))
+    #expect(center.contains("compactInspector("))
     #expect(center.contains("compactConnectionList"))
-    #expect(forwarding.contains("proxy.size.width < 940"))
-    #expect(forwarding.contains("VSplitView"))
+    #expect(!center.contains("VSplitView"))
+    #expect(forwarding.contains("AdaptiveWorkspaceLayout.usesDetailNavigation"))
+    #expect(forwarding.contains("compactInspector("))
     #expect(forwarding.contains("compactTunnelList"))
+    #expect(!forwarding.contains("VSplitView"))
+}
+
+
+@Test("Adaptive workspace breakpoints cover compact, regular, and 8K widths")
+func adaptiveWorkspaceBreakpoints() {
+    #expect(AdaptiveWorkspaceLayout.usesSingleColumnProfileEditor(width: 720))
+    #expect(!AdaptiveWorkspaceLayout.usesSingleColumnProfileEditor(width: 1_200))
+    #expect(AdaptiveWorkspaceLayout.usesStackedSFTPPanes(width: 900))
+    #expect(!AdaptiveWorkspaceLayout.usesStackedSFTPPanes(width: 1_400))
+    #expect(AdaptiveWorkspaceLayout.usesDetailNavigation(width: 900))
+    #expect(!AdaptiveWorkspaceLayout.usesDetailNavigation(width: 1_400))
+    #expect(AdaptiveWorkspaceLayout.showsProfileInspector(width: 7_680))
 }

--- a/Tests/SelectiveRemoteTests/ResponsiveLayoutAndSnippetSortTests.swift
+++ b/Tests/SelectiveRemoteTests/ResponsiveLayoutAndSnippetSortTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+@testable import SelectiveRemote
+
+@Test("Legacy snippet groups decode their modification date without data loss")
+func legacySnippetGroupModificationDateMigration() throws {
+    let id = UUID()
+    let profileID = UUID()
+    let createdAt = Date(timeIntervalSince1970: 1_700_000_000)
+    let legacy: [String: Any] = [
+        "id": id.uuidString,
+        "profileID": profileID.uuidString,
+        "name": "Legacy",
+        "createdAt": createdAt.timeIntervalSinceReferenceDate
+    ]
+    let data = try JSONSerialization.data(withJSONObject: legacy)
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .deferredToDate
+    let decoded = try decoder.decode(TerminalSnippetGroup.self, from: data)
+
+    #expect(decoded.id == id)
+    #expect(decoded.updatedAt == createdAt)
+}
+
+@Test("Root snippet groups sort by the newest child modification")
+func rootSnippetGroupsSortByModificationDate() {
+    let profileID = UUID()
+    let old = Date(timeIntervalSince1970: 1_000)
+    let middle = Date(timeIntervalSince1970: 2_000)
+    let newest = Date(timeIntervalSince1970: 3_000)
+    let first = TerminalSnippetGroup(
+        id: UUID(),
+        profileID: profileID,
+        name: "First",
+        createdAt: old
+    )
+    let second = TerminalSnippetGroup(
+        id: UUID(),
+        profileID: profileID,
+        name: "Second",
+        createdAt: middle
+    )
+    let modifiedChild = TerminalCommandTemplate(
+        id: UUID(),
+        profileID: profileID,
+        title: "Recently edited",
+        command: "uptime",
+        category: first.name,
+        groupID: first.id,
+        updatedAt: newest
+    )
+
+    let descending = TerminalSnippetRootGroupSorter.sorted(
+        [first, second],
+        templates: [modifiedChild],
+        byModifiedDate: true,
+        ascending: false
+    )
+    #expect(descending.map(\.id) == [first.id, second.id])
+
+    let ascending = TerminalSnippetRootGroupSorter.sorted(
+        [first, second],
+        templates: [modifiedChild],
+        byModifiedDate: true,
+        ascending: true
+    )
+    #expect(ascending.map(\.id) == [second.id, first.id])
+}
+
+@Test("Connection Center and Forwarding use compact vertical layouts")
+func narrowManagerLayoutsAreAdaptive() throws {
+    let root = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    let center = try String(
+        contentsOf: root.appendingPathComponent(
+            "Sources/SelectiveRemote/ConnectionCenter.swift"
+        ),
+        encoding: .utf8
+    )
+    let forwarding = try String(
+        contentsOf: root.appendingPathComponent(
+            "Sources/SelectiveRemote/ForwardingManager.swift"
+        ),
+        encoding: .utf8
+    )
+
+    #expect(center.contains("proxy.size.width < 900"))
+    #expect(center.contains("VSplitView"))
+    #expect(center.contains("compactConnectionList"))
+    #expect(forwarding.contains("proxy.size.width < 940"))
+    #expect(forwarding.contains("VSplitView"))
+    #expect(forwarding.contains("compactTunnelList"))
+}


### PR DESCRIPTION
## Что изменено

- сохранённые пароли RDP, RD Gateway, SSH и Proxy можно раскрыть кнопкой с глазом;
- перед раскрытием обязательна системная аутентификация macOS (Touch ID или пароль пользователя);
- пароль автоматически скрывается через 30 секунд, при смене хоста, закрытии экрана или уходе приложения в фон;
- после раскрытия доступно копирование; буфер очищается через 30 секунд, только если в нём всё ещё находится скопированный пароль;
- введённый новый пароль также можно временно показать обычной кнопкой;
- секрет не сохраняется в UserDefaults и не публикуется через ObservableObject;
- добавлены regression tests.

## Безопасность

Все существующие секреты остаются в macOS Keychain. Apple Developer account и Cloud для этой функции не требуются.

## Проверка

- [ ] CI / Swift tests
- [ ] Test DMG
- [ ] Ручная проверка RDP
- [ ] Ручная проверка SSH
- [ ] Ручная проверка RD Gateway / Proxy
