### PR TITLE
macOS: fix localization, update retention, and toolbar sizing

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -435,6 +435,10 @@
 "Загрузка и проверка SHA-256 · %@%%" = "Downloading and verifying SHA-256 · %@%%";
 "DMG загружен и проверен" = "DMG downloaded and verified";
 "Автоматически загружать обновления" = "Automatically download updates";
+"Автоматически загружать найденные обновления" = "Automatically download available updates";
+"Место автоматической загрузки" = "Automatic download location";
+"Выбрать пользовательский каталог…" = "Choose Custom Folder…";
+"Использовать системный каталог" = "Use System Folder";
 "Загрузить обновление" = "Download Update";
 "Установить и перезапустить" = "Install & Restart";
 "Показать DMG" = "Show DMG";

--- a/Sources/SelectiveRemote/AppModel.swift
+++ b/Sources/SelectiveRemote/AppModel.swift
@@ -378,6 +378,14 @@ final class AppModel: NSObject, ObservableObject {
             }
         }
     }
+    var automaticUpdateDownloadDirectoryDisplayPath: String {
+        if let automaticUpdateDownloadDirectoryPath,
+           !automaticUpdateDownloadDirectoryPath.isEmpty {
+            return automaticUpdateDownloadDirectoryPath
+        }
+        return (try? UpdateInstaller.defaultDownloadDirectoryURL().path)
+            ?? "~/Library/Application Support/Selective Remote/Updates"
+    }
     @Published private(set) var sessions: [UUID: RDPSessionSummary] = [:]
     @Published private(set) var passwordStoredProfileIDs: Set<String> = []
     @Published private(set) var gatewayPasswordStoredProfileIDs: Set<String> = []
