### PR TITLE
Cloud: prevent runtime environment files from entering Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ DerivedData/
 .idea/
 .vscode/
 node_modules/
+.env
+.env.*
+!.env.example
 cloud/backups/
 *.log
 *.swp

--- a/cloud/tests/config.test.mjs
+++ b/cloud/tests/config.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { loadConfig, validateProxySecret, validateSecret } from "../src/config.mjs";
@@ -113,6 +114,29 @@ test("example environment leaves optional SMTP disabled for closed staging", asy
     assert.match(example, new RegExp(`^# ${name}=`, "m"));
   }
   assert.match(example, /^ALLOW_REGISTRATION=false$/m);
+});
+
+test("Git ignores runtime environment files but preserves the example", async () => {
+  const repositoryRoot = fileURLToPath(new URL("../../", import.meta.url));
+  const ignore = await readFile(new URL("../../.gitignore", import.meta.url), "utf8");
+  assert.match(ignore, /^\.env$/m);
+  assert.match(ignore, /^\.env\.\*$/m);
+  assert.match(ignore, /^!\.env\.example$/m);
+
+  for (const path of ["cloud/.env", "cloud/.env.tmp.example"]) {
+    const result = spawnSync("git", ["check-ignore", "--no-index", "-q", path], {
+      cwd: repositoryRoot,
+      encoding: "utf8",
+    });
+    assert.equal(result.status, 0, `${path}: ${result.stderr}`);
+  }
+
+  const example = spawnSync(
+    "git",
+    ["check-ignore", "--no-index", "-q", "cloud/.env.example"],
+    { cwd: repositoryRoot, encoding: "utf8" },
+  );
+  assert.equal(example.status, 1, example.stderr);
 });
 
 test("verification pepper remains mandatory while registration is disabled", () => {


### PR DESCRIPTION
## Summary

- ignore runtime `.env` files and temporary variants repository-wide
- keep tracked `.env.example` templates explicitly available
- add a regression test using `git check-ignore --no-index`

## Why

The closed-staging preparation gate found that `cloud/.dockerignore` protected Docker build context, but the repository root did not protect `cloud/.env` from accidental Git staging. The deployment gate failed closed before build or service startup.

## Verification

- `node --test tests/*.test.mjs`: 115/115 passed
- KDF probe: `STAGING_KDF_PROBE_OK max-rss-kib=166432`
- regression test verifies:
  - `cloud/.env` is ignored
  - `cloud/.env.tmp.example` is ignored
  - `cloud/.env.example` is not ignored

## Boundaries

No existing environment file or secret is committed. This PR does not start services, enable registration, run migrations, alter DNS, or publish ports.