### PR TITLE
Cloud: add opt-in small-host staging resource profile

### DIFF
--- a/cloud/STAGING-SMALL-HOST.md
+++ b/cloud/STAGING-SMALL-HOST.md
@@ -1,0 +1,102 @@
+# Optional small-host closed staging
+
+This profile is an experimental, opt-in budget for one operator using tiny
+synthetic records. It is not production sizing, protection against a hostile
+public workload, or permission to deploy. Leave the default profile unchanged.
+
+Apply files in this exact order from the `cloud` directory:
+
+```bash
+docker compose -f compose.yaml -f compose.443-only.yaml -f compose.small-host.yaml config --quiet
+docker compose -f compose.yaml -f compose.443-only.yaml -f compose.small-host.yaml config --format json \
+  | node scripts/validate-small-host-model.mjs
+```
+
+Use Node 22 for the checker. A generated Compose model may contain secrets;
+pipe it directly to the checker, do not paste it into chat/CI and do not commit
+it. Use a fresh private temporary directory and dummy-only `.env` when testing
+configuration before deployment. The checker prints only fixed status/budget
+metadata. Keep shell strict mode inside a child Bash, not the interactive SSH
+login shell. These commands do not start containers.
+
+## Reviewed starting budgets, not measured service capacity
+
+| Service | Memory cap | Memory + swap cap | CPU cap | PID cap |
+| --- | ---: | ---: | ---: | ---: |
+| PostgreSQL | 160 MiB | 192 MiB | 0.25 | 128 |
+| Cloud | 320 MiB | 384 MiB | 0.40 | 128 |
+| Caddy | 96 MiB | 128 MiB | 0.10 | 128 |
+
+Total caps are 576 MiB RAM, 128 MiB additional swap and 0.75 CPU. This does not
+reserve capacity for the host or neighboring workloads: review their peaks,
+not just idle usage. Docker/kernel swap-limit support must be verified before
+launch. Do not disable OOM handling or remove limits to force startup.
+
+Each service rotates JSON logs at 10 MiB with 3 files (about 90 MiB across the
+stack, plus filesystem/rotation overhead). Database storage and WAL remain
+unbounded by this profile: `max_wal_size` is a soft checkpoint target, not a
+disk quota. Retained images, build cache, database growth and private backups
+also consume disk. Do not run a broad Docker prune on a shared host.
+
+The profile uses `on-failure:3` to bound immediate crash-restart loops; it is
+not unattended availability management, and services do not automatically
+return just because the Docker daemon restarts. Inspect a failure before a
+manual restart. Never restart or reconfigure unrelated services.
+
+## Password hashing and memory
+
+The current scrypt parameters are N=131072, r=8, p=1: approximately 128 MiB
+native working memory per active calculation. The 256 MiB `maxmem` option is
+an upper bound, not the Node heap size. Do not reduce scrypt's cost parameters.
+
+`UV_THREADPOOL_SIZE=1` is set before Node starts and serializes libuv work,
+including scrypt. This also delays filesystem and DNS work; it does not bound
+the HTTP request queue. `NODE_OPTIONS=--max-old-space-size=96` limits V8 old
+space, not total RSS, native crypto allocations or Buffers. The container cap
+is the separate total-memory boundary. Registration is forced off even if
+`.env` requests otherwise.
+
+A bounded probe exercises four submitted hashes and verifications without
+weakening their parameters and prints peak RSS only:
+
+```bash
+UV_THREADPOOL_SIZE=1 NODE_OPTIONS=--max-old-space-size=96 node scripts/probe-staging-kdf.mjs
+```
+
+This is a baseline crypto probe, not an HTTP/SQL/cgroup load test. Run it first
+in the reviewed Node 22 image with the same memory/swap/CPU limits and no
+published ports. Confirm actual container limits and test service readiness,
+database initialization, migrations, single-user login and small CRUD before
+accepting these budgets. Large Vaults/concurrent uploads are outside this
+experimental profile and can still exhaust memory. Use a larger isolated host
+for broader tests or public traffic.
+
+## Launch gates and monitoring
+
+- Recheck available RAM/swap/disk and TCP/UDP 443 immediately before launch.
+- Build/pull one component at a time; runtime limits do not limit Docker builds.
+- Generate independent runtime secrets directly into an owner-only `.env`,
+  never through terminal output, chat, command arguments or git. Keep secrets
+  out of container inspection output. Do not use the validation placeholders.
+- SMTP may remain entirely unset only while registration is disabled; email
+  verification and password reset delivery are not accepted without real SMTP.
+- Apply the same three ordered profiles and project name to every later
+  operation. Prefer the default project identity derived from `cloud` so the
+  existing backup/restore scripts locate the same PostgreSQL service. They
+  currently select the base file only; a custom project name needs a separate
+  reviewed backup/restore integration before use.
+- Check Docker stats, host MemAvailable, swap pressure, filesystem space,
+  service health, OOMKilled and restart counters. Never print container Env.
+- Pause testing and stop only the Cloud stack if memory availability drops
+  below 128 MiB, root free space below 1 GiB, swap activity persists, any OOM
+  occurs, or a neighboring service degrades. These are conservative initial
+  operator thresholds, not guarantees. Preserve all database/certificate volumes.
+- Recheck image security/updates before Internet exposure; version pinning and
+  successful config validation are not a vulnerability assessment.
+- No real data until a disposable restore drill and encrypted off-host backup
+  policy are verified. No general-purpose public registration in this profile.
+
+References: [Compose service limits](https://docs.docker.com/reference/compose-file/services/),
+[Node scrypt](https://nodejs.org/docs/latest-v22.x/api/crypto.html#cryptoscryptpassword-salt-keylen-options-callback),
+[Node thread pool](https://nodejs.org/docs/latest-v22.x/api/cli.html#uv_threadpool_sizesize),
+[PostgreSQL memory settings](https://www.postgresql.org/docs/16/runtime-config-resource.html).

--- a/cloud/STAGING-SMALL-HOST.md
+++ b/cloud/STAGING-SMALL-HOST.md
@@ -6,6 +6,7 @@ public workload, or permission to deploy. Leave the default profile unchanged.
 
 On the current dedicated staging host, apply files in this exact order from
 the `cloud` directory. The PostgreSQL bind profile must appear once and last:
+Earlier three-file examples are not valid for this host and must not be reused.
 
 ```bash
 docker compose -f compose.yaml -f compose.443-only.yaml -f compose.small-host.yaml \

--- a/cloud/compose.small-host.yaml
+++ b/cloud/compose.small-host.yaml
@@ -1,0 +1,64 @@
+# Opt-in, single-user closed staging only. Apply after the 443-only override.
+# These limits do not establish production capacity or replace host monitoring.
+services:
+  postgres:
+    mem_limit: 160m
+    memswap_limit: 192m
+    cpus: 0.25
+    pids_limit: 128
+    restart: "on-failure:3"
+    command:
+      - postgres
+      - -c
+      - shared_buffers=32MB
+      - -c
+      - work_mem=1MB
+      - -c
+      - maintenance_work_mem=16MB
+      - -c
+      - autovacuum_work_mem=16MB
+      - -c
+      - autovacuum_max_workers=1
+      - -c
+      - max_connections=20
+      - -c
+      - max_parallel_workers=0
+      - -c
+      - max_parallel_workers_per_gather=0
+      - -c
+      - max_wal_size=128MB
+      - -c
+      - min_wal_size=32MB
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  cloud:
+    mem_limit: 320m
+    memswap_limit: 384m
+    cpus: 0.4
+    pids_limit: 128
+    restart: "on-failure:3"
+    environment:
+      ALLOW_REGISTRATION: "false"
+      UV_THREADPOOL_SIZE: "1"
+      NODE_OPTIONS: "--max-old-space-size=96"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  caddy:
+    mem_limit: 96m
+    memswap_limit: 128m
+    cpus: 0.1
+    pids_limit: 128
+    restart: "on-failure:3"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/cloud/scripts/probe-staging-kdf.mjs
+++ b/cloud/scripts/probe-staging-kdf.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { hashPassword, verifyPassword } from "../src/security.mjs";
+
+assert.equal(process.env.UV_THREADPOOL_SIZE, "1", "Run with UV_THREADPOOL_SIZE=1 set before Node starts");
+assert.equal(process.env.NODE_OPTIONS, "--max-old-space-size=96", "Use the reviewed staging heap limit");
+
+// Public test input only; never pass real credentials to this probe.
+const password = "closed-staging-probe-not-a-real-password";
+const hashes = await Promise.all(Array.from({ length: 4 }, () => hashPassword(password)));
+for (const hash of hashes) assert.match(hash, /^scrypt\$v=1\$N=131072,r=8,p=1\$/);
+assert.ok((await Promise.all(hashes.map(hash => verifyPassword(password, hash)))).every(Boolean));
+assert.equal(await verifyPassword("wrong-staging-test-password", hashes[0]), false);
+
+const maxRSSKiB = process.resourceUsage().maxRSS;
+assert.ok(maxRSSKiB > 0 && maxRSSKiB < 320 * 1024, "KDF probe exceeded the Cloud memory budget");
+console.log(`STAGING_KDF_PROBE_OK max-rss-kib=${maxRSSKiB}`);

--- a/cloud/scripts/validate-small-host-model.mjs
+++ b/cloud/scripts/validate-small-host-model.mjs
@@ -1,0 +1,76 @@
+import { pathToFileURL } from "node:url";
+
+const MiB = 1024 * 1024;
+const budgets = Object.freeze({
+  postgres: [160, 192, 0.25],
+  cloud: [320, 384, 0.4],
+  caddy: [96, 128, 0.1],
+});
+const postgresCommand = [
+  "postgres", "-c", "shared_buffers=32MB", "-c", "work_mem=1MB",
+  "-c", "maintenance_work_mem=16MB", "-c", "autovacuum_work_mem=16MB",
+  "-c", "autovacuum_max_workers=1", "-c", "max_connections=20",
+  "-c", "max_parallel_workers=0", "-c", "max_parallel_workers_per_gather=0",
+  "-c", "max_wal_size=128MB", "-c", "min_wal_size=32MB",
+];
+
+function bytes(value) {
+  if (typeof value === "number") return value;
+  if (typeof value !== "string") return NaN;
+  const match = /^(\d+)([kmg])?b?$/i.exec(value);
+  if (!match) return NaN;
+  return Number(match[1]) * (1024 ** ({ k: 1, m: 2, g: 3 }[match[2]?.toLowerCase()] ?? 0));
+}
+
+function requireCheck(condition, code) {
+  // Codes are fixed strings, never values from a possibly secret-bearing model.
+  if (!condition) throw new Error(code);
+}
+
+export function validateSmallHostModel(model) {
+  const services = model?.services;
+  requireCheck(services && Object.keys(services).sort().join(",") === "caddy,cloud,postgres", "unexpected_services");
+  for (const [name, [memory, combined, cpus]] of Object.entries(budgets)) {
+    const service = services[name];
+    requireCheck(bytes(service.mem_limit) === memory * MiB, `${name}_memory_limit`);
+    requireCheck(bytes(service.memswap_limit) === combined * MiB, `${name}_swap_limit`);
+    requireCheck(Number(service.cpus) === cpus, `${name}_cpu_limit`);
+    requireCheck(Number(service.pids_limit) === 128, `${name}_pids_limit`);
+    requireCheck(service.restart === "on-failure:3", `${name}_restart_policy`);
+    requireCheck(service.logging?.driver === "json-file" &&
+      service.logging.options?.["max-size"] === "10m" &&
+      service.logging.options?.["max-file"] === "3", `${name}_log_rotation`);
+    requireCheck(!service.privileged && !service.network_mode, `${name}_isolation`);
+  }
+  const env = services.cloud.environment;
+  requireCheck(env?.ALLOW_REGISTRATION === "false", "registration_must_be_disabled");
+  requireCheck(env?.UV_THREADPOOL_SIZE === "1", "one_libuv_worker_required");
+  requireCheck(env?.NODE_OPTIONS === "--max-old-space-size=96", "node_heap_limit");
+  requireCheck(JSON.stringify(services.postgres.command) === JSON.stringify(postgresCommand), "postgres_tuning");
+  requireCheck(!services.cloud.ports?.length && !services.postgres.ports?.length, "backend_ports_published");
+  const ports = services.caddy.ports;
+  requireCheck(Array.isArray(ports) && ports.length === 2 && ports.every(p =>
+    String(p.published) === "443" && String(p.target) === "443") &&
+    ports.map(p => p.protocol).sort().join(",") === "tcp,udp", "caddy_ports");
+  const mounts = services.caddy.volumes?.filter(v => v.target === "/etc/caddy/Caddyfile");
+  requireCheck(mounts?.length === 1 && mounts[0].type === "bind" && mounts[0].read_only === true &&
+    typeof mounts[0].source === "string" && mounts[0].source.endsWith("/Caddyfile.443-only"), "caddy_mount");
+  return { memoryMiB: 576, additionalSwapMiB: 128, cpus: 0.75 };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    process.stdin.setEncoding("utf8");
+    let input = "";
+    for await (const chunk of process.stdin) {
+      input += chunk;
+      if (Buffer.byteLength(input) > 1024 * 1024) throw new Error("model_too_large");
+    }
+    const result = validateSmallHostModel(JSON.parse(input));
+    console.log(`SMALL_HOST_MODEL_OK memory=${result.memoryMiB}MiB extra-swap=${result.additionalSwapMiB}MiB cpu=${result.cpus}`);
+  } catch {
+    // Do not echo JSON, environment, paths, parse errors or secrets from stdin.
+    console.error("SMALL_HOST_MODEL_INVALID: check the ordered profiles and required settings locally; do not share rendered environment values.");
+    process.exitCode = 1;
+  }
+}

--- a/cloud/tests/small-host-profile.test.mjs
+++ b/cloud/tests/small-host-profile.test.mjs
@@ -133,6 +133,7 @@ test("guide preserves operational and secret-handling boundaries", () => {
     /compose\.yaml[\s\S]*compose\.443-only\.yaml[\s\S]*compose\.small-host\.yaml[\s\S]*compose\.postgres-bind\.yaml/;
   assert.match(guide, orderedProfiles);
   assert.match(guide, /PostgreSQL bind profile must appear once and last/);
+  assert.match(guide, /Earlier three-file examples are not valid/);
   assert.match(guide, /same four ordered profiles/);
   assert.match(guide, /start-staging-guarded\.sh/);
   assert.match(guide, /runtime limits do not limit Docker builds/);

--- a/cloud/tests/small-host-profile.test.mjs
+++ b/cloud/tests/small-host-profile.test.mjs
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import { validateSmallHostModel } from "../scripts/validate-small-host-model.mjs";
+
+const cloudURL = new URL("../", import.meta.url);
+const checkerPath = fileURLToPath(new URL("scripts/validate-small-host-model.mjs", cloudURL));
+const probePath = fileURLToPath(new URL("scripts/probe-staging-kdf.mjs", cloudURL));
+const profile = await readFile(new URL("compose.small-host.yaml", cloudURL), "utf8");
+const guide = await readFile(new URL("STAGING-SMALL-HOST.md", cloudURL), "utf8");
+
+function fixture() {
+  const model = { services: {} };
+  for (const [name, memory, swap, cpus] of [
+    ["postgres", 160, 192, 0.25], ["cloud", 320, 384, 0.4], ["caddy", 96, 128, 0.1],
+  ]) {
+    model.services[name] = {
+      mem_limit: memory * 1024 * 1024, memswap_limit: swap * 1024 * 1024,
+      cpus, pids_limit: 128, restart: "on-failure:3",
+      logging: { driver: "json-file", options: { "max-size": "10m", "max-file": "3" } },
+    };
+  }
+  model.services.cloud.environment = {
+    ALLOW_REGISTRATION: "false", UV_THREADPOOL_SIZE: "1", NODE_OPTIONS: "--max-old-space-size=96",
+    SESSION_TOKEN_PEPPER: "test-secret-must-never-be-printed",
+  };
+  model.services.postgres.command = [
+    "postgres", "-c", "shared_buffers=32MB", "-c", "work_mem=1MB",
+    "-c", "maintenance_work_mem=16MB", "-c", "autovacuum_work_mem=16MB",
+    "-c", "autovacuum_max_workers=1", "-c", "max_connections=20",
+    "-c", "max_parallel_workers=0", "-c", "max_parallel_workers_per_gather=0",
+    "-c", "max_wal_size=128MB", "-c", "min_wal_size=32MB",
+  ];
+  model.services.caddy.ports = [
+    { published: "443", target: 443, protocol: "tcp" },
+    { published: "443", target: 443, protocol: "udp" },
+  ];
+  model.services.caddy.volumes = [{
+    type: "bind", source: "/private/test/Caddyfile.443-only", target: "/etc/caddy/Caddyfile", read_only: true,
+  }];
+  return model;
+}
+
+test("small-host overlay has explicit budgets without changing ingress or secrets", () => {
+  const model = fixture();
+  for (const [name, s] of Object.entries(model.services)) {
+    const block = profile.match(new RegExp(`^  ${name}:\\n([\\s\\S]*?)(?=^  [a-z]+:|$(?![\\s\\S]))`, "m"))?.[1];
+    assert.ok(block, name);
+    assert.match(block, new RegExp(`mem_limit: ${s.mem_limit / 1024 / 1024}m`));
+    assert.match(block, new RegExp(`memswap_limit: ${s.memswap_limit / 1024 / 1024}m`));
+    assert.match(block, new RegExp(`cpus: ${s.cpus}\\s`));
+    assert.match(block, /pids_limit: 128/);
+    assert.match(block, /restart: "on-failure:3"/);
+    assert.match(block, /driver: json-file/);
+    assert.match(block, /max-size: "10m"/);
+    assert.match(block, /max-file: "3"/);
+  }
+  for (const [key, value] of Object.entries(model.services.cloud.environment).slice(0, 3)) {
+    assert.ok(profile.includes(`${key}: "${value}"`));
+  }
+  for (const entry of model.services.postgres.command.filter(x => x.includes("="))) assert.ok(profile.includes(`- ${entry}`));
+  assert.doesNotMatch(profile, /ports:|volumes:|privileged:|cap_add:|image:|build:|PASSWORD|PEPPER|PROXY_SHARED_SECRET/);
+  assert.doesNotMatch(profile, /fsync|full_page_writes|synchronous_commit|oom_kill_disable/);
+});
+
+test("model checker accepts normalized bytes and Compose byte-size strings", () => {
+  assert.deepEqual(validateSmallHostModel(fixture()), { memoryMiB: 576, additionalSwapMiB: 128, cpus: 0.75 });
+  const model = fixture();
+  model.services.cloud.mem_limit = "320m";
+  model.services.cloud.memswap_limit = String(384 * 1024 * 1024);
+  validateSmallHostModel(model);
+});
+
+const invalidCases = [
+  ["extra service", m => { m.services.extra = {}; }],
+  ["unlimited memory", m => { delete m.services.cloud.mem_limit; }],
+  ["unlimited swap", m => { m.services.cloud.memswap_limit = -1; }],
+  ["no CPU cap", m => { delete m.services.caddy.cpus; }],
+  ["unlimited PIDs", m => { m.services.postgres.pids_limit = -1; }],
+  ["restart loop", m => { m.services.cloud.restart = "always"; }],
+  ["unbounded logs", m => { delete m.services.postgres.logging; }],
+  ["privileged service", m => { m.services.cloud.privileged = true; }],
+  ["host networking", m => { m.services.cloud.network_mode = "host"; }],
+  ["registration enabled", m => { m.services.cloud.environment.ALLOW_REGISTRATION = "true"; }],
+  ["parallel scrypt", m => { m.services.cloud.environment.UV_THREADPOOL_SIZE = "4"; }],
+  ["unbounded heap", m => { delete m.services.cloud.environment.NODE_OPTIONS; }],
+  ["unsafe postgres tuning", m => { m.services.postgres.command.push("-c", "fsync=off"); }],
+  ["published database", m => { m.services.postgres.ports = [{ published: "5432", target: 5432 }]; }],
+  ["published API", m => { m.services.cloud.ports = [{ published: "8080", target: 8080 }]; }],
+  ["TCP 80 exposed", m => { m.services.caddy.ports.push({ published: "80", target: 80, protocol: "tcp" }); }],
+  ["wrong Caddyfile", m => { m.services.caddy.volumes[0].source = "/private/test/Caddyfile"; }],
+  ["writable Caddyfile", m => { m.services.caddy.volumes[0].read_only = false; }],
+];
+for (const [name, change] of invalidCases) {
+  test(`model checker rejects ${name}`, () => {
+    const model = fixture();
+    change(model);
+    assert.throws(() => validateSmallHostModel(model));
+  });
+}
+
+test("checker CLI prints sanitized status only, including malformed or oversized input", () => {
+  const secret = fixture().services.cloud.environment.SESSION_TOKEN_PEPPER;
+  const invalid = fixture();
+  invalid.services.cloud.environment.ALLOW_REGISTRATION = "true";
+  for (const [input, status] of [
+    [JSON.stringify(fixture()), 0], [JSON.stringify(invalid), 1],
+    [`{"secret":"${secret}",`, 1], ["x".repeat(1024 * 1024 + 1), 1],
+  ]) {
+    const result = spawnSync(process.execPath, [checkerPath], { input, encoding: "utf8", timeout: 10_000 });
+    assert.equal(result.status, status, result.stderr);
+    assert.doesNotMatch(result.stdout + result.stderr, new RegExp(secret));
+    assert.doesNotMatch(result.stdout + result.stderr, /\/private\/test|SyntaxError|stack|SESSION_TOKEN_PEPPER/);
+    assert.match(result.stdout + result.stderr, status === 0 ? /SMALL_HOST_MODEL_OK/ : /SMALL_HOST_MODEL_INVALID/);
+  }
+});
+
+test("single-worker KDF probe preserves hashing strength within the baseline budget", { timeout: 60_000 }, t => {
+  const result = spawnSync(process.execPath, [probePath], {
+    encoding: "utf8", timeout: 55_000,
+    env: { ...process.env, UV_THREADPOOL_SIZE: "1", NODE_OPTIONS: "--max-old-space-size=96" },
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /^STAGING_KDF_PROBE_OK max-rss-kib=\d+\s*$/);
+  t.diagnostic(result.stdout.trim());
+});
+
+test("guide preserves operational and secret-handling boundaries", () => {
+  assert.match(guide, /config --format json\s*\\\n\s*\| node scripts\/validate-small-host-model\.mjs/);
+  assert.match(guide, /runtime limits do not limit Docker builds/);
+  assert.match(guide, /not a\s+disk quota/);
+  assert.match(guide, /does not bound\s+the HTTP request queue/);
+  assert.match(guide, /No real data until a disposable restore drill/);
+  assert.match(guide, /default project identity/);
+  assert.match(guide, /never through terminal output, chat, command arguments or git/);
+  assert.doesNotMatch(guide, /\b(?:\d{1,3}\.){3}\d{1,3}\b|ssh -p/);
+});


### PR DESCRIPTION
## Scope

Optional resource overlay for experimental single-operator closed staging. The default profile, application dependencies, images, secrets, ingress behavior and production sizing remain unchanged.

- Explicit per-service memory/swap/CPU/PID limits, bounded logs and crash retries.
- Registration forced off; one libuv worker and a bounded V8 heap, without weakening scrypt parameters.
- Conservative PostgreSQL memory/worker settings; durability unchanged.
- Secret-safe merged-model checker, actual KDF baseline probe and regression/operating gates.
- Current dedicated-host order is documented as `compose.yaml → compose.443-only.yaml → compose.small-host.yaml → compose.postgres-bind.yaml`; the exact storage profile must appear once and last.

## Evidence

- Base main: `fd935f1123856d5486d5e52d792fb23a20fdc9cb` (merged PR #35).
- Head: `7cec31a3ca805f7b0458b335f6507965c9e8619b`.
- Tree: `8549d5665d8ca64bf462994f778b896ac751f541`, matching the final locally tested combined tree.
- Compared with main: 4 commits ahead, 0 behind; diff remains exactly the 5 PR #34 files.
- Local Node 24.19.0: 111/111 combined Cloud tests passed. After the final documentation guard, focused small-host/storage tests passed 32/32; final KDF peak RSS 166128 KiB.
- Exact PostgreSQL bind profile SHA-256 `4b7a54d666140ed4e9a3785437315cda9026bda2753c3d13086398f37e91704a` passed the once-and-final source guard in the four-file order.
- Shell syntax and whitespace checks passed.
- The local `npm test` wrapper was intercepted by the network approval mechanism before tests started, so the equivalent Node runner was used locally. Authoritative CI then completed `npm audit` with 0 vulnerabilities.
- Authoritative Node 22/macOS CI run 33519409385 completed successfully with Cloud 111/111. Test DMG run 33519409324 completed successfully; artifact `SelectiveRemote-test-34-arm64`, id 9805254800, SHA-256 `00b0d5f255bcb0c93ab721df2c02f10437af1e47295a46303a6d337a4953397a`.

## Remaining gates

Run the exact four-file Compose render/model check and the KDF probe in the reviewed Node 22 container/cgroup on the dedicated host. Then verify actual limits, PostgreSQL initialization/migrations, readiness, tiny synthetic CRUD, shutdown/restart behavior and monitoring thresholds. Runtime limits do not constrain image builds; this profile is not public-load or production sizing.

No stack was deployed and no real credentials or data were used. Keep this preparation separate from deployment. Merging into `main` still requires fresh explicit Owner approval for the final verified head.