### PR TITLE
Cloud: guard dedicated PostgreSQL LV storage

### DIFF
--- a/cloud/POSTGRES-BIND-STAGING.md
+++ b/cloud/POSTGRES-BIND-STAGING.md
@@ -13,7 +13,9 @@ unpublished, and the existing image/security/backup gates still apply.
 - The source is a direct child of a verified mount, never the mount root.
 - Device, filesystem, writable state, ownership and mode are checked.
 - Symlink traversal and an unexpected nested mount are rejected.
-- Compose automatic source-directory creation is disabled.
+- Compose automatic source-directory creation is disabled. Because Compose
+  2.40.3 omits the explicit `false` from rendered JSON, the exact reviewed
+  storage profile is digest-checked and must be the final Compose file.
 - All services use `on-failure:3`, so Docker daemon startup does not bypass the
   operator's guarded startup path.
 - A successful preflight does not prove backup/restore or mount-loss recovery.
@@ -43,15 +45,17 @@ scripts/start-staging-guarded.sh \
   compose.postgres-bind.yaml
 ```
 
-Add other reviewed overlays after `compose.yaml` and before or after the
-storage profile as their documentation requires. The storage profile must be
-included exactly once.
+Add other reviewed overlays after `compose.yaml` and before the storage
+profile as their documentation requires. The exact storage profile must be
+included once and must always be the final Compose file.
 
 ## Acceptance before real data
 
+- The final Compose input is the exact reviewed storage profile containing
+  `create_host_path: false`; its digest is verified before storage checks.
 - Rendered model contains exactly one PostgreSQL mount at
-  `/var/lib/postgresql/data`, of type `bind`, with the reviewed source and
-  `create_host_path: false`.
+  `/var/lib/postgresql/data`, of type `bind`, with the reviewed source and no
+  unsafe bind options.
 - PostgreSQL and API ports are not published; registration is false.
 - Actual container Mounts match the reviewed model without printing Env.
 - Missing mount, wrong device/filesystem, symlink path, wrong ownership and

--- a/cloud/POSTGRES-BIND-STAGING.md
+++ b/cloud/POSTGRES-BIND-STAGING.md
@@ -1,0 +1,64 @@
+# Dedicated PostgreSQL filesystem for closed staging
+
+This optional profile replaces the default Docker-managed `postgres-data`
+volume with an explicit host bind. It is intended for a host where PostgreSQL
+has a separately mounted filesystem. It does not change the default profile.
+
+The profile is not a backup, HA, disk-resize procedure or permission to expose
+the service. Registration must remain disabled, PostgreSQL/API ports must stay
+unpublished, and the existing image/security/backup gates still apply.
+
+## Safety model
+
+- The source is a direct child of a verified mount, never the mount root.
+- Device, filesystem, writable state, ownership and mode are checked.
+- Symlink traversal and an unexpected nested mount are rejected.
+- Compose automatic source-directory creation is disabled.
+- All services use `on-failure:3`, so Docker daemon startup does not bypass the
+  operator's guarded startup path.
+- A successful preflight does not prove backup/restore or mount-loss recovery.
+
+## Preparation sequence
+
+1. Select and review the immutable PostgreSQL image/digest. Pull it before the
+   storage step; do not combine storage preparation with a major upgrade.
+2. Determine the numeric `postgres` UID/GID from that exact image using an
+   isolated, no-network inspection. Record the image digest and IDs privately.
+3. Export the six non-secret `POSTGRES_DATA_*` values documented by
+   `scripts/validate-postgres-storage.sh --help`.
+4. Run `validate-postgres-storage.sh --prepare` once. It creates only a missing
+   direct-child directory after all mount checks pass. It never recursively
+   changes the mount root.
+5. Use `start-staging-guarded.sh` for every allowed start. Put the storage
+   profile after `compose.yaml` so `!override` replaces the named volume.
+   The wrapper parses the rendered model without printing it and refuses to
+   start unless the bind, restart policy, closed registration and unpublished
+   PostgreSQL/API ports match the contract.
+
+Example order for a new host with ordinary 80/443 ingress:
+
+```bash
+scripts/start-staging-guarded.sh \
+  compose.yaml \
+  compose.postgres-bind.yaml
+```
+
+Add other reviewed overlays after `compose.yaml` and before or after the
+storage profile as their documentation requires. The storage profile must be
+included exactly once.
+
+## Acceptance before real data
+
+- Rendered model contains exactly one PostgreSQL mount at
+  `/var/lib/postgresql/data`, of type `bind`, with the reviewed source and
+  `create_host_path: false`.
+- PostgreSQL and API ports are not published; registration is false.
+- Actual container Mounts match the reviewed model without printing Env.
+- Missing mount, wrong device/filesystem, symlink path, wrong ownership and
+  missing data path all fail before Compose starts.
+- A controlled reboot test shows containers do not auto-start around the guard.
+- Backup and restore helpers are tested with the exact final Compose project and
+  ordered overlays; an encrypted off-host copy and isolated restore are proven.
+
+Never test mount loss by unmounting a live database. Use disposable fixtures and
+synthetic data until the lifecycle and recovery procedure are accepted.

--- a/cloud/compose.postgres-bind.yaml
+++ b/cloud/compose.postgres-bind.yaml
@@ -1,0 +1,17 @@
+# Opt-in staging storage profile. The host path must be prepared and verified
+# by scripts/validate-postgres-storage.sh before this file is applied.
+services:
+  postgres:
+    restart: "on-failure:3"
+    volumes: !override
+      - type: bind
+        source: ${POSTGRES_DATA_HOST_PATH:?POSTGRES_DATA_HOST_PATH is required}
+        target: /var/lib/postgresql/data
+        bind:
+          create_host_path: false
+
+  cloud:
+    restart: "on-failure:3"
+
+  caddy:
+    restart: "on-failure:3"

--- a/cloud/scripts/start-staging-guarded.sh
+++ b/cloud/scripts/start-staging-guarded.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+cloud_dir="$(cd -- "${script_dir}/.." && pwd -P)"
+
+usage() {
+    cat <<'USAGE'
+Usage: start-staging-guarded.sh COMPOSE_FILE [COMPOSE_FILE ...]
+
+Runs the PostgreSQL storage preflight, validates the merged Compose model and
+then starts the supplied ordered Compose files. All POSTGRES_DATA_* settings
+required by validate-postgres-storage.sh must already be exported.
+
+Example:
+  scripts/start-staging-guarded.sh \
+    compose.yaml compose.443-only.yaml compose.postgres-bind.yaml
+USAGE
+}
+
+if [[ $# -eq 1 && ( "$1" == "--help" || "$1" == "-h" ) ]]; then
+    usage
+    exit 0
+fi
+if [[ $# -lt 1 ]]; then
+    usage >&2
+    exit 64
+fi
+
+compose=(docker compose --project-directory "${cloud_dir}")
+for compose_file in "$@"; do
+    if [[ "${compose_file}" == /* ]]; then
+        resolved_file="${compose_file}"
+    else
+        resolved_file="${cloud_dir}/${compose_file}"
+    fi
+    if [[ ! -f "${resolved_file}" || -L "${resolved_file}" ]]; then
+        echo "Compose file must be an existing non-symlink file: ${compose_file}" >&2
+        exit 64
+    fi
+    compose+=( -f "${resolved_file}" )
+done
+
+"${script_dir}/validate-postgres-storage.sh" --check
+"${compose[@]}" config --quiet
+"${compose[@]}" config --format json | node "${script_dir}/validate-postgres-bind-model.mjs"
+exec "${compose[@]}" up -d

--- a/cloud/scripts/start-staging-guarded.sh
+++ b/cloud/scripts/start-staging-guarded.sh
@@ -28,6 +28,7 @@ if [[ $# -lt 1 ]]; then
 fi
 
 compose=(docker compose --project-directory "${cloud_dir}")
+compose_files=()
 for compose_file in "$@"; do
     if [[ "${compose_file}" == /* ]]; then
         resolved_file="${compose_file}"
@@ -39,8 +40,10 @@ for compose_file in "$@"; do
         exit 64
     fi
     compose+=( -f "${resolved_file}" )
+    compose_files+=( "${resolved_file}" )
 done
 
+node "${script_dir}/validate-postgres-bind-source.mjs" "${compose_files[@]}"
 "${script_dir}/validate-postgres-storage.sh" --check
 "${compose[@]}" config --quiet
 "${compose[@]}" config --format json | node "${script_dir}/validate-postgres-bind-model.mjs"

--- a/cloud/scripts/validate-postgres-bind-model.mjs
+++ b/cloud/scripts/validate-postgres-bind-model.mjs
@@ -1,0 +1,43 @@
+import process from "node:process";
+
+const expectedSource = process.env.POSTGRES_DATA_HOST_PATH;
+if (!expectedSource) {
+  throw new Error("POSTGRES_DATA_HOST_PATH is required for model validation");
+}
+
+let input = "";
+for await (const chunk of process.stdin) input += chunk;
+const model = JSON.parse(input);
+const services = model.services ?? {};
+const postgres = services.postgres;
+if (!postgres) throw new Error("Rendered model has no postgres service");
+
+const pgDataMounts = (postgres.volumes ?? []).filter(
+  (mount) => mount.target === "/var/lib/postgresql/data",
+);
+if (pgDataMounts.length !== 1) {
+  throw new Error("Rendered model must have exactly one PostgreSQL data mount");
+}
+const mount = pgDataMounts[0];
+if (mount.type !== "bind" || mount.source !== expectedSource) {
+  throw new Error("Rendered PostgreSQL data mount is not the reviewed bind source");
+}
+if (mount.bind?.create_host_path !== false) {
+  throw new Error("Rendered PostgreSQL bind must disable host path creation");
+}
+
+for (const name of ["postgres", "cloud", "caddy"]) {
+  if (services[name]?.restart !== "on-failure:3") {
+    throw new Error(`${name} must use the guarded on-failure restart policy`);
+  }
+}
+for (const name of ["postgres", "cloud"]) {
+  if ((services[name]?.ports ?? []).length !== 0) {
+    throw new Error(`${name} must not publish ports`);
+  }
+}
+if (String(services.cloud?.environment?.ALLOW_REGISTRATION) !== "false") {
+  throw new Error("Closed staging must keep registration disabled");
+}
+
+process.stdout.write("POSTGRES_BIND_MODEL_OK: storage and startup policy verified\n");

--- a/cloud/scripts/validate-postgres-bind-model.mjs
+++ b/cloud/scripts/validate-postgres-bind-model.mjs
@@ -22,8 +22,20 @@ const mount = pgDataMounts[0];
 if (mount.type !== "bind" || mount.source !== expectedSource) {
   throw new Error("Rendered PostgreSQL data mount is not the reviewed bind source");
 }
-if (mount.bind?.create_host_path !== false) {
-  throw new Error("Rendered PostgreSQL bind must disable host path creation");
+const bindOptions = mount.bind;
+const bindKeys =
+  bindOptions !== null &&
+  typeof bindOptions === "object" &&
+  !Array.isArray(bindOptions)
+    ? Object.keys(bindOptions)
+    : null;
+if (
+  bindKeys === null ||
+  bindKeys.some((key) => key !== "create_host_path") ||
+  (Object.hasOwn(bindOptions, "create_host_path") &&
+    bindOptions.create_host_path !== false)
+) {
+  throw new Error("Rendered PostgreSQL mount has unsafe bind options");
 }
 
 for (const name of ["postgres", "cloud", "caddy"]) {

--- a/cloud/scripts/validate-postgres-bind-source.mjs
+++ b/cloud/scripts/validate-postgres-bind-source.mjs
@@ -1,0 +1,33 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import process from "node:process";
+
+const expectedDigest =
+  "4b7a54d666140ed4e9a3785437315cda9026bda2753c3d13086398f37e91704a";
+const composeFiles = process.argv.slice(2);
+if (composeFiles.length === 0) {
+  throw new Error("At least one Compose file is required for source validation");
+}
+
+const digests = await Promise.all(
+  composeFiles.map(async (path) => {
+    const content = await readFile(path);
+    return createHash("sha256").update(content).digest("hex");
+  }),
+);
+const matches = digests
+  .map((digest, index) => (digest === expectedDigest ? index : -1))
+  .filter((index) => index >= 0);
+
+if (matches.length !== 1) {
+  throw new Error(
+    "Compose inputs must contain exactly one exact reviewed PostgreSQL bind profile",
+  );
+}
+if (matches[0] !== composeFiles.length - 1) {
+  throw new Error("The reviewed PostgreSQL bind profile must be the final Compose file");
+}
+
+process.stdout.write(
+  "POSTGRES_BIND_SOURCE_OK: exact reviewed storage profile is final\n",
+);

--- a/cloud/scripts/validate-postgres-storage.sh
+++ b/cloud/scripts/validate-postgres-storage.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage: validate-postgres-storage.sh --check|--prepare
+
+Required environment (non-secret):
+  POSTGRES_DATA_MOUNT_ROOT       dedicated mounted filesystem root
+  POSTGRES_DATA_HOST_PATH        direct child used as PostgreSQL data directory
+  POSTGRES_DATA_EXPECTED_SOURCE  expected block/LVM device path
+  POSTGRES_DATA_EXPECTED_FSTYPE  expected filesystem type, for example ext4
+  POSTGRES_DATA_UID              numeric postgres UID from the reviewed image
+  POSTGRES_DATA_GID              numeric postgres GID from the reviewed image
+
+--check validates an already prepared path without changing it.
+--prepare creates only the missing direct-child data directory after every
+mount/device/filesystem check passes. It refuses existing wrong ownership and
+never changes the mount root recursively.
+USAGE
+}
+
+if [[ $# -eq 1 && ( "$1" == "--help" || "$1" == "-h" ) ]]; then
+    usage
+    exit 0
+fi
+if [[ $# -ne 1 || ( "$1" != "--check" && "$1" != "--prepare" ) ]]; then
+    usage >&2
+    exit 64
+fi
+mode="$1"
+
+required=(
+    POSTGRES_DATA_MOUNT_ROOT
+    POSTGRES_DATA_HOST_PATH
+    POSTGRES_DATA_EXPECTED_SOURCE
+    POSTGRES_DATA_EXPECTED_FSTYPE
+    POSTGRES_DATA_UID
+    POSTGRES_DATA_GID
+)
+for name in "${required[@]}"; do
+    if [[ -z "${!name:-}" ]]; then
+        echo "Missing required setting: ${name}" >&2
+        exit 64
+    fi
+done
+
+mount_root="${POSTGRES_DATA_MOUNT_ROOT%/}"
+data_path="${POSTGRES_DATA_HOST_PATH%/}"
+expected_source="${POSTGRES_DATA_EXPECTED_SOURCE}"
+expected_fstype="${POSTGRES_DATA_EXPECTED_FSTYPE}"
+expected_uid="${POSTGRES_DATA_UID}"
+expected_gid="${POSTGRES_DATA_GID}"
+
+if [[ "${mount_root}" != /* || "${data_path}" != /* || "${expected_source}" != /* ]]; then
+    echo "Mount root, data path and expected source must be absolute." >&2
+    exit 64
+fi
+if [[ "${mount_root}" == "/" || "${data_path}" == "/" ]]; then
+    echo "Root filesystem paths are not valid PostgreSQL storage targets." >&2
+    exit 64
+fi
+if [[ "$(dirname -- "${data_path}")" != "${mount_root}" ]]; then
+    echo "PostgreSQL data path must be a direct child of the mount root." >&2
+    exit 64
+fi
+if [[ ! "${expected_uid}" =~ ^[0-9]+$ || ! "${expected_gid}" =~ ^[0-9]+$ ]]; then
+    echo "PostgreSQL UID and GID must be numeric." >&2
+    exit 64
+fi
+if [[ ! -d "${mount_root}" || -L "${mount_root}" ]]; then
+    echo "Mount root must be an existing non-symlink directory." >&2
+    exit 72
+fi
+if [[ "$(readlink -f -- "${mount_root}")" != "${mount_root}" ]]; then
+    echo "Mount root must not traverse symlinks." >&2
+    exit 72
+fi
+if ! mountpoint -q -- "${mount_root}"; then
+    echo "Dedicated PostgreSQL filesystem is not mounted." >&2
+    exit 72
+fi
+
+actual_target="$(findmnt -nr -M "${mount_root}" -o TARGET)"
+actual_source="$(findmnt -nr -M "${mount_root}" -o SOURCE)"
+actual_fstype="$(findmnt -nr -M "${mount_root}" -o FSTYPE)"
+actual_options="$(findmnt -nr -M "${mount_root}" -o OPTIONS)"
+if [[ "${actual_target}" != "${mount_root}" ]]; then
+    echo "Mount lookup did not resolve to the exact mount root." >&2
+    exit 72
+fi
+if [[ "${actual_fstype}" != "${expected_fstype}" ]]; then
+    echo "PostgreSQL filesystem type does not match the reviewed value." >&2
+    exit 72
+fi
+case ",${actual_options}," in
+    *,rw,*) ;;
+    *) echo "PostgreSQL filesystem is not writable." >&2; exit 72 ;;
+esac
+
+resolved_actual_source="$(readlink -f -- "${actual_source}")"
+resolved_expected_source="$(readlink -f -- "${expected_source}")"
+if [[ -z "${resolved_actual_source}" || "${resolved_actual_source}" != "${resolved_expected_source}" ]]; then
+    echo "Mounted PostgreSQL device does not match the reviewed source." >&2
+    exit 72
+fi
+
+if [[ -L "${data_path}" ]]; then
+    echo "PostgreSQL data path must not be a symlink." >&2
+    exit 72
+fi
+if [[ ! -e "${data_path}" ]]; then
+    if [[ "${mode}" != "--prepare" ]]; then
+        echo "PostgreSQL data path is missing; run explicit preparation first." >&2
+        exit 72
+    fi
+    if [[ "${EUID}" -ne 0 ]]; then
+        echo "Preparation must run as root." >&2
+        exit 77
+    fi
+    install -d -m 0700 -o "${expected_uid}" -g "${expected_gid}" -- "${data_path}"
+fi
+if [[ ! -d "${data_path}" || -L "${data_path}" ]]; then
+    echo "PostgreSQL data path must be a non-symlink directory." >&2
+    exit 72
+fi
+if [[ "$(readlink -f -- "${data_path}")" != "${data_path}" ]]; then
+    echo "PostgreSQL data path must not traverse symlinks." >&2
+    exit 72
+fi
+if [[ "$(findmnt -nr -T "${data_path}" -o TARGET)" != "${mount_root}" ]]; then
+    echo "PostgreSQL data path is not on the reviewed mount." >&2
+    exit 72
+fi
+if [[ "$(stat -c '%d' -- "${data_path}")" != "$(stat -c '%d' -- "${mount_root}")" ]]; then
+    echo "PostgreSQL data path is on a different filesystem." >&2
+    exit 72
+fi
+if [[ "$(stat -c '%u' -- "${data_path}")" != "${expected_uid}" || \
+      "$(stat -c '%g' -- "${data_path}")" != "${expected_gid}" ]]; then
+    echo "PostgreSQL data path ownership does not match the reviewed image." >&2
+    exit 77
+fi
+if [[ "$(stat -c '%a' -- "${data_path}")" != "700" ]]; then
+    echo "PostgreSQL data path mode must be 0700." >&2
+    exit 77
+fi
+
+echo "POSTGRES_STORAGE_OK: reviewed mount and data path are ready"

--- a/cloud/scripts/validate-postgres-storage.sh
+++ b/cloud/scripts/validate-postgres-storage.sh
@@ -20,6 +20,38 @@ never changes the mount root recursively.
 USAGE
 }
 
+stat_device() {
+    if stat -c '%d' -- "$1" >/dev/null 2>&1; then
+        stat -c '%d' -- "$1"
+    else
+        stat -f '%d' -- "$1"
+    fi
+}
+
+stat_uid() {
+    if stat -c '%u' -- "$1" >/dev/null 2>&1; then
+        stat -c '%u' -- "$1"
+    else
+        stat -f '%u' -- "$1"
+    fi
+}
+
+stat_gid() {
+    if stat -c '%g' -- "$1" >/dev/null 2>&1; then
+        stat -c '%g' -- "$1"
+    else
+        stat -f '%g' -- "$1"
+    fi
+}
+
+stat_mode() {
+    if stat -c '%a' -- "$1" >/dev/null 2>&1; then
+        stat -c '%a' -- "$1"
+    else
+        stat -f '%Lp' -- "$1"
+    fi
+}
+
 if [[ $# -eq 1 && ( "$1" == "--help" || "$1" == "-h" ) ]]; then
     usage
     exit 0
@@ -132,16 +164,16 @@ if [[ "$(findmnt -nr -T "${data_path}" -o TARGET)" != "${mount_root}" ]]; then
     echo "PostgreSQL data path is not on the reviewed mount." >&2
     exit 72
 fi
-if [[ "$(stat -c '%d' -- "${data_path}")" != "$(stat -c '%d' -- "${mount_root}")" ]]; then
+if [[ "$(stat_device "${data_path}")" != "$(stat_device "${mount_root}")" ]]; then
     echo "PostgreSQL data path is on a different filesystem." >&2
     exit 72
 fi
-if [[ "$(stat -c '%u' -- "${data_path}")" != "${expected_uid}" || \
-      "$(stat -c '%g' -- "${data_path}")" != "${expected_gid}" ]]; then
+if [[ "$(stat_uid "${data_path}")" != "${expected_uid}" || \
+      "$(stat_gid "${data_path}")" != "${expected_gid}" ]]; then
     echo "PostgreSQL data path ownership does not match the reviewed image." >&2
     exit 77
 fi
-if [[ "$(stat -c '%a' -- "${data_path}")" != "700" ]]; then
+if [[ "$(stat_mode "${data_path}")" != "700" ]]; then
     echo "PostgreSQL data path mode must be 0700." >&2
     exit 77
 fi

--- a/cloud/tests/postgres-bind-profile.test.mjs
+++ b/cloud/tests/postgres-bind-profile.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -44,7 +44,10 @@ test("guarded starter validates before Compose config and start", async () => {
 });
 
 async function makeFixture() {
-  const root = await mkdtemp(join(tmpdir(), "sr-pg-storage-"));
+  // macOS exposes /var through /private/var. Canonicalize the fixture root so
+  // the test does not manufacture a path that our production symlink guard is
+  // specifically expected to reject.
+  const root = await realpath(await mkdtemp(join(tmpdir(), "sr-pg-storage-")));
   const bin = join(root, "bin");
   const mountRoot = join(root, "postgres-mount");
   const dataPath = join(mountRoot, "selective-remote");

--- a/cloud/tests/postgres-bind-profile.test.mjs
+++ b/cloud/tests/postgres-bind-profile.test.mjs
@@ -1,0 +1,212 @@
+import assert from "node:assert/strict";
+import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const composePath = fileURLToPath(new URL("../compose.postgres-bind.yaml", import.meta.url));
+const validatorPath = fileURLToPath(new URL("../scripts/validate-postgres-storage.sh", import.meta.url));
+const modelValidatorPath = fileURLToPath(new URL("../scripts/validate-postgres-bind-model.mjs", import.meta.url));
+const starterPath = fileURLToPath(new URL("../scripts/start-staging-guarded.sh", import.meta.url));
+const guidePath = fileURLToPath(new URL("../POSTGRES-BIND-STAGING.md", import.meta.url));
+
+test("storage scripts have valid shell syntax and safe help", () => {
+  for (const path of [validatorPath, starterPath]) {
+    const syntax = spawnSync("bash", ["-n", path], { encoding: "utf8" });
+    assert.equal(syntax.status, 0, syntax.stderr);
+    const help = spawnSync("bash", [path, "--help"], { encoding: "utf8" });
+    assert.equal(help.status, 0, help.stderr);
+    assert.match(help.stdout, /Usage:/);
+  }
+});
+
+test("Compose profile replaces the PG volume and disables daemon auto-start", async () => {
+  const source = await readFile(composePath, "utf8");
+  assert.match(source, /volumes:\s*!override/);
+  assert.match(source, /POSTGRES_DATA_HOST_PATH:\?POSTGRES_DATA_HOST_PATH is required/);
+  assert.match(source, /target: \/var\/lib\/postgresql\/data/);
+  assert.match(source, /create_host_path: false/);
+  assert.equal((source.match(/restart: "on-failure:3"/g) || []).length, 3);
+  assert.doesNotMatch(source, /5432:|8080:/);
+});
+
+test("guarded starter validates before Compose config and start", async () => {
+  const source = await readFile(starterPath, "utf8");
+  const guard = source.indexOf('validate-postgres-storage.sh" --check');
+  const config = source.indexOf("config --quiet");
+  const model = source.indexOf("validate-postgres-bind-model.mjs");
+  const start = source.indexOf("up -d");
+  assert.ok(guard >= 0 && guard < config && config < model && model < start);
+  assert.match(source, /--project-directory/);
+  assert.doesNotMatch(source, /\.env|POSTGRES_PASSWORD|DATABASE_URL/);
+});
+
+async function makeFixture() {
+  const root = await mkdtemp(join(tmpdir(), "sr-pg-storage-"));
+  const bin = join(root, "bin");
+  const mountRoot = join(root, "postgres-mount");
+  const dataPath = join(mountRoot, "selective-remote");
+  const sourceDevice = join(root, "expected-device");
+  await mkdir(bin);
+  await mkdir(mountRoot);
+  await mkdir(dataPath, { mode: 0o700 });
+  await writeFile(sourceDevice, "fixture");
+
+  await writeFile(join(bin, "mountpoint"), "#!/usr/bin/env bash\nexit 0\n", { mode: 0o700 });
+  await writeFile(join(bin, "findmnt"), `#!/usr/bin/env bash
+set -euo pipefail
+case " $* " in
+  *" -o TARGET "*) printf '%s\\n' "$MOCK_MOUNT_ROOT" ;;
+  *" -o SOURCE "*) printf '%s\\n' "$MOCK_SOURCE" ;;
+  *" -o FSTYPE "*) printf '%s\\n' "\${MOCK_FSTYPE:-ext4}" ;;
+  *" -o OPTIONS "*) printf 'rw,relatime\\n' ;;
+  *) exit 64 ;;
+esac
+`, { mode: 0o700 });
+  await chmod(join(bin, "findmnt"), 0o700);
+
+  return { root, bin, mountRoot, dataPath, sourceDevice };
+}
+
+function validatorEnv(fixture, overrides = {}) {
+  return {
+    ...process.env,
+    PATH: `${fixture.bin}:${process.env.PATH}`,
+    MOCK_MOUNT_ROOT: fixture.mountRoot,
+    MOCK_SOURCE: fixture.sourceDevice,
+    MOCK_FSTYPE: "ext4",
+    POSTGRES_DATA_MOUNT_ROOT: fixture.mountRoot,
+    POSTGRES_DATA_HOST_PATH: fixture.dataPath,
+    POSTGRES_DATA_EXPECTED_SOURCE: fixture.sourceDevice,
+    POSTGRES_DATA_EXPECTED_FSTYPE: "ext4",
+    POSTGRES_DATA_UID: String(process.getuid()),
+    POSTGRES_DATA_GID: String(process.getgid()),
+    ...overrides,
+  };
+}
+
+test("validator accepts an exact reviewed fixture", async () => {
+  const fixture = await makeFixture();
+  try {
+    const result = spawnSync("bash", [validatorPath, "--check"], {
+      encoding: "utf8",
+      env: validatorEnv(fixture),
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /POSTGRES_STORAGE_OK/);
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("validator rejects an absent mount and unexpected filesystem", async () => {
+  const fixture = await makeFixture();
+  try {
+    await writeFile(join(fixture.bin, "mountpoint"), `#!/usr/bin/env bash
+if [[ "\${MOCK_MOUNTED:-yes}" == yes ]]; then exit 0; fi
+exit 1
+`, { mode: 0o700 });
+    let result = spawnSync("bash", [validatorPath, "--check"], {
+      encoding: "utf8",
+      env: validatorEnv(fixture, { MOCK_MOUNTED: "no" }),
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /is not mounted/);
+
+    result = spawnSync("bash", [validatorPath, "--check"], {
+      encoding: "utf8",
+      env: validatorEnv(fixture, { MOCK_MOUNTED: "yes", MOCK_FSTYPE: "xfs" }),
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /filesystem type does not match/);
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("rendered-model validator accepts only the exact bind contract", () => {
+  const source = "/srv/postgres/selective-remote";
+  const valid = {
+    services: {
+      postgres: {
+        restart: "on-failure:3",
+        ports: [],
+        volumes: [{
+          type: "bind",
+          source,
+          target: "/var/lib/postgresql/data",
+          bind: { create_host_path: false },
+        }],
+      },
+      cloud: {
+        restart: "on-failure:3",
+        ports: [],
+        environment: { ALLOW_REGISTRATION: "false" },
+      },
+      caddy: { restart: "on-failure:3" },
+    },
+  };
+  let result = spawnSync("node", [modelValidatorPath], {
+    encoding: "utf8",
+    input: JSON.stringify(valid),
+    env: { ...process.env, POSTGRES_DATA_HOST_PATH: source },
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /POSTGRES_BIND_MODEL_OK/);
+
+  const unsafe = structuredClone(valid);
+  unsafe.services.postgres.volumes[0].bind.create_host_path = true;
+  result = spawnSync("node", [modelValidatorPath], {
+    encoding: "utf8",
+    input: JSON.stringify(unsafe),
+    env: { ...process.env, POSTGRES_DATA_HOST_PATH: source },
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /disable host path creation/);
+});
+
+test("validator rejects wrong device, missing path and symlink path", async () => {
+  const fixture = await makeFixture();
+  try {
+    const wrongDevice = join(fixture.root, "wrong-device");
+    await writeFile(wrongDevice, "wrong");
+    let result = spawnSync("bash", [validatorPath, "--check"], {
+      encoding: "utf8",
+      env: validatorEnv(fixture, { POSTGRES_DATA_EXPECTED_SOURCE: wrongDevice }),
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /device does not match/);
+
+    const missing = join(fixture.mountRoot, "missing");
+    result = spawnSync("bash", [validatorPath, "--check"], {
+      encoding: "utf8",
+      env: validatorEnv(fixture, { POSTGRES_DATA_HOST_PATH: missing }),
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /data path is missing/);
+
+    const target = join(fixture.mountRoot, "real-target");
+    const link = join(fixture.mountRoot, "linked-target");
+    await mkdir(target, { mode: 0o700 });
+    await symlink(target, link);
+    result = spawnSync("bash", [validatorPath, "--check"], {
+      encoding: "utf8",
+      env: validatorEnv(fixture, { POSTGRES_DATA_HOST_PATH: link }),
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /must not be a symlink/);
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("guide preserves mount, backup and no-live-unmount gates", async () => {
+  const guide = await readFile(guidePath, "utf8");
+  assert.match(guide, /direct child of a verified mount/);
+  assert.match(guide, /automatic source-directory creation is disabled/);
+  assert.match(guide, /do not auto-start around the guard/);
+  assert.match(guide, /encrypted off-host copy/);
+  assert.match(guide, /Never test mount loss by unmounting a live database/);
+});

--- a/cloud/tests/postgres-bind-profile.test.mjs
+++ b/cloud/tests/postgres-bind-profile.test.mjs
@@ -20,6 +20,13 @@ test("storage scripts have valid shell syntax and safe help", () => {
     assert.equal(help.status, 0, help.stderr);
     assert.match(help.stdout, /Usage:/);
   }
+  const validator = readFile(validatorPath, "utf8");
+  return validator.then((source) => {
+    assert.match(source, /stat -f '%d'/);
+    assert.match(source, /stat -f '%u'/);
+    assert.match(source, /stat -f '%g'/);
+    assert.match(source, /stat -f '%Lp'/);
+  });
 });
 
 test("Compose profile replaces the PG volume and disables daemon auto-start", async () => {

--- a/cloud/tests/postgres-bind-profile.test.mjs
+++ b/cloud/tests/postgres-bind-profile.test.mjs
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 const composePath = fileURLToPath(new URL("../compose.postgres-bind.yaml", import.meta.url));
 const validatorPath = fileURLToPath(new URL("../scripts/validate-postgres-storage.sh", import.meta.url));
 const modelValidatorPath = fileURLToPath(new URL("../scripts/validate-postgres-bind-model.mjs", import.meta.url));
+const sourceValidatorPath = fileURLToPath(new URL("../scripts/validate-postgres-bind-source.mjs", import.meta.url));
 const starterPath = fileURLToPath(new URL("../scripts/start-staging-guarded.sh", import.meta.url));
 const guidePath = fileURLToPath(new URL("../POSTGRES-BIND-STAGING.md", import.meta.url));
 
@@ -41,12 +42,20 @@ test("Compose profile replaces the PG volume and disables daemon auto-start", as
 
 test("guarded starter validates before Compose config and start", async () => {
   const source = await readFile(starterPath, "utf8");
-  const guard = source.indexOf('validate-postgres-storage.sh" --check');
+  const sourceGuard = source.indexOf("validate-postgres-bind-source.mjs");
+  const storageGuard = source.indexOf('validate-postgres-storage.sh" --check');
   const config = source.indexOf("config --quiet");
   const model = source.indexOf("validate-postgres-bind-model.mjs");
   const start = source.indexOf("up -d");
-  assert.ok(guard >= 0 && guard < config && config < model && model < start);
+  assert.ok(
+    sourceGuard >= 0 &&
+      sourceGuard < storageGuard &&
+      storageGuard < config &&
+      config < model &&
+      model < start,
+  );
   assert.match(source, /--project-directory/);
+  assert.match(source, /compose_files/);
   assert.doesNotMatch(source, /\.env|POSTGRES_PASSWORD|DATABASE_URL/);
 });
 
@@ -136,6 +145,46 @@ exit 1
   }
 });
 
+test("source validator requires the exact reviewed profile as the final file", async () => {
+  const root = await mkdtemp(join(tmpdir(), "sr-pg-source-"));
+  const ordinary = join(root, "ordinary.yaml");
+  const altered = join(root, "altered.yaml");
+  try {
+    await writeFile(ordinary, "services: {}\n");
+    await writeFile(
+      altered,
+      (await readFile(composePath, "utf8")).replace(
+        "create_host_path: false",
+        "create_host_path: true",
+      ),
+    );
+
+    let result = spawnSync(
+      "node",
+      [sourceValidatorPath, ordinary, composePath],
+      { encoding: "utf8" },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /POSTGRES_BIND_SOURCE_OK/);
+
+    result = spawnSync(
+      "node",
+      [sourceValidatorPath, composePath, ordinary],
+      { encoding: "utf8" },
+    );
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /must be the final Compose file/);
+
+    result = spawnSync("node", [sourceValidatorPath, ordinary, altered], {
+      encoding: "utf8",
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /exactly one exact reviewed/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("rendered-model validator accepts only the exact bind contract", () => {
   const source = "/srv/postgres/selective-remote";
   const valid = {
@@ -147,7 +196,7 @@ test("rendered-model validator accepts only the exact bind contract", () => {
           type: "bind",
           source,
           target: "/var/lib/postgresql/data",
-          bind: { create_host_path: false },
+          bind: {},
         }],
       },
       cloud: {
@@ -166,6 +215,17 @@ test("rendered-model validator accepts only the exact bind contract", () => {
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /POSTGRES_BIND_MODEL_OK/);
 
+  const explicitFalse = structuredClone(valid);
+  explicitFalse.services.postgres.volumes[0].bind = {
+    create_host_path: false,
+  };
+  result = spawnSync("node", [modelValidatorPath], {
+    encoding: "utf8",
+    input: JSON.stringify(explicitFalse),
+    env: { ...process.env, POSTGRES_DATA_HOST_PATH: source },
+  });
+  assert.equal(result.status, 0, result.stderr);
+
   const unsafe = structuredClone(valid);
   unsafe.services.postgres.volumes[0].bind.create_host_path = true;
   result = spawnSync("node", [modelValidatorPath], {
@@ -174,7 +234,7 @@ test("rendered-model validator accepts only the exact bind contract", () => {
     env: { ...process.env, POSTGRES_DATA_HOST_PATH: source },
   });
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /disable host path creation/);
+  assert.match(result.stderr, /unsafe bind options/);
 });
 
 test("validator rejects wrong device, missing path and symlink path", async () => {


### PR DESCRIPTION
## Purpose

Make the dedicated PostgreSQL filesystem on the small closed-staging host an explicit, fail-closed deployment profile. The default Compose profile is unchanged.

## Changes

- add an opt-in Compose overlay that replaces the named PostgreSQL volume with a reviewed host bind;
- disable automatic host-path creation;
- add a storage preflight that verifies the exact mount, device, filesystem, writable state, direct-child path, ownership, mode and symlink safety;
- require the exact reviewed storage overlay once and as the final Compose input, verified by SHA-256;
- validate the secret-safe rendered model before `up -d`;
- require `on-failure:3` for PostgreSQL, API and Caddy so Docker daemon restart does not bypass the guard;
- keep registration disabled and PostgreSQL/API ports unpublished;
- document preparation, reboot, backup/restore and mount-loss acceptance gates.

Docker documents that the `on-failure` restart policy does not restart a container when the Docker daemon restarts: https://docs.docker.com/engine/containers/start-containers-automatically/

## Current verified source

- head: `72ba165951e8a9c8ab83627bf0e9e699e5e18d08`;
- tree: `2d929a248efce03c9771f20768a848e3f0672072`;
- 7 changed files, 686 additions;
- full Cloud tests in CI: 88/88 passed;
- Swift tests: 348 passed;
- terminal resource tests: 12/12 passed;
- CI run 33479521843: success;
- Test DMG run 33479521796: success.

## Target-host validation

Owner-executed isolated gate on the new VPS passed against the exact head above:

- Docker Compose: `2.40.3+ds1-0ubuntu1~24.04.1`;
- exact source-file SHA-256 checks passed;
- exact reviewed storage profile was present once and last;
- normalized rendered model contained the exact bind source/target and no unsafe options;
- PostgreSQL image: `postgres:16.6-alpine`, image/repository digest `sha256:1d04b9ba1d4996401f2552b51beda8187f175c0645c091e4781134fc9c9a3eef`;
- reviewed PostgreSQL numeric identity: UID/GID `70:70`;
- Node validation image digest: `sha256:1b2479dd35a99687d6638f5976fd235e26c5b37e8122f786fcd5fe231d63de5b`;
- dedicated mount: `/dev/mapper/vg0-lv_pgdata` at `/var/lib/postgresql`, ext4, `rw,relatime`;
- missing `/var/lib/postgresql/selective-remote` first failed closed with the expected exit;
- guarded `--prepare` then created only that direct child with UID/GID `70:70` and mode `0700`;
- the immediate post-preparation `--check` passed on the reviewed LV;
- a controlled reboot produced a new boot identity and restored the reviewed LV, fstab/swap state, PGDATA metadata and root/PG device separation;
- Docker inventory remained empty and the expected ingress ports remained free;
- a private child mount namespace hid the PG LV, the guard failed closed before Compose, and the host namespace remained mounted with empty PGDATA unchanged;
- success markers: `PG_HOST_GATE_OK`, `PGDATA_PREPARE_OK`, `POST_REBOOT_STORAGE_OK` and `MOUNT_NAMESPACE_GUARD_OK`, all exit 0;
- no service was started and no database was initialized.

Compose 2.40.3 omits explicit `create_host_path: false` from both normalized and `--no-normalize` JSON, rendering `"bind": {}`. The guard therefore verifies the exact source overlay digest/final position and independently verifies the rendered source/target/options contract; it does not weaken the source requirement.

## Follow-up history

- Head `e8d4820dae16b634b95de9e98385514383caa3fd`: CI 33442836322 exposed macOS `/var` → `/private/var` canonicalization in synthetic fixtures.
- Head `c29ffc2b0f3c21f6796241d929563f93b85fbbb4`: CI 33443603485 exposed GNU-only `stat -c`.
- Head `97982412b6b4a4f71c33a63f4f8e4d6cfe406bf0`: CI/Test DMG passed; target Compose exposed the rendered-`false` omission.
- Current head `72ba165951e8a9c8ab83627bf0e9e699e5e18d08`: exact source/final-order guard added; CI, Test DMG and isolated target-host gate passed.

## Still intentionally pending

- encrypted off-host backup plus isolated restore after disposable database initialization;
- Cloud deployment, migrations, HTTPS or production data;
- any change to `main`.

No `npm audit` result is claimed for this cycle; dependencies and lockfiles are unchanged. The optional source change and its storage-specific host gates are ready for review. Database initialization, backup/restore and Cloud deployment remain separate post-merge staging gates.