### PR TITLE
Cloud: add read-only staging host audit

### DIFF
--- a/cloud/STAGING-READINESS.md
+++ b/cloud/STAGING-READINESS.md
@@ -1,0 +1,45 @@
+# Closed staging readiness
+
+This milestone prepares a non-destructive inventory before choosing how Cloud
+will coexist with services already running on an Ubuntu host. It does not
+authorize deployment, firewall changes, service restarts, container removal or
+host reset.
+
+## Read-only audit
+
+Copy only the script to the target host or run it from an audited checkout:
+
+```bash
+bash cloud/scripts/audit-host-readonly.sh cloud.example.invalid
+```
+
+The optional hostname is used only for DNS resolution. The script reports:
+
+- operating system, kernel and capacity;
+- TCP/UDP listeners, with a focused 80/443 summary;
+- running Docker containers and published ports;
+- Docker network names and drivers;
+- selected reverse-proxy, container and tunnel service unit names;
+- IPv4/IPv6 resolution for the supplied hostname.
+
+It intentionally does not use `sudo`, print process environments, read `.env`
+or service configuration files, inspect container environment variables, or
+change any host state.
+
+## Handling the report
+
+Review the output before sharing it. Container names, images, public addresses
+and service names can be operationally sensitive. Store the sanitized result
+in the private continuity repository, never in a public issue or pull request.
+
+## Decision gate
+
+After reviewing the inventory, choose one deployment model:
+
+1. a dedicated staging server or IP;
+2. a reviewed shared reverse proxy on TCP 443;
+3. a temporary non-production port restricted by firewall and authentication.
+
+Do not start the bundled Caddy service while another listener owns TCP 443.
+Back up and verify recovery of existing services before any later approved
+reconfiguration.

