### PR TITLE
Cloud: add guarded PostgreSQL backup and restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ DerivedData/
 .idea/
 .vscode/
 node_modules/
+cloud/backups/
 *.log
 *.swp
 *~

--- a/cloud/DEPLOY-UBUNTU.md
+++ b/cloud/DEPLOY-UBUNTU.md
@@ -11,10 +11,10 @@ must resolve to the Ubuntu host before Caddy starts certificate issuance.
 
 ## 1. Read-only preflight
 
-From a clean checkout of PR 28, run:
+From a clean reviewed checkout, run the generic audit without `sudo`:
 
 ```bash
-sudo bash cloud/scripts/preflight-ubuntu.sh
+bash cloud/scripts/audit-host-readonly.sh cloud.pastfly.ru
 ```
 
 Review the output before changing packages or firewall rules. In particular,
@@ -66,11 +66,41 @@ the certificate contact address. Configure `SMTP_HOST`, `SMTP_PORT`,
 STARTTLS; the application requires encryption and validates the server
 certificate in both modes.
 
-Keep `ALLOW_REGISTRATION=false` until email verification, password reset,
-request rate limiting and abuse protection are implemented and the complete
-flow is manually approved.
+Email verification, password reset, request rate limiting and abuse protection
+are implemented, but registration remains disabled until SMTP is configured
+and the complete browser/macOS flow is manually approved.
 
-## 4. Start and verify
+## 4. Database backup and restore drill
+
+Create a private directory outside the checkout, then run a custom-format
+backup. The script uses the PostgreSQL container environment without printing
+database credentials, validates the archive and writes a SHA-256 checksum.
+
+```bash
+sudo install -d -m 700 /var/backups/selective-remote-cloud
+bash cloud/scripts/backup-postgres.sh /var/backups/selective-remote-cloud
+```
+
+Keep at least one encrypted off-host copy under a separately controlled backup
+policy. A backup is not accepted until a restore drill succeeds on disposable
+staging infrastructure.
+
+Restore is destructive and fails unless the checksum is valid, PostgreSQL is
+running, Cloud is stopped and the exact confirmation flag is supplied:
+
+```bash
+docker compose -f cloud/compose.yaml stop cloud
+bash cloud/scripts/restore-postgres.sh --confirm-restore \
+  /var/backups/selective-remote-cloud/selective-remote-cloud-YYYYMMDDTHHMMSSZ.dump
+docker compose -f cloud/compose.yaml up -d cloud
+curl --fail --silent --show-error https://cloud.pastfly.ru/healthz
+```
+
+Do not perform the first restore drill against the only production database.
+Record only sanitized success metadata in the private continuity repository;
+never commit a dump, checksum containing a private path, or credentials.
+
+## 5. Start and verify
 
 This section is blocked on the current host until the 443 coexistence design is
 approved. Do not run the commands below while Xray owns TCP 443.
@@ -90,14 +120,14 @@ certificate, redirects HTTP to HTTPS and renews automatically. The persistent
 `caddy-data` volume contains ACME account and certificate state and must not be
 deleted during routine updates.
 
-## 5. Routine updates
+## 6. Routine updates
 
-Deploy only reviewed commits from the Cloud feature branch until v0.32 is
-approved for `main`:
+Deploy only an exact reviewed commit. For work already approved and merged,
+use `main` with fast-forward-only updates:
 
 ```bash
 git fetch origin
-git switch feature/selective-remote-cloud-v0.32.0
+git switch main
 git pull --ff-only
 docker compose -f cloud/compose.yaml build --pull
 docker compose -f cloud/compose.yaml up -d

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -18,9 +18,9 @@ cp .env.example .env
 docker compose up --build
 ```
 
-Registration is intentionally disabled in the example configuration. It must
-stay disabled on a public host until email verification and SMTP delivery are
-configured, password reset and request throttling are implemented, and the
+Registration is intentionally disabled in the example configuration. Email
+verification, password reset and request throttling are implemented, but it
+must stay disabled on a public host until SMTP delivery is configured and the
 complete flow passes manual security review. Enabling it fails closed unless
 the verification-token pepper and all SMTP settings are present. SMTP uses
 implicit TLS when `SMTP_SECURE=true`; otherwise the client requires STARTTLS
