### PR TITLE
Cloud: add optional 443-only staging ingress

### DIFF
--- a/cloud/Caddyfile.443-only
+++ b/cloud/Caddyfile.443-only
@@ -1,0 +1,26 @@
+{
+    email {$ACME_EMAIL}
+    auto_https disable_redirects
+}
+
+{$CLOUD_PUBLIC_HOST} {
+    tls {
+        issuer acme https://acme-v02.api.letsencrypt.org/directory {
+            email {$ACME_EMAIL}
+            disable_http_challenge
+        }
+    }
+    encode zstd gzip
+    header {
+        Strict-Transport-Security "max-age=31536000; includeSubDomains"
+        X-Content-Type-Options "nosniff"
+        X-Frame-Options "DENY"
+        Referrer-Policy "strict-origin-when-cross-origin"
+        Permissions-Policy "camera=(), microphone=(), geolocation=()"
+        -Server
+    }
+    reverse_proxy cloud:8080 {
+        header_up X-Selective-Client-IP {remote_host}
+        header_up X-Selective-Proxy-Secret {$PROXY_SHARED_SECRET}
+    }
+}

--- a/cloud/STAGING-443-ONLY.md
+++ b/cloud/STAGING-443-ONLY.md
@@ -1,0 +1,56 @@
+# Optional 443-only staging ingress
+
+Use this opt-in Compose override only when an existing, reviewed host service
+must continue to own TCP 80 and TCP 443 is available. The default deployment
+profile is unchanged.
+
+## Requirements
+
+- Docker Compose 2.24.4 or newer for the `!override` merge tag;
+- TCP 443 available immediately before launch;
+- public DNS for `CLOUD_PUBLIC_HOST` resolving to the host;
+- an ACME contact address in `ACME_EMAIL`;
+- enough memory and disk for PostgreSQL, Node.js, container images and private
+  backup/restore work;
+- public registration disabled until SMTP and the complete flow are reviewed.
+
+Hosts with only 1 GiB RAM and no swap have little failure margin. Prefer at
+least 2 GiB RAM. A smaller closed-staging host requires a separately reviewed
+swap and resource-monitoring plan before deployment.
+
+## Verify the merged model
+
+Keep secrets in the private `.env` file and set these two non-secret values:
+
+```dotenv
+CLOUD_PUBLIC_HOST=staging.example.invalid
+CLOUD_PUBLIC_ORIGIN=https://staging.example.invalid
+```
+
+Validate the exact merged model before starting it:
+
+```bash
+docker compose version
+docker compose -f compose.yaml -f compose.443-only.yaml config --quiet
+docker compose -f compose.yaml -f compose.443-only.yaml config
+```
+
+The rendered `caddy` service must publish only TCP/UDP 443 and must mount
+`Caddyfile.443-only` at `/etc/caddy/Caddyfile`. PostgreSQL and the Cloud API
+must remain unpublished.
+
+## Launch boundary
+
+Run the read-only host audit again immediately before launch. Do not stop an
+unknown TCP 443 owner. When the port is available, start the closed staging
+stack with the same ordered file pair:
+
+```bash
+docker compose -f compose.yaml -f compose.443-only.yaml build --pull
+docker compose -f compose.yaml -f compose.443-only.yaml up -d
+docker compose -f compose.yaml -f compose.443-only.yaml ps
+```
+
+This mode disables HTTP redirects and the ACME HTTP challenge. Caddy obtains
+and renews the certificate through TLS-ALPN on TCP 443. Clients and health
+checks must use an explicit `https://` URL.

--- a/cloud/compose.443-only.yaml
+++ b/cloud/compose.443-only.yaml
@@ -1,0 +1,9 @@
+services:
+  caddy:
+    environment:
+      CLOUD_PUBLIC_HOST: ${CLOUD_PUBLIC_HOST:?CLOUD_PUBLIC_HOST is required}
+    ports: !override
+      - "443:443"
+      - "443:443/udp"
+    volumes:
+      - ./Caddyfile.443-only:/etc/caddy/Caddyfile:ro

