### PR TITLE
Cloud: containerize guarded staging validators

### DIFF
--- a/cloud/POSTGRES-BIND-STAGING.md
+++ b/cloud/POSTGRES-BIND-STAGING.md
@@ -35,7 +35,10 @@ unpublished, and the existing image/security/backup gates still apply.
    profile after `compose.yaml` so `!override` replaces the named volume.
    The wrapper parses the rendered model without printing it and refuses to
    start unless the bind, restart policy, closed registration and unpublished
-   PostgreSQL/API ports match the contract.
+   PostgreSQL/API ports match the contract. It runs both JavaScript validators
+   in the pinned Node 22 image with no network, a read-only filesystem and
+   bounded resources; host Node.js is not a prerequisite. Pull and verify that
+   exact image before invoking the wrapper; the wrapper uses `--pull=never`.
 
 Example order for a new host with ordinary 80/443 ingress:
 

--- a/cloud/STAGING-SMALL-HOST.md
+++ b/cloud/STAGING-SMALL-HOST.md
@@ -9,20 +9,28 @@ the `cloud` directory. The PostgreSQL bind profile must appear once and last:
 Earlier three-file examples are not valid for this host and must not be reused.
 
 ```bash
+node_validator_image='node@sha256:1b2479dd35a99687d6638f5976fd235e26c5b37e8122f786fcd5fe231d63de5b'
 docker compose -f compose.yaml -f compose.443-only.yaml -f compose.small-host.yaml \
   -f compose.postgres-bind.yaml config --quiet
 docker compose -f compose.yaml -f compose.443-only.yaml -f compose.small-host.yaml \
   -f compose.postgres-bind.yaml config --format json \
-  | node scripts/validate-small-host-model.mjs
+  | docker run --rm -i --pull=never --network none --read-only \
+      --user 65534:65534 --cap-drop ALL --security-opt no-new-privileges \
+      --memory 128m --memory-swap 128m --cpus 0.5 --pids-limit 64 \
+      --mount "type=bind,src=$(pwd -P)/scripts/validate-small-host-model.mjs,dst=/validator.mjs,readonly" \
+      "$node_validator_image" node /validator.mjs
 ```
 
-Use Node 22 for the checker. A generated Compose model may contain secrets;
-pipe it directly to the checker, do not paste it into chat/CI and do not commit
-it. Use a fresh private temporary directory and dummy-only `.env` when testing
-configuration before deployment. The checker prints only fixed status/budget
-metadata. Keep shell strict mode inside a child Bash, not the interactive SSH
-login shell. These commands do not start containers. The resource checker does
-not replace the independent exact-source, mount and rendered-bind checks in
+Use the pinned Node 22 container for the checker; host Node.js is not required.
+Pre-pull and verify the exact image because this command fails closed with
+`--pull=never`. A generated Compose model may contain secrets; pipe it directly
+to the checker, do not paste it into chat/CI and do not commit it. Use a fresh
+private temporary directory and dummy-only `.env` when testing configuration
+before deployment. The checker prints only fixed status/budget metadata. Keep
+shell strict mode inside a child Bash, not the interactive SSH login shell.
+These commands do not start services; Docker starts only the disposable
+validator container. The resource checker does not replace the independent
+exact-source, mount and rendered-bind checks in
 `scripts/start-staging-guarded.sh`; pass the same four files to that wrapper
 only after all deployment gates are approved.
 