@@ -4875,7 +4883,12 @@ final class AppModel: NSObject, ObservableObject {
         updateDownloadStage = .installing
         do {
             let mounted = try UpdateInstaller.mountValidatedDMG(downloadedUpdateDMGURL)
-            try UpdateInstaller.installAndRestart(mounted)
+            try UpdateInstaller.installAndRestart(
+                mounted,
+                retention: downloadedUpdateUsesCustomDestination
+                    ? .keepAfterInstallation
+                    : .removeAfterInstallation
+            )
         } catch {
             updateDownloadStage = .ready
             updateInstallError = error.localizedDescription

--- a/Sources/SelectiveRemote/ConnectionCenter.swift
+++ b/Sources/SelectiveRemote/ConnectionCenter.swift
@@ -461,7 +461,10 @@ struct ConnectionCenterView: View {
     private func header(snapshot: ConnectionCenterSnapshot) -> some View {
         HStack(alignment: .center, spacing: 12) {
             VStack(alignment: .leading, spacing: 4) {
-                Text("Connection Center")
+                Text(UpdateLocalization.text(
+                    ru: "Центр подключений",
+                    en: "Connection Center"
+                ))
                     .font(.system(size: 30, weight: .bold, design: .rounded))
                 Text("Единое состояние активных RDP, SSH, SFTP и Forwarding-подключений")
                     .foregroundStyle(.secondary)

--- a/Sources/SelectiveRemote/ContentView.swift
+++ b/Sources/SelectiveRemote/ContentView.swift
@@ -56,7 +56,7 @@ private enum MainArea: String, CaseIterable, Identifiable {
         case .connections: UpdateLocalization.text(ru: "Подключения", en: "Connections")
         case .ssh: "SSH"
         case .terminal: UpdateLocalization.text(ru: "Терминал", en: "Terminal")
-        case .sftp: "SFTP"
+        case .sftp: UpdateLocalization.text(ru: "Файлы SFTP", en: "SFTP")
         case .forwarding: UpdateLocalization.text(ru: "Туннели", en: "Forwarding")
         case .snippets: UpdateLocalization.text(ru: "Сниппеты", en: "Snippets")
         case .sessionLogs: UpdateLocalization.text(
@@ -2261,7 +2261,7 @@ struct ContentView: View {
         VStack(spacing: 0) {
             HStack {
                 VStack(alignment: .leading, spacing: 5) {
-                    Text("SFTP")
+                    Text(UpdateLocalization.text(ru: "Файлы SFTP", en: "SFTP"))
                         .font(.system(size: 30, weight: .bold, design: .rounded))
                     Text("Несколько SFTP-вкладок · Local ↔ Server · Server ↔ Server")
                         .foregroundStyle(.secondary)

--- a/Sources/SelectiveRemote/ContentView.swift
+++ b/Sources/SelectiveRemote/ContentView.swift
@@ -49,17 +49,23 @@ private enum MainArea: String, CaseIterable, Identifiable {
 
     var title: String {
         switch self {
-        case .connectionCenter: "Connection Center"
+        case .connectionCenter: UpdateLocalization.text(
+            ru: "Центр подключений",
+            en: "Connection Center"
+        )
         case .connections: UpdateLocalization.text(ru: "Подключения", en: "Connections")
         case .ssh: "SSH"
         case .terminal: UpdateLocalization.text(ru: "Терминал", en: "Terminal")
         case .sftp: "SFTP"
-        case .forwarding: "Forwarding"
+        case .forwarding: UpdateLocalization.text(ru: "Туннели", en: "Forwarding")
         case .snippets: UpdateLocalization.text(ru: "Сниппеты", en: "Snippets")
-        case .sessionLogs: "Session Logs"
+        case .sessionLogs: UpdateLocalization.text(
+            ru: "Журналы сессий",
+            en: "Session Logs"
+        )
         case .activity: UpdateLocalization.text(ru: "Журнал", en: "Activity")
         case .diagnostics: UpdateLocalization.text(ru: "Диагностика", en: "Diagnostics")
-        case .keychain: "Keychain"
+        case .keychain: UpdateLocalization.text(ru: "Связка ключей", en: "Keychain")
         }
     }
 

--- a/Sources/SelectiveRemote/ContentView.swift
+++ b/Sources/SelectiveRemote/ContentView.swift
@@ -2255,6 +2255,7 @@ struct ContentView: View {
             .padding(.bottom, 10)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+        .controlSize(.large)
     }
 
     private var globalSFTPDetail: some View {

--- a/Sources/SelectiveRemote/ForwardingManager.swift
+++ b/Sources/SelectiveRemote/ForwardingManager.swift
@@ -450,7 +450,7 @@ struct ForwardingManagerView: View {
     private var header: some View {
         HStack(alignment: .center, spacing: 12) {
             VStack(alignment: .leading, spacing: 4) {
-                Text("Forwarding")
+                Text(UpdateLocalization.text(ru: "Туннели", en: "Forwarding"))
                     .font(.system(size: 30, weight: .bold, design: .rounded))
                 Text("Менеджер SSH-туннелей · Local / Remote / Dynamic")
                     .foregroundStyle(.secondary)

--- a/Sources/SelectiveRemote/TerminalSessionLogs.swift
+++ b/Sources/SelectiveRemote/TerminalSessionLogs.swift
@@ -489,7 +489,10 @@ struct TerminalSessionLogsView: View {
     private var header: some View {
         HStack(alignment: .top) {
             VStack(alignment: .leading, spacing: 5) {
-                Text("Session Logs")
+                Text(UpdateLocalization.text(
+                    ru: "Журналы сессий",
+                    en: "Session Logs"
+                ))
                     .font(.system(size: 30, weight: .bold, design: .rounded))
                 Text("Локальная запись вывода SSH и Local Terminal")
                     .foregroundStyle(.secondary)

--- a/Sources/SelectiveRemote/TerminalToolbarStyle.swift
+++ b/Sources/SelectiveRemote/TerminalToolbarStyle.swift
@@ -3,7 +3,6 @@ import SwiftUI
 private struct TerminalToolbarContainerModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
-            .controlSize(.regular)
             .padding(.horizontal, 12)
             .padding(.vertical, 9)
             .background(

--- a/Sources/SelectiveRemote/UpdateExperienceView.swift
+++ b/Sources/SelectiveRemote/UpdateExperienceView.swift
@@ -71,26 +71,31 @@ private struct UpdateSettingsView: View {
                 Toggle("Проверять обновления при запуске и каждые 5 часов", isOn: $model.automaticallyCheckForUpdates)
                 Toggle("Автоматически загружать найденные обновления", isOn: $model.automaticallyDownloadUpdates)
                     .disabled(!model.automaticallyCheckForUpdates)
-                LabeledContent("Каталог автоматической загрузки") {
-                    Text(model.automaticUpdateDownloadDirectoryPath ?? "Внутренний каталог приложения")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(2)
-                        .truncationMode(.middle)
+                LabeledContent("Место автоматической загрузки") {
+                    VStack(alignment: .trailing, spacing: 3) {
+                        Text(automaticDownloadModeTitle)
+                            .font(.caption.weight(.semibold))
+                        Text(model.automaticUpdateDownloadDirectoryDisplayPath)
+                            .font(.caption2.monospaced())
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                            .truncationMode(.middle)
+                    }
                 }
                 HStack {
-                    Button("Выбрать каталог…", systemImage: "folder") {
+                    Button("Выбрать пользовательский каталог…", systemImage: "folder") {
                         model.chooseAutomaticUpdateDownloadDirectory()
                     }
                     Spacer()
-                    Button("Использовать внутренний каталог") {
+                    Button("Использовать системный каталог") {
                         model.resetAutomaticUpdateDownloadDirectory()
                     }
                     .disabled(model.automaticUpdateDownloadDirectoryPath == nil)
                 }
-                Text("DMG в выбранном каталоге сохраняется после установки и не удаляется автоматически.")
+                Text(automaticDownloadRetentionDescription)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
             Section("Действия") {
@@ -119,6 +124,25 @@ private struct UpdateSettingsView: View {
         guard let date = model.lastSuccessfulUpdateCheckDate else { return "Ещё не выполнялась" }
         return UpdateLocalization.dateTimeShort(date)
     }
+
+    private var automaticDownloadModeTitle: String {
+        model.automaticUpdateDownloadDirectoryPath == nil
+            ? UpdateLocalization.text(ru: "Системный каталог", en: "System folder")
+            : UpdateLocalization.text(ru: "Пользовательский каталог", en: "Custom folder")
+    }
+
+    private var automaticDownloadRetentionDescription: String {
+        if model.automaticUpdateDownloadDirectoryPath == nil {
+            return UpdateLocalization.text(
+                ru: "Системный каталог используется по умолчанию. После успешной установки загруженный DMG удаляется автоматически.",
+                en: "The system folder is used by default. After a successful installation, the downloaded DMG is removed automatically."
+            )
+        }
+        return UpdateLocalization.text(
+            ru: "В пользовательском каталоге DMG сохраняется после установки. Чтобы вернуться к автоматическому удалению, выберите «Использовать системный каталог».",
+            en: "A DMG in a custom folder is kept after installation. To restore automatic removal, choose “Use System Folder”."
+        )
+    }
 }
 
 struct UpdateExperiencePopover: View {
@@ -140,11 +164,17 @@ struct UpdateExperiencePopover: View {
                         .background(Color.red.opacity(0.07), in: RoundedRectangle(cornerRadius: 10))
                 }
 
-                Toggle(
-                    "Автоматически загружать обновления",
-                    isOn: $model.automaticallyDownloadUpdates
-                )
-                .disabled(model.isDownloadingUpdate || model.updateDownloadStage == .installing)
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle(
+                        "Автоматически загружать обновления",
+                        isOn: $model.automaticallyDownloadUpdates
+                    )
+                    .disabled(model.isDownloadingUpdate || model.updateDownloadStage == .installing)
+                    Label(automaticDownloadModeSummary, systemImage: "folder")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
 
                 Divider()
 
@@ -421,6 +451,19 @@ struct UpdateExperiencePopover: View {
         return UpdateLocalization.text(
             ru: "Последняя проверка: \(formatted)",
             en: "Last checked: \(formatted)"
+        )
+    }
+
+    private var automaticDownloadModeSummary: String {
+        if model.automaticUpdateDownloadDirectoryPath == nil {
+            return UpdateLocalization.text(
+                ru: "Системный каталог · DMG удаляется после успешной установки",
+                en: "System folder · the DMG is removed after a successful installation"
+            )
+        }
+        return UpdateLocalization.text(
+            ru: "Пользовательский каталог · DMG сохраняется после установки",
+            en: "Custom folder · the DMG is kept after installation"
         )
     }
 }

--- a/Sources/SelectiveRemote/UpdateInstaller.swift
+++ b/Sources/SelectiveRemote/UpdateInstaller.swift
@@ -64,6 +64,13 @@ enum UpdateDownloadStage: Equatable, Sendable {
     case installing
 }
 
+enum UpdateDMGRetention: Equatable, Sendable {
+    case removeAfterInstallation
+    case keepAfterInstallation
+
+    var removesDMG: Bool { self == .removeAfterInstallation }
+}
+
 struct UpdateNotificationPolicy {
     static let minimumRepeatInterval: TimeInterval = 24 * 60 * 60
 
@@ -226,14 +233,7 @@ enum UpdateInstaller {
             }
             destinationURL = requestedDestinationURL.standardizedFileURL
         } else {
-            let cacheRoot = try FileManager.default.url(
-                for: .applicationSupportDirectory,
-                in: .userDomainMask,
-                appropriateFor: nil,
-                create: true
-            )
-            .appendingPathComponent("Selective Remote", isDirectory: true)
-            .appendingPathComponent("Updates", isDirectory: true)
+            let cacheRoot = try defaultDownloadDirectoryURL()
             destinationURL = cacheRoot.appendingPathComponent(sourceURL.lastPathComponent)
         }
         let operation = UpdateDownloadOperation(sourceURL: sourceURL, destinationURL: destinationURL)
@@ -308,7 +308,23 @@ enum UpdateInstaller {
         return MountedSelectiveRemoteUpdate(dmgURL: dmgURL, mountURL: mountURL, appURL: appURL)
     }
 
-    static func installAndRestart(_ mounted: MountedSelectiveRemoteUpdate) throws {
+    static func defaultDownloadDirectoryURL(
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        try fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        .appendingPathComponent("Selective Remote", isDirectory: true)
+        .appendingPathComponent("Updates", isDirectory: true)
+    }
+
+    static func installAndRestart(
+        _ mounted: MountedSelectiveRemoteUpdate,
+        retention: UpdateDMGRetention
+    ) throws {
         let destination = Bundle.main.bundleURL.standardizedFileURL
         guard destination.pathExtension.lowercased() == "app" else {
             try? detach(mounted.mountURL)
@@ -334,6 +350,7 @@ SRC="$2"
 DST="$3"
 MOUNT="$4"
 DMG="$5"
+CLEANUP_DMG="$6"
 while /bin/kill -0 "$PID" 2>/dev/null; do
     /bin/sleep 0.2
 done
@@ -354,7 +371,10 @@ else
     exit 1
 fi
 /usr/bin/hdiutil detach "$MOUNT" >/dev/null 2>&1 || true
-/bin/rm -f "$DMG" "$0"
+if [ "$CLEANUP_DMG" = "1" ]; then
+    /bin/rm -f "$DMG"
+fi
+/bin/rm -f "$0"
 """#
         do {
             try script.write(to: scriptURL, atomically: true, encoding: .utf8)
@@ -370,7 +390,8 @@ fi
                 mounted.appURL.path,
                 destination.path,
                 mounted.mountURL.path,
-                mounted.dmgURL.path
+                mounted.dmgURL.path,
+                retention.removesDMG ? "1" : "0"
             ]
             process.standardOutput = FileHandle.nullDevice
             process.standardError = FileHandle.nullDevice

--- a/Tests/SelectiveRemoteTests/LocalizationAndAuxiliaryWindowsTests.swift
+++ b/Tests/SelectiveRemoteTests/LocalizationAndAuxiliaryWindowsTests.swift
@@ -64,6 +64,10 @@ func englishLocalizationCoversReportedViews() throws {
     }
 
     #expect(content.contains("case .snippets: UpdateLocalization.text"))
+    #expect(content.contains("ru: \"Центр подключений\""))
+    #expect(content.contains("case .forwarding: UpdateLocalization.text(ru: \"Туннели\""))
+    #expect(content.contains("ru: \"Журналы сессий\""))
+    #expect(content.contains("case .keychain: UpdateLocalization.text(ru: \"Связка ключей\""))
     #expect(activity.contains("en: \"Interrupted\""))
     #expect(activity.contains("localizedErrorMessage"))
     #expect(vault.contains("Label(LocalizedStringKey(title)"))

--- a/Tests/SelectiveRemoteTests/LocalizationAndAuxiliaryWindowsTests.swift
+++ b/Tests/SelectiveRemoteTests/LocalizationAndAuxiliaryWindowsTests.swift
@@ -49,6 +49,9 @@ func englishLocalizationCoversReportedViews() throws {
     let content = try repositorySource("Sources/SelectiveRemote/ContentView.swift")
     let activity = try repositorySource("Sources/SelectiveRemote/ConnectionActivity.swift")
     let vault = try repositorySource("Sources/SelectiveRemote/CredentialVaultView.swift")
+    let connectionCenter = try repositorySource("Sources/SelectiveRemote/ConnectionCenter.swift")
+    let forwarding = try repositorySource("Sources/SelectiveRemote/ForwardingManager.swift")
+    let sessionLogs = try repositorySource("Sources/SelectiveRemote/TerminalSessionLogs.swift")
 
     for key in [
         "Сниппеты",
@@ -68,6 +71,10 @@ func englishLocalizationCoversReportedViews() throws {
     #expect(content.contains("case .forwarding: UpdateLocalization.text(ru: \"Туннели\""))
     #expect(content.contains("ru: \"Журналы сессий\""))
     #expect(content.contains("case .keychain: UpdateLocalization.text(ru: \"Связка ключей\""))
+    #expect(content.contains("case .sftp: UpdateLocalization.text(ru: \"Файлы SFTP\""))
+    #expect(connectionCenter.contains("ru: \"Центр подключений\""))
+    #expect(forwarding.contains("Text(UpdateLocalization.text(ru: \"Туннели\""))
+    #expect(sessionLogs.contains("ru: \"Журналы сессий\""))
     #expect(activity.contains("en: \"Interrupted\""))
     #expect(activity.contains("localizedErrorMessage"))
     #expect(vault.contains("Label(LocalizedStringKey(title)"))

--- a/Tests/SelectiveRemoteTests/TerminalUX0250Tests.swift
+++ b/Tests/SelectiveRemoteTests/TerminalUX0250Tests.swift
@@ -36,9 +36,18 @@ struct TerminalUX0250Tests {
     @Test("Local toolbar uses SSH-sized icon controls")
     func localToolbarUsesTitle3Icons() throws {
         let local = try source("Sources/SelectiveRemote/LocalTerminalView.swift")
+        let content = try source("Sources/SelectiveRemote/ContentView.swift")
         #expect(local.contains("Image(systemName: \"clock.arrow.circlepath\")\n                    .font(.title3)"))
         #expect(local.contains("Image(systemName: \"curlybraces\")\n                    .font(.title3)"))
         #expect(local.contains("Image(systemName: \"paintpalette.fill\")\n                    .font(.title3)"))
+
+        let localDetailStart = try #require(content.range(of: "private var localTerminalDetail"))
+        let nextDetailStart = try #require(content.range(
+            of: "private var globalSFTPDetail",
+            range: localDetailStart.upperBound..<content.endIndex
+        ))
+        let localDetail = content[localDetailStart.lowerBound..<nextDetailStart.lowerBound]
+        #expect(localDetail.contains(".controlSize(.large)"))
     }
 
     @Test("Individual terminal appearance persists every setting independently")

--- a/Tests/SelectiveRemoteTests/TerminalUX0280Tests.swift
+++ b/Tests/SelectiveRemoteTests/TerminalUX0280Tests.swift
@@ -65,6 +65,7 @@ func snippetGroupAndToolbarSourceRegression() throws {
     let content = try String(contentsOf: root.appendingPathComponent("Sources/SelectiveRemote/ContentView.swift"))
     let local = try String(contentsOf: root.appendingPathComponent("Sources/SelectiveRemote/LocalTerminalView.swift"))
     let ssh = try String(contentsOf: root.appendingPathComponent("Sources/SelectiveRemote/EmbeddedTerminalView.swift"))
+    let toolbar = try String(contentsOf: root.appendingPathComponent("Sources/SelectiveRemote/TerminalToolbarStyle.swift"))
 
     #expect(snippets.contains("preferredGroupID: selectedGroupID"))
     #expect(snippets.contains("Text(\"Без группы\")"))
@@ -72,6 +73,7 @@ func snippetGroupAndToolbarSourceRegression() throws {
     #expect(content.contains("case .snippets: \"curlybraces\""))
     #expect(local.contains(".terminalToolbarContainer()"))
     #expect(ssh.contains(".terminalToolbarContainer()"))
+    #expect(!toolbar.contains(".controlSize("))
     #expect(local.contains("Image(systemName: \"curlybraces\")"))
     #expect(ssh.contains("Image(systemName: \"curlybraces\")"))
     #expect(local.contains("Button(\"Развернуть терминал\""))

--- a/Tests/SelectiveRemoteTests/UpdateExperienceTests.swift
+++ b/Tests/SelectiveRemoteTests/UpdateExperienceTests.swift
@@ -59,6 +59,7 @@ struct UpdateExperienceTests {
         let installer = try repositorySource("Sources/SelectiveRemote/UpdateInstaller.swift")
         let view = try repositorySource("Sources/SelectiveRemote/UpdateExperienceView.swift")
         let app = try repositorySource("Sources/SelectiveRemote/SelectiveRemoteApp.swift")
+        let strings = try repositorySource("Resources/en.lproj/Localizable.strings")
 
         #expect(model.contains("func downloadAvailableUpdateChoosingDestination()"))
         #expect(model.contains("let panel = NSSavePanel()"))
@@ -70,9 +71,25 @@ struct UpdateExperienceTests {
         #expect(installer.contains("destinationURL requestedDestinationURL: URL? = nil"))
         #expect(installer.contains("requestedDestinationURL.standardizedFileURL"))
         #expect(view.contains("Button(\"Сохранить DMG…\")"))
-        #expect(view.contains("не будет удалён автоматически"))
-        #expect(view.contains("Каталог автоматической загрузки"))
-        #expect(view.contains("Использовать внутренний каталог"))
+        #expect(view.contains("Пользовательский каталог · DMG сохраняется после установки"))
+        #expect(view.contains("Место автоматической загрузки"))
+        #expect(view.contains("Использовать системный каталог"))
+        #expect(model.contains("retention: downloadedUpdateUsesCustomDestination"))
+        #expect(installer.contains("if [ \"$CLEANUP_DMG\" = \"1\" ]; then"))
         #expect(app.contains("preventsClosing: model.isUpdateOperationInProgress"))
+        for key in [
+            "Автоматически загружать найденные обновления",
+            "Место автоматической загрузки",
+            "Выбрать пользовательский каталог…",
+            "Использовать системный каталог"
+        ] {
+            #expect(strings.contains("\"\(key)\" ="))
+        }
+    }
+
+    @Test("Only updater-managed DMGs are removed after installation")
+    func updateDMGRetentionPolicy() {
+        #expect(UpdateDMGRetention.removeAfterInstallation.removesDMG)
+        #expect(!UpdateDMGRetention.keepAfterInstallation.removesDMG)
     }
 }


### PR DESCRIPTION
## Summary
- restore Russian main navigation and workspace headers: Центр подключений, Подключения, Терминал, Файлы SFTP, Туннели, Сниппеты, Журналы сессий, Журнал, Диагностика, Связка ключей; SSH remains the protocol label
- keep DMG files saved to user-selected destinations after installation
- make system/custom update download modes and cleanup behavior explicit
- make Local Terminal use the same large control sizing as the global SSH workspace

## Local verification
- Terminal resource tests: 12 passed
- shell script syntax: passed
- release-notes generation: passed
- git diff checks: passed
- regression coverage verifies Local Terminal applies the same large control size as SSH

## Manual verification required
- install the final Test DMG built from commit 94133f8
- confirm all listed Russian navigation labels and workspace headers
- compare Local Terminal and SSH toolbar and tab controls at the same UI density; their heights must match
- confirm a DMG in a custom folder survives installation when a newer update is available
- confirm the system update folder removes its DMG after installation when a newer update is available

Draft only. Do not merge or release before explicit owner approval.