### PR TITLE
Cloud: pin container images by digest

### DIFF
--- a/cloud/Dockerfile
+++ b/cloud/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:22.18.0-alpine AS dependencies
+FROM node:22.18.0-alpine@sha256:1b2479dd35a99687d6638f5976fd235e26c5b37e8122f786fcd5fe231d63de5b AS dependencies
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
 
-FROM node:22.18.0-alpine
+FROM node:22.18.0-alpine@sha256:1b2479dd35a99687d6638f5976fd235e26c5b37e8122f786fcd5fe231d63de5b
 ENV NODE_ENV=production
 WORKDIR /app
 RUN addgroup -S cloud && adduser -S -G cloud cloud

--- a/cloud/POSTGRES-BIND-STAGING.md
+++ b/cloud/POSTGRES-BIND-STAGING.md
@@ -22,8 +22,9 @@ unpublished, and the existing image/security/backup gates still apply.
 
 ## Preparation sequence
 
-1. Select and review the immutable PostgreSQL image/digest. Pull it before the
-   storage step; do not combine storage preparation with a major upgrade.
+1. Confirm that the pinned PostgreSQL `tag@sha256` identity matches the reviewed
+   target architecture. Pull it before the storage step; do not combine storage
+   preparation with a major upgrade.
 2. Determine the numeric `postgres` UID/GID from that exact image using an
    isolated, no-network inspection. Record the image digest and IDs privately.
 3. Export the six non-secret `POSTGRES_DATA_*` values documented by

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -60,6 +60,11 @@ The Cloud container applies numbered SQL migrations before starting the API.
 Applied filenames and SHA-256 checksums are recorded in `schema_migrations`.
 Never edit an applied migration; add the next numbered file instead.
 
+All base and runtime container images are referenced as `tag@sha256`. Treat
+digest changes as reviewed dependency upgrades: verify the exact image on the
+target architecture, run the complete test and staging gates, then update the
+tag and digest together. Do not replace these references with mutable tags.
+
 ## Production host
 
 The supplied Caddy configuration expects `cloud.pastfly.ru` to resolve to the

--- a/cloud/compose.yaml
+++ b/cloud/compose.yaml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:16.6-alpine
+    image: postgres:16.6-alpine@sha256:1d04b9ba1d4996401f2552b51beda8187f175c0645c091e4781134fc9c9a3eef
     restart: unless-stopped
     environment:
       POSTGRES_DB: ${POSTGRES_DB}
@@ -30,7 +30,7 @@ services:
     networks: [private]
 
   caddy:
-    image: caddy:2.9.1-alpine
+    image: caddy:2.9.1-alpine@sha256:b4e3952384eb9524a887633ce65c752dd7c71314d2c2acf98cd5c715aaa534f0
     restart: unless-stopped
     environment:
       ACME_EMAIL: ${ACME_EMAIL}

--- a/cloud/tests/image-pinning.test.mjs
+++ b/cloud/tests/image-pinning.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const dockerfile = await readFile(new URL("../Dockerfile", import.meta.url), "utf8");
+const compose = await readFile(new URL("../compose.yaml", import.meta.url), "utf8");
+const readme = await readFile(new URL("../README.md", import.meta.url), "utf8");
+
+const expectedNode =
+  "node:22.18.0-alpine@sha256:1b2479dd35a99687d6638f5976fd235e26c5b37e8122f786fcd5fe231d63de5b";
+const expectedPostgres =
+  "postgres:16.6-alpine@sha256:1d04b9ba1d4996401f2552b51beda8187f175c0645c091e4781134fc9c9a3eef";
+const expectedCaddy =
+  "caddy:2.9.1-alpine@sha256:b4e3952384eb9524a887633ce65c752dd7c71314d2c2acf98cd5c715aaa534f0";
+
+test("Dockerfile pins every build and runtime stage to the reviewed Node image", () => {
+  const images = [...dockerfile.matchAll(/^FROM\s+(\S+)/gm)].map((match) => match[1]);
+  assert.deepEqual(images, [expectedNode, expectedNode]);
+});
+
+test("Compose pins every external runtime image to its reviewed digest", () => {
+  const images = [...compose.matchAll(/^\s+image:\s+(\S+)\s*$/gm)].map((match) => match[1]);
+  assert.deepEqual(images, [expectedPostgres, expectedCaddy]);
+});
+
+test("operator documentation preserves the immutable upgrade contract", () => {
+  assert.match(readme, /referenced as `tag@sha256`/);
+  assert.match(readme, /Do not replace these references with mutable tags/);
+});


### PR DESCRIPTION
## Summary

- pin both Cloud Dockerfile stages to the reviewed Node 22 image digest
- pin PostgreSQL and Caddy Compose images to reviewed immutable digests
- add regression coverage that rejects mutable build/runtime image references
- document the tag-plus-digest dependency upgrade contract

## Why

A version tag can be republished or resolve to different bytes later. Closed staging should build and run the exact images that passed the host identity gate.

## Verification

- `node --test tests/*.test.mjs`: 114/114 passed
- KDF probe: `STAGING_KDF_PROBE_OK max-rss-kib=166140`
- reviewed amd64 staging Docker Engine identity gate:
  - PostgreSQL digest matched
  - Node digest matched
  - Caddy digest matched
  - no container or Cloud service was created or started

## Boundaries

This PR does not start staging, change registration, expose ports, run migrations, or modify production data. Registration remains disabled.