--- a/cloud/tests/request-security.test.mjs
+++ b/cloud/tests/request-security.test.mjs
@@ -43,3 +43,27 @@ test("bundled ingress overwrites and authenticates the client IP header", async 
   assert.match(compose, /PROXY_SHARED_SECRET: \$\{PROXY_SHARED_SECRET\}/);
   assert.doesNotMatch(compose, /8080:8080/);
 });
+
+test("optional 443-only ingress keeps TCP 80 with the existing host service", async () => {
+  const caddyfile = await readFile(fileURLToPath(new URL("../Caddyfile.443-only", import.meta.url)), "utf8");
+  const override = await readFile(fileURLToPath(new URL("../compose.443-only.yaml", import.meta.url)), "utf8");
+  const guide = await readFile(fileURLToPath(new URL("../STAGING-443-ONLY.md", import.meta.url)), "utf8");
+
+  assert.match(caddyfile, /\{\$CLOUD_PUBLIC_HOST\}/);
+  assert.match(caddyfile, /auto_https disable_redirects/);
+  assert.match(caddyfile, /issuer acme https:\/\/acme-v02\.api\.letsencrypt\.org\/directory/);
+  assert.match(caddyfile, /disable_http_challenge/);
+  assert.match(caddyfile, /header_up X-Selective-Client-IP \{remote_host\}/);
+  assert.match(caddyfile, /header_up X-Selective-Proxy-Secret \{\$PROXY_SHARED_SECRET\}/);
+
+  assert.match(override, /ports: !override/);
+  assert.doesNotMatch(override, /80:80/);
+  assert.match(override, /"443:443"/);
+  assert.match(override, /"443:443\/udp"/);
+  assert.match(override, /CLOUD_PUBLIC_HOST: \$\{CLOUD_PUBLIC_HOST:\?/);
+  assert.match(override, /Caddyfile\.443-only:\/etc\/caddy\/Caddyfile:ro/);
+
+  assert.match(guide, /Docker Compose 2\.24\.4 or newer/);
+  assert.match(guide, /registration disabled/i);
+  assert.doesNotMatch(guide, /cloud\.pastfly\.ru|\b\d{1,3}(?:\.\d{1,3}){3}\b/);
+});


### PR DESCRIPTION
## Summary

- add an opt-in Docker Compose override that leaves TCP 80 with an existing host service;
- add a generic Caddy configuration that publishes only TCP/UDP 443;
- disable HTTP redirects and the ACME HTTP challenge so certificate issuance uses TLS-ALPN on TCP 443;
- require Docker Compose 2.24.4+ and an explicit `CLOUD_PUBLIC_HOST`;
- add regression tests that keep the API/PostgreSQL private and prevent TCP 80 publication in the override.

The default Compose profile and production-specific deployment documentation are unchanged.

## Verification

- Cloud tests: 79/79 passed locally;
- `npm audit --omit=dev`: 0 vulnerabilities;
- `git diff --check`: passed;
- remote tree matches the locally tested tree: `558a443fbd8ae1dbab6a2f955e182ff44627c03e`.

No server change, deployment, secret, hostname, IP address or private audit report is included.

## Operator-reported configuration validation — 2026-08-31

Validated source head: `ba393deab5daa2a281e7865e3efccb62bae548d5`.

- Docker Compose 2.40.3: merged-model validation passed.
- Published ports are exactly TCP/UDP 443; the alternate Caddyfile is mounted read-only; API and PostgreSQL ports are not published.
- Placeholder-only environment keeps registration disabled.
- Caddy v2.9.1: `validate` returned `Valid configuration` and exit code 0.
- Exact image index digest: `sha256:b4e3952384eb9524a887633ce65c752dd7c71314d2c2acf98cd5c715aaa534f0`.
- Disposable validator retained network isolation, no published ports, read-only root and no-new-privileges. It used drop-all plus NET_BIND_SERVICE to satisfy the official binary's file capability.
- Caddy emitted a non-blocking whitespace-formatting warning. The reviewed source is unchanged.
- CI [33244929243](https://github.com/PastFly/Selective-Remote/actions/runs/33244929243): success.
- Test DMG [33244929239](https://github.com/PastFly/Selective-Remote/actions/runs/33244929239): success.

These results validate configuration, not deployment: no live HTTPS/ACME issuance, database migration, SMTP, backup/restore drill or end-to-end Cloud flow is established. Main merge still requires explicit Owner approval.