@@ -67,5 +67,6 @@ Ubuntu host. Only Caddy publishes host ports; PostgreSQL is private to the
 Compose network.
 
 See [`DEPLOY-UBUNTU.md`](DEPLOY-UBUNTU.md) for the read-only preflight, required
-ports, secret generation, first launch and verification steps. Caddy uses the
-Let’s Encrypt production ACME endpoint and renews certificates automatically.
+ports, secret generation, guarded PostgreSQL backup/restore drill, first launch
+and verification steps. Caddy uses the Let’s Encrypt production ACME endpoint
+and renews certificates automatically.

--- a/cloud/scripts/backup-postgres.sh
+++ b/cloud/scripts/backup-postgres.sh
@@ -14,6 +14,22 @@ the repository. Existing backups are never overwritten.
 USAGE
 }
 
+stat_mode() {
+    if stat -c '%a' -- "$1" >/dev/null 2>&1; then
+        stat -c '%a' -- "$1"
+    else
+        stat -f '%Lp' -- "$1"
+    fi
+}
+
+stat_owner() {
+    if stat -c '%u' -- "$1" >/dev/null 2>&1; then
+        stat -c '%u' -- "$1"
+    else
+        stat -f '%u' -- "$1"
+    fi
+}
+
 if [[ $# -eq 1 && ( "$1" == "--help" || "$1" == "-h" ) ]]; then
     usage
     exit 0
@@ -33,12 +49,12 @@ if [[ ! -d "${backup_dir}" || -L "${backup_dir}" ]]; then
     echo "Backup destination must be an existing non-symlink directory." >&2
     exit 64
 fi
-backup_dir_mode="$(stat -c '%a' -- "${backup_dir}")"
+backup_dir_mode="$(stat_mode "${backup_dir}")"
 if (( (8#${backup_dir_mode} & 077) != 0 )); then
     echo "Backup directory must not grant group or other permissions." >&2
     exit 77
 fi
-if [[ "$(stat -c '%u' -- "${backup_dir}")" != "$(id -u)" ]]; then
+if [[ "$(stat_owner "${backup_dir}")" != "$(id -u)" ]]; then
     echo "Backup directory must be owned by the current user." >&2
     exit 77
 fi

--- a/cloud/scripts/backup-postgres.sh
+++ b/cloud/scripts/backup-postgres.sh
@@ -70,8 +70,12 @@ fi
 
 temporary_backup="$(mktemp "${backup_dir}/.selective-remote-cloud.XXXXXX")"
 temporary_checksum="$(mktemp "${backup_dir}/.selective-remote-cloud-sha256.XXXXXX")"
+backup_published=false
 cleanup() {
     rm -f -- "${temporary_backup}" "${temporary_checksum}"
+    if [[ "${backup_published}" != true ]]; then
+        rm -f -- "${backup_path}" "${checksum_path}"
+    fi
 }
 trap cleanup EXIT INT TERM
 
@@ -95,6 +99,7 @@ mv -- "${temporary_backup}" "${backup_path}"
 chmod 600 "${temporary_checksum}"
 mv -- "${temporary_checksum}" "${checksum_path}"
 
+backup_published=true
 trap - EXIT INT TERM
 echo "Backup created: ${backup_path}"
 echo "Checksum created: ${checksum_path}"

--- a/cloud/scripts/backup-postgres.sh
+++ b/cloud/scripts/backup-postgres.sh
@@ -30,6 +30,17 @@ stat_owner() {
     fi
 }
 
+write_sha256() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum -- "$1"
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1"
+    else
+        echo "A SHA-256 utility is required." >&2
+        return 69
+    fi
+}
+
 if [[ $# -eq 1 && ( "$1" == "--help" || "$1" == "-h" ) ]]; then
     usage
     exit 0
@@ -110,7 +121,7 @@ mv -- "${temporary_backup}" "${backup_path}"
 
 (
     cd -- "${backup_dir}"
-    sha256sum -- "${backup_name}" > "${temporary_checksum}"
+    write_sha256 "${backup_name}" > "${temporary_checksum}"
 )
 chmod 600 "${temporary_checksum}"
 mv -- "${temporary_checksum}" "${checksum_path}"

--- a/cloud/scripts/backup-postgres.sh
+++ b/cloud/scripts/backup-postgres.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+cloud_dir="$(cd -- "${script_dir}/.." && pwd -P)"
+
+usage() {
+    cat <<'USAGE'
+Usage: backup-postgres.sh /absolute/private/backup-directory
+
+Creates a PostgreSQL custom-format backup, validates it with pg_restore, and
+writes a sibling SHA-256 checksum. The destination must already exist outside
+the repository. Existing backups are never overwritten.
+USAGE
+}
+
+if [[ $# -eq 1 && ( "$1" == "--help" || "$1" == "-h" ) ]]; then
+    usage
+    exit 0
+fi
+
+if [[ $# -ne 1 ]]; then
+    usage >&2
+    exit 64
+fi
+
+backup_dir="$1"
+if [[ "${backup_dir}" != /* ]]; then
+    echo "Backup directory must be an absolute path." >&2
+    exit 64
+fi
+if [[ ! -d "${backup_dir}" || -L "${backup_dir}" ]]; then
+    echo "Backup destination must be an existing non-symlink directory." >&2
+    exit 64
+fi
+backup_dir_mode="$(stat -c '%a' -- "${backup_dir}")"
+if (( (8#${backup_dir_mode} & 077) != 0 )); then
+    echo "Backup directory must not grant group or other permissions." >&2
+    exit 77
+fi
+if [[ "$(stat -c '%u' -- "${backup_dir}")" != "$(id -u)" ]]; then
+    echo "Backup directory must be owned by the current user." >&2
+    exit 77
+fi
+if [[ "${backup_dir}" == "${cloud_dir}" || "${backup_dir}" == "${cloud_dir}/"* ]]; then
+    echo "Backup destination must be outside the repository." >&2
+    exit 64
+fi
+if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>&1; then
+    echo "Docker Compose is required." >&2
+    exit 69
+fi
+
+compose=(docker compose --project-directory "${cloud_dir}" -f "${cloud_dir}/compose.yaml")
+if ! "${compose[@]}" exec -T postgres pg_isready >/dev/null 2>&1; then
+    echo "The Compose PostgreSQL service is not ready." >&2
+    exit 69
+fi
+
+umask 077
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+backup_name="selective-remote-cloud-${timestamp}.dump"
+backup_path="${backup_dir}/${backup_name}"
+checksum_path="${backup_path}.sha256"
+
+if [[ -e "${backup_path}" || -e "${checksum_path}" ]]; then
+    echo "Refusing to overwrite an existing backup." >&2
+    exit 73
+fi
+
+temporary_backup="$(mktemp "${backup_dir}/.selective-remote-cloud.XXXXXX")"
+temporary_checksum="$(mktemp "${backup_dir}/.selective-remote-cloud-sha256.XXXXXX")"
+cleanup() {
+    rm -f -- "${temporary_backup}" "${temporary_checksum}"
+}
+trap cleanup EXIT INT TERM
+
+"${compose[@]}" exec -T postgres sh -ceu \
+    'exec pg_dump --format=custom --compress=9 --no-owner --no-privileges --username="$POSTGRES_USER" --dbname="$POSTGRES_DB"' \
+    > "${temporary_backup}"
+
+if [[ ! -s "${temporary_backup}" ]]; then
+    echo "PostgreSQL returned an empty backup." >&2
+    exit 74
+fi
+
+"${compose[@]}" exec -T postgres pg_restore --list < "${temporary_backup}" >/dev/null
+chmod 600 "${temporary_backup}"
+mv -- "${temporary_backup}" "${backup_path}"
+
+(
+    cd -- "${backup_dir}"
+    sha256sum -- "${backup_name}" > "${temporary_checksum}"
+)
+chmod 600 "${temporary_checksum}"
+mv -- "${temporary_checksum}" "${checksum_path}"
+
+trap - EXIT INT TERM
+echo "Backup created: ${backup_path}"
+echo "Checksum created: ${checksum_path}"

--- a/cloud/scripts/restore-postgres.sh
+++ b/cloud/scripts/restore-postgres.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+cloud_dir="$(cd -- "${script_dir}/.." && pwd -P)"
+
+usage() {
+    cat <<'USAGE'
+Usage: restore-postgres.sh --confirm-restore /absolute/path/backup.dump
+
+Restores a validated custom-format backup into the Compose PostgreSQL service.
+The Cloud service must already be stopped. This operation replaces database
+objects and is intentionally blocked without the exact confirmation flag.
+USAGE
+}
+
+if [[ $# -eq 1 && ( "$1" == "--help" || "$1" == "-h" ) ]]; then
+    usage
+    exit 0
+fi
+
+if [[ $# -ne 2 || "$1" != "--confirm-restore" ]]; then
+    usage >&2
+    exit 64
+fi
+
+backup_path="$2"
+if [[ "${backup_path}" != /* || ! -f "${backup_path}" || -L "${backup_path}" ]]; then
+    echo "Backup must be an absolute path to a regular non-symlink file." >&2
+    exit 64
+fi
+checksum_path="${backup_path}.sha256"
+if [[ ! -f "${checksum_path}" || -L "${checksum_path}" ]]; then
+    echo "A regular sibling .sha256 file is required." >&2
+    exit 65
+fi
+if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>&1; then
+    echo "Docker Compose is required." >&2
+    exit 69
+fi
+
+backup_dir="$(cd -- "$(dirname -- "${backup_path}")" && pwd -P)"
+backup_name="$(basename -- "${backup_path}")"
+if [[ ! "${backup_name}" =~ ^selective-remote-cloud-[0-9]{8}T[0-9]{6}Z\.dump$ ]]; then
+    echo "Backup filename does not match the generated backup format." >&2
+    exit 65
+fi
+read -r recorded_hash recorded_name < <(awk 'NR == 1 { print $1, $2 }' "${checksum_path}")
+if [[ ! "${recorded_hash}" =~ ^[0-9a-f]{64}$ || "${recorded_name}" != "${backup_name}" ]]; then
+    echo "Checksum file does not describe the selected backup." >&2
+    exit 65
+fi
+(
+    cd -- "${backup_dir}"
+    sha256sum --check --status -- "${backup_name}.sha256"
+) || {
+    echo "Backup checksum verification failed." >&2
+    exit 65
+}
+
+compose=(docker compose --project-directory "${cloud_dir}" -f "${cloud_dir}/compose.yaml")
+running_services="$("${compose[@]}" ps --status running --services 2>/dev/null || true)"
+if grep -Fxq "cloud" <<< "${running_services}"; then
+    echo "Stop the Cloud service before restoring the database." >&2
+    exit 75
+fi
+if ! grep -Fxq "postgres" <<< "${running_services}"; then
+    echo "The PostgreSQL service must be running for restore." >&2
+    exit 69
+fi
+
+"${compose[@]}" exec -T postgres pg_restore --list < "${backup_path}" >/dev/null
+
+echo "Checksum and archive format verified; restoring database objects."
+"${compose[@]}" exec -T postgres sh -ceu \
+    'exec pg_restore --clean --if-exists --no-owner --no-privileges --exit-on-error --single-transaction --username="$POSTGRES_USER" --dbname="$POSTGRES_DB"' \
+    < "${backup_path}"
+
+echo "Restore completed. Start Cloud, verify migrations, health and application data."

--- a/cloud/scripts/restore-postgres.sh
+++ b/cloud/scripts/restore-postgres.sh
@@ -14,6 +14,17 @@ objects and is intentionally blocked without the exact confirmation flag.
 USAGE
 }
 
+calculate_sha256() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum -- "$1" | awk '{ print $1 }'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{ print $1 }'
+    else
+        echo "A SHA-256 utility is required." >&2
+        return 69
+    fi
+}
+
 if [[ $# -eq 1 && ( "$1" == "--help" || "$1" == "-h" ) ]]; then
     usage
     exit 0
@@ -39,7 +50,6 @@ if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>
     exit 69
 fi
 
-backup_dir="$(cd -- "$(dirname -- "${backup_path}")" && pwd -P)"
 backup_name="$(basename -- "${backup_path}")"
 if [[ ! "${backup_name}" =~ ^selective-remote-cloud-[0-9]{8}T[0-9]{6}Z\.dump$ ]]; then
     echo "Backup filename does not match the generated backup format." >&2
@@ -54,13 +64,14 @@ if [[ ! "${recorded_hash}" =~ ^[0-9a-f]{64}$ || "${recorded_name}" != "${backup_
     echo "Checksum file does not describe the selected backup." >&2
     exit 65
 fi
-(
-    cd -- "${backup_dir}"
-    sha256sum --check --status -- "${backup_name}.sha256"
-) || {
+actual_hash="$(calculate_sha256 "${backup_path}")" || {
+    echo "Backup checksum could not be calculated." >&2
+    exit 69
+}
+if [[ "${actual_hash}" != "${recorded_hash}" ]]; then
     echo "Backup checksum verification failed." >&2
     exit 65
-}
+fi
 
 compose=(docker compose --project-directory "${cloud_dir}" -f "${cloud_dir}/compose.yaml")
 running_services="$("${compose[@]}" ps --status running --services 2>/dev/null || true)"

--- a/cloud/scripts/restore-postgres.sh
+++ b/cloud/scripts/restore-postgres.sh
@@ -45,6 +45,10 @@ if [[ ! "${backup_name}" =~ ^selective-remote-cloud-[0-9]{8}T[0-9]{6}Z\.dump$ ]]
     echo "Backup filename does not match the generated backup format." >&2
     exit 65
 fi
+if [[ "$(wc -l < "${checksum_path}")" -ne 1 ]]; then
+    echo "Checksum file must contain exactly one record." >&2
+    exit 65
+fi
 read -r recorded_hash recorded_name < <(awk 'NR == 1 { print $1, $2 }' "${checksum_path}")
 if [[ ! "${recorded_hash}" =~ ^[0-9a-f]{64}$ || "${recorded_name}" != "${backup_name}" ]]; then
     echo "Checksum file does not describe the selected backup." >&2

--- a/cloud/tests/backup-restore.test.mjs
+++ b/cloud/tests/backup-restore.test.mjs
@@ -25,7 +25,9 @@ test("backup is private, validated and does not read or print secrets", async ()
   const script = await readFile(backupPath, "utf8");
   assert.match(script, /umask 077/);
   assert.match(script, /backup_dir_mode/);
-  assert.match(script, /stat -c '%u'/);
+  assert.match(script, /stat_mode/);
+  assert.match(script, /stat_owner/);
+  assert.match(script, /stat -f '%Lp'/);
   assert.match(script, /mktemp/);
   assert.match(script, /pg_dump --format=custom/);
   assert.match(script, /pg_restore --list/);

--- a/cloud/tests/backup-restore.test.mjs
+++ b/cloud/tests/backup-restore.test.mjs
@@ -31,7 +31,9 @@ test("backup is private, validated and does not read or print secrets", async ()
   assert.match(script, /mktemp/);
   assert.match(script, /pg_dump --format=custom/);
   assert.match(script, /pg_restore --list/);
+  assert.match(script, /write_sha256/);
   assert.match(script, /sha256sum/);
+  assert.match(script, /shasum -a 256/);
   assert.match(script, /Refusing to overwrite/);
   assert.match(script, /backup_published/);
   assert.doesNotMatch(script, /POSTGRES_PASSWORD|DATABASE_URL|\.env\b/);
@@ -40,7 +42,9 @@ test("backup is private, validated and does not read or print secrets", async ()
 test("restore fails closed around confirmation, integrity and active writes", async () => {
   const script = await readFile(restorePath, "utf8");
   assert.match(script, /--confirm-restore/);
-  assert.match(script, /sha256sum --check --status/);
+  assert.match(script, /calculate_sha256/);
+  assert.match(script, /actual_hash.*recorded_hash/);
+  assert.match(script, /shasum -a 256/);
   assert.match(script, /recorded_name.*backup_name/);
   assert.match(script, /generated backup format/);
   assert.match(script, /exactly one record/);

--- a/cloud/tests/backup-restore.test.mjs
+++ b/cloud/tests/backup-restore.test.mjs
@@ -31,6 +31,7 @@ test("backup is private, validated and does not read or print secrets", async ()
   assert.match(script, /pg_restore --list/);
   assert.match(script, /sha256sum/);
   assert.match(script, /Refusing to overwrite/);
+  assert.match(script, /backup_published/);
   assert.doesNotMatch(script, /POSTGRES_PASSWORD|DATABASE_URL|\.env\b/);
 });
 
@@ -40,6 +41,7 @@ test("restore fails closed around confirmation, integrity and active writes", as
   assert.match(script, /sha256sum --check --status/);
   assert.match(script, /recorded_name.*backup_name/);
   assert.match(script, /generated backup format/);
+  assert.match(script, /exactly one record/);
   assert.match(script, /grep -Fxq "cloud"/);
   assert.match(script, /pg_restore --list/);
   assert.match(script, /--clean --if-exists/);

--- a/cloud/tests/backup-restore.test.mjs
+++ b/cloud/tests/backup-restore.test.mjs
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
@@ -43,6 +45,61 @@ test("restore fails closed around confirmation, integrity and active writes", as
   assert.match(script, /--clean --if-exists/);
   assert.match(script, /--exit-on-error --single-transaction/);
   assert.doesNotMatch(script, /POSTGRES_PASSWORD|DATABASE_URL|\.env\b/);
+});
+
+test("backup and restore complete through a controlled Compose boundary", async () => {
+  const root = await mkdtemp(join(tmpdir(), "selective-remote-backup-test-"));
+  const binDir = join(root, "bin");
+  const backupDir = join(root, "private-backups");
+  const dockerPath = join(binDir, "docker");
+  const dockerLog = join(root, "docker.log");
+  await mkdir(binDir);
+  await mkdir(backupDir, { mode: 0o700 });
+  await writeFile(dockerPath, `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$DOCKER_LOG"
+case "$*" in
+  "compose version") exit 0 ;;
+  *"exec -T postgres pg_isready"*) exit 0 ;;
+  *"pg_dump --format=custom"*) printf 'PGDMP-controlled-test-archive' ;;
+  *"exec -T postgres pg_restore --list"*) cat >/dev/null ;;
+  *"ps --status running --services"*) printf 'postgres\\n' ;;
+  *"pg_restore --clean --if-exists"*) cat >/dev/null ;;
+  *) printf 'Unexpected docker call: %s\\n' "$*" >&2; exit 90 ;;
+esac
+`, { mode: 0o700 });
+  await chmod(dockerPath, 0o700);
+
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    DOCKER_LOG: dockerLog,
+  };
+
+  try {
+    const backup = spawnSync("bash", [backupPath, backupDir], { encoding: "utf8", env });
+    assert.equal(backup.status, 0, backup.stderr);
+
+    const entries = await readdir(backupDir);
+    const dumpName = entries.find((name) => name.endsWith(".dump"));
+    assert.ok(dumpName, "backup dump was not created");
+    assert.ok(entries.includes(`${dumpName}.sha256`), "checksum was not created");
+    assert.equal((await stat(join(backupDir, dumpName))).mode & 0o777, 0o600);
+
+    const restore = spawnSync(
+      "bash",
+      [restorePath, "--confirm-restore", join(backupDir, dumpName)],
+      { encoding: "utf8", env },
+    );
+    assert.equal(restore.status, 0, restore.stderr);
+
+    const calls = await readFile(dockerLog, "utf8");
+    assert.match(calls, /pg_dump --format=custom/);
+    assert.match(calls, /pg_restore --list/);
+    assert.match(calls, /pg_restore --clean --if-exists/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 test("deployment guide requires an off-host backup and restore drill", async () => {

--- a/cloud/tests/backup-restore.test.mjs
+++ b/cloud/tests/backup-restore.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const backupPath = fileURLToPath(new URL("../scripts/backup-postgres.sh", import.meta.url));
+const restorePath = fileURLToPath(new URL("../scripts/restore-postgres.sh", import.meta.url));
+const deploymentGuidePath = fileURLToPath(new URL("../DEPLOY-UBUNTU.md", import.meta.url));
+
+for (const [name, scriptPath] of [["backup", backupPath], ["restore", restorePath]]) {
+  test(`${name} script has valid shell syntax and help works without Docker`, () => {
+    const syntax = spawnSync("bash", ["-n", scriptPath], { encoding: "utf8" });
+    assert.equal(syntax.status, 0, syntax.stderr);
+
+    const help = spawnSync("bash", [scriptPath, "--help"], { encoding: "utf8" });
+    assert.equal(help.status, 0, help.stderr);
+    assert.match(help.stdout, /Usage:/);
+  });
+}
+
+test("backup is private, validated and does not read or print secrets", async () => {
+  const script = await readFile(backupPath, "utf8");
+  assert.match(script, /umask 077/);
+  assert.match(script, /backup_dir_mode/);
+  assert.match(script, /stat -c '%u'/);
+  assert.match(script, /mktemp/);
+  assert.match(script, /pg_dump --format=custom/);
+  assert.match(script, /pg_restore --list/);
+  assert.match(script, /sha256sum/);
+  assert.match(script, /Refusing to overwrite/);
+  assert.doesNotMatch(script, /POSTGRES_PASSWORD|DATABASE_URL|\.env\b/);
+});
+
+test("restore fails closed around confirmation, integrity and active writes", async () => {
+  const script = await readFile(restorePath, "utf8");
+  assert.match(script, /--confirm-restore/);
+  assert.match(script, /sha256sum --check --status/);
+  assert.match(script, /recorded_name.*backup_name/);
+  assert.match(script, /generated backup format/);
+  assert.match(script, /grep -Fxq "cloud"/);
+  assert.match(script, /pg_restore --list/);
+  assert.match(script, /--clean --if-exists/);
+  assert.match(script, /--exit-on-error --single-transaction/);
+  assert.doesNotMatch(script, /POSTGRES_PASSWORD|DATABASE_URL|\.env\b/);
+});
+
+test("deployment guide requires an off-host backup and restore drill", async () => {
+  const guide = await readFile(deploymentGuidePath, "utf8");
+  assert.match(guide, /off-host copy/);
+  assert.match(guide, /restore drill/);
+  assert.match(guide, /--confirm-restore/);
+  assert.match(guide, /registration remains disabled/i);
+});


### PR DESCRIPTION
## Purpose

Add a guarded PostgreSQL backup and restore procedure for the Cloud 0.32 closed-staging milestone.

## Changes

- adds a custom-format PostgreSQL backup script with private-directory checks, atomic file creation, archive validation and SHA-256 checksum;
- removes incomplete published artifacts if checksum generation fails;
- adds a restore script requiring an exact confirmation flag, one matching checksum record, stopped Cloud service and running PostgreSQL;
- performs restore with `--exit-on-error` and `--single-transaction`;
- supports GNU/BSD `stat` and Linux/macOS SHA-256 utilities so the safety path is testable on Ubuntu and macOS CI;
- prevents backup files from being stored under `cloud/backups/`;
- updates Ubuntu deployment guidance for off-host copies and a disposable restore drill;
- updates registration documentation to reflect that auth controls are implemented but public registration remains disabled pending SMTP and end-to-end review;
- adds regression tests plus a controlled fake-Compose execution of the complete backup/checksum/restore boundary.

## Verification

Head: `70f54bb2bb0a611295d6785c1468a985d58b9067`  
Tree: `42690211a051b8ddea409208d524fcf9d7a2b590`

- remote tree exactly matches the locally tested tree;
- 5 commits ahead and 0 behind `main`;
- Cloud tests: 78/78 passed;
- focused backup/restore tests: 6/6 passed;
- `npm audit --audit-level=high`: 0 vulnerabilities;
- shell syntax and `git diff --check`: passed;
- CI run 33221692458: success;
- Test DMG run 33221692554: success;
- artifact `SelectiveRemote-test-32-arm64`, id 9705490184;
- artifact SHA-256 `1986ac1232ee1114f3ef05f1221e28ddae5777382ab96173eb83fc3161bb6afd`.

## Boundaries

This PR does not contain database dumps, checksums, credentials or server output. It does not contact or modify a server and does not change `main`. The first restore drill must run on disposable staging infrastructure, never against the only production database.