--- a/cloud/scripts/start-staging-guarded.sh
+++ b/cloud/scripts/start-staging-guarded.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 cloud_dir="$(cd -- "${script_dir}/.." && pwd -P)"
+readonly node_validator_image="node@sha256:1b2479dd35a99687d6638f5976fd235e26c5b37e8122f786fcd5fe231d63de5b"
 
 usage() {
     cat <<'USAGE'
@@ -29,6 +30,9 @@ fi
 
 compose=(docker compose --project-directory "${cloud_dir}")
 compose_files=()
+container_compose_files=()
+compose_mounts=()
+compose_index=0
 for compose_file in "$@"; do
     if [[ "${compose_file}" == /* ]]; then
         resolved_file="${compose_file}"
@@ -41,10 +45,29 @@ for compose_file in "$@"; do
     fi
     compose+=( -f "${resolved_file}" )
     compose_files+=( "${resolved_file}" )
+    container_file="/compose-input-${compose_index}.yaml"
+    container_compose_files+=( "${container_file}" )
+    compose_mounts+=(
+        --mount "type=bind,src=${resolved_file},dst=${container_file},readonly"
+    )
+    ((compose_index += 1))
 done
 
-node "${script_dir}/validate-postgres-bind-source.mjs" "${compose_files[@]}"
+validator_container=(
+    docker run --rm --pull=never --network none --read-only
+    --user 65534:65534 --cap-drop ALL --security-opt no-new-privileges
+    --memory 128m --memory-swap 128m --cpus 0.5 --pids-limit 64
+)
+
+"${validator_container[@]}" \
+    "${compose_mounts[@]}" \
+    --mount "type=bind,src=${script_dir}/validate-postgres-bind-source.mjs,dst=/validator.mjs,readonly" \
+    "${node_validator_image}" node /validator.mjs "${container_compose_files[@]}"
 "${script_dir}/validate-postgres-storage.sh" --check
 "${compose[@]}" config --quiet
-"${compose[@]}" config --format json | node "${script_dir}/validate-postgres-bind-model.mjs"
+"${compose[@]}" config --format json |
+    "${validator_container[@]}" -i \
+        --env "POSTGRES_DATA_HOST_PATH=${POSTGRES_DATA_HOST_PATH}" \
+        --mount "type=bind,src=${script_dir}/validate-postgres-bind-model.mjs,dst=/validator.mjs,readonly" \
+        "${node_validator_image}" node /validator.mjs
 exec "${compose[@]}" up -d

--- a/cloud/tests/postgres-bind-profile.test.mjs
+++ b/cloud/tests/postgres-bind-profile.test.mjs
@@ -56,6 +56,11 @@ test("guarded starter validates before Compose config and start", async () => {
   );
   assert.match(source, /--project-directory/);
   assert.match(source, /compose_files/);
+  assert.match(source, /node@sha256:1b2479dd35a99687d6638f5976fd235e26c5b37e8122f786fcd5fe231d63de5b/);
+  assert.match(source, /docker run --rm --pull=never --network none --read-only/);
+  assert.match(source, /--user 65534:65534 --cap-drop ALL --security-opt no-new-privileges/);
+  assert.match(source, /config --format json \|\s*\n\s*"\$\{validator_container\[@\]\}" -i/);
+  assert.doesNotMatch(source, /(?:^|\n)\s*node\s/m);
   assert.doesNotMatch(source, /\.env|POSTGRES_PASSWORD|DATABASE_URL/);
 });
 

--- a/cloud/tests/small-host-profile.test.mjs
+++ b/cloud/tests/small-host-profile.test.mjs
@@ -128,7 +128,10 @@ test("single-worker KDF probe preserves hashing strength within the baseline bud
 });
 
 test("guide preserves operational and secret-handling boundaries", () => {
-  assert.match(guide, /config --format json\s*\\\n\s*\| node scripts\/validate-small-host-model\.mjs/);
+  assert.match(guide, /config --format json\s*\\\n\s*\| docker run --rm -i --pull=never --network none --read-only/);
+  assert.match(guide, /node@sha256:1b2479dd35a99687d6638f5976fd235e26c5b37e8122f786fcd5fe231d63de5b/);
+  assert.match(guide, /host Node\.js is not required/);
+  assert.doesNotMatch(guide, /\| node scripts\/validate-small-host-model\.mjs/);
   const orderedProfiles =
     /compose\.yaml[\s\S]*compose\.443-only\.yaml[\s\S]*compose\.small-host\.yaml[\s\S]*compose\.postgres-bind\.yaml/;
   assert.match(guide, orderedProfiles);


### PR DESCRIPTION
## Summary

- run both guarded-start JavaScript validators in the pinned Node 22 image instead of requiring host Node.js
- keep validator containers offline, read-only, non-root, capability-dropped and resource-bounded
- keep stdin open only for the rendered Compose model
- use `--pull=never` so guarded startup fails closed unless the reviewed image is already present
- update PostgreSQL/small-host staging documentation and regression expectations

## Why

The dedicated staging host intentionally has no host Node.js runtime. The pre-deployment v4 gate passed, but inspection before startup found that `start-staging-guarded.sh` still invoked bare host `node` twice. Without this fix, a real guarded start would fail before `docker compose up`.

No Cloud service was started while finding or testing this issue.

## Verification

Exact commit: `7f3c9b81b0c963783df2a251f9bb47ad8f00020b`

- `bash -n cloud/scripts/start-staging-guarded.sh`
- full Cloud suite: 111/111 passed on Node 24.19.0
- KDF regression peak RSS: 166260 KiB
- regression test rejects bare host-Node validator invocation
- documentation test requires pinned Node digest, `docker run -i`, no network and read-only execution

## Deployment boundary

This PR only prepares a self-contained guarded startup path. It does not deploy Cloud, initialize PostgreSQL, run migrations, request ACME certificates, enable registration or change public `main`.