--- a/cloud/scripts/audit-host-readonly.sh
+++ b/cloud/scripts/audit-host-readonly.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+audit_hostname="${1:-}"
+
+if [[ $# -gt 1 || "${audit_hostname}" == "--help" || "${audit_hostname}" == "-h" ]]; then
+    cat <<'USAGE'
+Usage: audit-host-readonly.sh [public-hostname]
+
+Prints a read-only Ubuntu host inventory for Selective Remote Cloud staging.
+The script does not use sudo, read environment files, or change services,
+containers, firewall rules, listeners, files, or network configuration.
+USAGE
+    [[ $# -le 1 ]] || exit 64
+    exit 0
+fi
+
+if [[ -n "${audit_hostname}" ]]; then
+    if [[ "${audit_hostname}" == -* || ${#audit_hostname} -gt 253 || ! "${audit_hostname}" =~ ^[A-Za-z0-9.-]+$ ]]; then
+        echo "Invalid public hostname" >&2
+        exit 64
+    fi
+fi
+
+section() {
+    echo
+    echo "## $1"
+}
+
+command_state() {
+    local name="$1"
+    if command -v "${name}" >/dev/null 2>&1; then
+        echo "${name}: available"
+    else
+        echo "${name}: unavailable"
+    fi
+}
+
+echo "Selective Remote Cloud read-only host audit"
+echo "Generated at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+section "Operating system"
+if [[ -r /etc/os-release ]]; then
+    # shellcheck disable=SC1091
+    source /etc/os-release
+    echo "OS: ${PRETTY_NAME:-unknown}"
+else
+    echo "OS: unknown"
+fi
+echo "Kernel: $(uname -srmo)"
+echo "Architecture: $(uname -m)"
+
+section "Capacity"
+df -hP / 2>/dev/null || true
+if command -v free >/dev/null 2>&1; then
+    free -h 2>/dev/null || true
+fi
+
+section "Audit tools"
+for tool in ss docker systemctl getent; do
+    command_state "${tool}"
+done
+
+section "Listening sockets"
+if command -v ss >/dev/null 2>&1; then
+    ss -H -lntup 2>/dev/null || true
+else
+    echo "Socket inventory unavailable: install iproute2 to provide ss."
+fi
+
+tcp_80="unknown"
+tcp_443="unknown"
+udp_443="unknown"
+if command -v ss >/dev/null 2>&1; then
+    tcp_80="available"
+    tcp_443="available"
+    udp_443="available"
+    ss -H -lnt '( sport = :80 )' 2>/dev/null | grep -q . && tcp_80="occupied"
+    ss -H -lnt '( sport = :443 )' 2>/dev/null | grep -q . && tcp_443="occupied"
+    ss -H -lnu '( sport = :443 )' 2>/dev/null | grep -q . && udp_443="occupied"
+fi
+
+section "Ingress summary"
+echo "TCP 80: ${tcp_80}"
+echo "TCP 443: ${tcp_443}"
+echo "UDP 443: ${udp_443}"
+
+section "Docker inventory"
+if command -v docker >/dev/null 2>&1; then
+    docker --version 2>/dev/null || true
+    docker ps --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}' 2>/dev/null || true
+    echo
+    docker network ls --format 'table {{.Name}}\t{{.Driver}}\t{{.Scope}}' 2>/dev/null || true
+else
+    echo "Docker is unavailable."
+fi
+
+section "Relevant running services"
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl list-units --type=service --state=running --no-pager --no-legend 2>/dev/null \
+        | awk '{print $1}' \
+        | grep -Ei '^(caddy|nginx|apache2?|docker|containerd|xray|amnezia|wg-quick|wireguard).*\.service$' \
+        || true
+else
+    echo "systemd inventory unavailable."
+fi
+
+if [[ -n "${audit_hostname}" ]]; then
+    section "Public hostname resolution"
+    if command -v getent >/dev/null 2>&1; then
+        getent ahostsv4 "${audit_hostname}" 2>/dev/null || echo "No IPv4 result."
+        getent ahostsv6 "${audit_hostname}" 2>/dev/null || echo "No IPv6 result."
+    else
+        echo "DNS inventory unavailable."
+    fi
+fi
+
+section "Result"
+if [[ "${tcp_443}" == "occupied" ]]; then
+    echo "BLOCKER: TCP 443 is occupied. Do not start the bundled standalone Caddy service."
+else
+    echo "No TCP 443 listener was detected by this audit. Recheck immediately before deployment."
+fi
+echo "This report is inventory only; no host state was changed."

--- a/cloud/tests/host-audit.test.mjs
+++ b/cloud/tests/host-audit.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(new URL("../scripts/audit-host-readonly.sh", import.meta.url));
+const guidePath = fileURLToPath(new URL("../STAGING-READINESS.md", import.meta.url));
+
+test("host audit shell is valid and limited to read-only inventory", async () => {
+  const syntax = spawnSync("bash", ["-n", scriptPath], { encoding: "utf8" });
+  assert.equal(syntax.status, 0, syntax.stderr);
+
+  const script = await readFile(scriptPath, "utf8");
+  for (const expected of ["ss -H -lntup", "docker ps --format", "docker network ls", "systemctl list-units", "getent ahostsv4"]) {
+    assert.ok(script.includes(expected), `missing inventory command: ${expected}`);
+  }
+
+  const executableSource = script
+    .replace(/cat <<'USAGE'[\s\S]*?\nUSAGE\n/, "")
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith("#"))
+    .join("\n");
+  const destructive = /\b(?:sudo|printenv|iptables|ufw\s+(?:allow|delete|reset)|docker\s+(?:stop|rm)|systemctl\s+(?:stop|restart|enable|disable)|rm\s+-|mv\s+)\b/;
+  assert.doesNotMatch(executableSource, destructive);
+  assert.doesNotMatch(executableSource, /(?:cat|source|\.)\s+[^\n]*\.env\b/);
+});
+
+test("staging guide keeps audit output private and deployment gated", async () => {
+  const guide = await readFile(guidePath, "utf8");
+  assert.match(guide, /private continuity repository/);
+  assert.match(guide, /does not\s+authorize deployment/);
+  assert.match(guide, /Do not start the bundled Caddy service/);
+});


### PR DESCRIPTION
## Purpose

Prepare the next Cloud 0.32 closed-staging milestone without touching a server or exposing secrets.

## Changes

- adds a generic read-only Ubuntu host audit;
- inventories OS/capacity, TCP/UDP listeners, Docker containers and networks, selected running services, and optional DNS resolution;
- summarizes whether TCP/UDP 443 and TCP 80 are occupied;
- explicitly avoids sudo, environment/config reads, container environment inspection and all state-changing commands;
- adds a staging-readiness guide with privacy and deployment gates;
- adds regression tests for shell syntax, required inventory commands, destructive-command absence and private report handling.

## Verification

Head: `ac43312196714e40447e1e943824ff42619e5d30`  
Tree: `8d66f2091fa7e70c072697e764e04c0b2b60041e`

- 1 commit ahead, 0 behind `main`;
- 3 new files, 203 additions;
- `bash -n`: passed;
- Cloud tests: 72/72 passed;
- `npm audit --audit-level=high`: 0 vulnerabilities;
- `git diff --check`: passed.

## Boundaries

This PR does not deploy Cloud, connect to a production host, modify firewall/listeners/services, reset a server, or change `main`. Audit output must be reviewed and stored privately.