### PR TITLE
Cloud: begin browser E2EE personal Vault

### DIFF
--- a/cloud/public/vault-crypto.js
+++ b/cloud/public/vault-crypto.js
@@ -53,19 +53,30 @@ function concatenate(...values) {
 function recoveryPassphraseBytes(passphrase) {
   const value = String(passphrase ?? "").normalize("NFC");
   const bytes = new TextEncoder().encode(value);
-  if (value.length < 16 || bytes.length > 1024) throw new Error("invalid_recovery_passphrase");
+  if (bytes.length < 16 || bytes.length > 1024) throw new Error("invalid_recovery_passphrase");
   return bytes;
 }
 
 function validatedWrappedKey(value) {
   if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("invalid_wrapped_key");
+  const keys = Object.keys(value).sort();
+  if (keys.join(",") !== "algorithm,iterations,salt,value") throw new Error("invalid_wrapped_key");
   if (value.algorithm !== recoveryAlgorithm || value.iterations !== recoveryKDFIterations) {
     throw new Error("invalid_wrapped_key");
   }
   try {
     const salt = base64URLToBytes(value.salt, 16);
     const wrapped = base64URLToBytes(value.value, 40);
-    return { salt, wrapped };
+    return {
+      salt,
+      wrapped,
+      normalized: {
+        algorithm: recoveryAlgorithm,
+        iterations: recoveryKDFIterations,
+        salt: value.salt,
+        value: value.value,
+      },
+    };
   } catch {
     throw new Error("invalid_wrapped_key");
   }
@@ -165,7 +176,7 @@ export async function encryptVaultPayload({
   cryptoValue = globalThis.crypto,
 }) {
   if (!Number.isSafeInteger(baseRevision) || baseRevision < 0) throw new Error("invalid_base_revision");
-  validatedWrappedKey(wrappedKey);
+  const { normalized: normalizedWrappedKey } = validatedWrappedKey(wrappedKey);
   const crypto = webCrypto(cryptoValue);
   const nonce = crypto.getRandomValues(new Uint8Array(12));
   const plaintext = validatedPayload(payload);
@@ -184,7 +195,7 @@ export async function encryptVaultPayload({
   return {
     baseRevision,
     envelopeVersion: vaultEnvelopeVersion,
-    wrappedKey: structuredClone(wrappedKey),
+    wrappedKey: normalizedWrappedKey,
     ciphertext: bytesToBase64URL(ciphertext),
     nonce: bytesToBase64URL(nonce),
     authTag: bytesToBase64URL(authTag),
@@ -198,6 +209,7 @@ export async function decryptVaultEnvelope(vaultKey, envelope, cryptoValue = glo
   const crypto = webCrypto(cryptoValue);
   const nonce = base64URLToBytes(envelope.nonce, 12);
   const authTag = base64URLToBytes(envelope.authTag, 16);
+  base64URLToBytes(envelope.contentHash, 32);
   if (typeof envelope.ciphertext !== "string" || envelope.ciphertext.length > maxCiphertextCharacters) {
     throw new Error("vault_too_large");
   }

--- a/cloud/public/vault-crypto.js
+++ b/cloud/public/vault-crypto.js
@@ -1,0 +1,224 @@
+export const vaultEnvelopeVersion = 1;
+export const recoveryKDFIterations = 600_000;
+
+const recoveryAlgorithm = "PBKDF2-SHA256+A256KW";
+const additionalData = new TextEncoder().encode("selective-remote:vault-envelope:v1");
+const base64URLPattern = /^[A-Za-z0-9_-]+$/;
+const maxCiphertextCharacters = 32 * 1024 * 1024;
+
+function webCrypto(cryptoValue) {
+  if (!cryptoValue?.subtle || typeof cryptoValue.getRandomValues !== "function") {
+    throw new Error("web_crypto_unavailable");
+  }
+  return cryptoValue;
+}
+
+function bytesToBase64URL(bytes) {
+  let binary = "";
+  for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000));
+  }
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/u, "");
+}
+
+function base64URLToBytes(value, expectedLength = null) {
+  if (typeof value !== "string" || !base64URLPattern.test(value)) {
+    throw new Error("invalid_vault_envelope");
+  }
+  const padded = value.replaceAll("-", "+").replaceAll("_", "/")
+    + "=".repeat((4 - (value.length % 4)) % 4);
+  let decoded;
+  try {
+    decoded = atob(padded);
+  } catch {
+    throw new Error("invalid_vault_envelope");
+  }
+  const bytes = Uint8Array.from(decoded, (character) => character.charCodeAt(0));
+  if (bytesToBase64URL(bytes) !== value || (expectedLength !== null && bytes.length !== expectedLength)) {
+    throw new Error("invalid_vault_envelope");
+  }
+  return bytes;
+}
+
+function concatenate(...values) {
+  const result = new Uint8Array(values.reduce((total, value) => total + value.length, 0));
+  let offset = 0;
+  for (const value of values) {
+    result.set(value, offset);
+    offset += value.length;
+  }
+  return result;
+}
+
+function recoveryPassphraseBytes(passphrase) {
+  const value = String(passphrase ?? "").normalize("NFC");
+  const bytes = new TextEncoder().encode(value);
+  if (value.length < 16 || bytes.length > 1024) throw new Error("invalid_recovery_passphrase");
+  return bytes;
+}
+
+function validatedWrappedKey(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("invalid_wrapped_key");
+  if (value.algorithm !== recoveryAlgorithm || value.iterations !== recoveryKDFIterations) {
+    throw new Error("invalid_wrapped_key");
+  }
+  try {
+    const salt = base64URLToBytes(value.salt, 16);
+    const wrapped = base64URLToBytes(value.value, 40);
+    return { salt, wrapped };
+  } catch {
+    throw new Error("invalid_wrapped_key");
+  }
+}
+
+function validatedPayload(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("invalid_vault_payload");
+  let serialized;
+  try {
+    serialized = JSON.stringify(value);
+  } catch {
+    throw new Error("invalid_vault_payload");
+  }
+  if (!serialized) throw new Error("invalid_vault_payload");
+  const bytes = new TextEncoder().encode(serialized);
+  if (bytes.length > 24 * 1024 * 1024) throw new Error("vault_too_large");
+  return bytes;
+}
+
+async function deriveRecoveryKey(passphrase, salt, cryptoValue) {
+  const crypto = webCrypto(cryptoValue);
+  const material = await crypto.subtle.importKey(
+    "raw",
+    recoveryPassphraseBytes(passphrase),
+    "PBKDF2",
+    false,
+    ["deriveKey"],
+  );
+  return crypto.subtle.deriveKey(
+    { name: "PBKDF2", hash: "SHA-256", salt, iterations: recoveryKDFIterations },
+    material,
+    { name: "AES-KW", length: 256 },
+    false,
+    ["wrapKey", "unwrapKey"],
+  );
+}
+
+async function contentHash(nonce, ciphertext, authTag, cryptoValue) {
+  const version = new Uint8Array([vaultEnvelopeVersion]);
+  const digest = await webCrypto(cryptoValue).subtle.digest(
+    "SHA-256",
+    concatenate(version, nonce, ciphertext, authTag),
+  );
+  return bytesToBase64URL(new Uint8Array(digest));
+}
+
+export async function generateVaultKey(cryptoValue = globalThis.crypto) {
+  return webCrypto(cryptoValue).subtle.generateKey(
+    { name: "AES-GCM", length: 256 },
+    true,
+    ["encrypt", "decrypt"],
+  );
+}
+
+export async function wrapVaultKey(vaultKey, passphrase, cryptoValue = globalThis.crypto) {
+  const crypto = webCrypto(cryptoValue);
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const recoveryKey = await deriveRecoveryKey(passphrase, salt, crypto);
+  let wrapped;
+  try {
+    wrapped = await crypto.subtle.wrapKey("raw", vaultKey, recoveryKey, "AES-KW");
+  } catch {
+    throw new Error("vault_key_wrap_failed");
+  }
+  return {
+    algorithm: recoveryAlgorithm,
+    iterations: recoveryKDFIterations,
+    salt: bytesToBase64URL(salt),
+    value: bytesToBase64URL(new Uint8Array(wrapped)),
+  };
+}
+
+export async function unwrapVaultKey(wrappedKey, passphrase, cryptoValue = globalThis.crypto) {
+  const crypto = webCrypto(cryptoValue);
+  const { salt, wrapped } = validatedWrappedKey(wrappedKey);
+  const recoveryKey = await deriveRecoveryKey(passphrase, salt, crypto);
+  try {
+    return await crypto.subtle.unwrapKey(
+      "raw",
+      wrapped,
+      recoveryKey,
+      "AES-KW",
+      { name: "AES-GCM", length: 256 },
+      true,
+      ["encrypt", "decrypt"],
+    );
+  } catch {
+    throw new Error("invalid_recovery_passphrase");
+  }
+}
+
+export async function encryptVaultPayload({
+  vaultKey,
+  payload,
+  baseRevision,
+  wrappedKey,
+  cryptoValue = globalThis.crypto,
+}) {
+  if (!Number.isSafeInteger(baseRevision) || baseRevision < 0) throw new Error("invalid_base_revision");
+  validatedWrappedKey(wrappedKey);
+  const crypto = webCrypto(cryptoValue);
+  const nonce = crypto.getRandomValues(new Uint8Array(12));
+  const plaintext = validatedPayload(payload);
+  let encrypted;
+  try {
+    encrypted = new Uint8Array(await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv: nonce, additionalData, tagLength: 128 },
+      vaultKey,
+      plaintext,
+    ));
+  } catch {
+    throw new Error("vault_encryption_failed");
+  }
+  const ciphertext = encrypted.subarray(0, encrypted.length - 16);
+  const authTag = encrypted.subarray(encrypted.length - 16);
+  return {
+    baseRevision,
+    envelopeVersion: vaultEnvelopeVersion,
+    wrappedKey: structuredClone(wrappedKey),
+    ciphertext: bytesToBase64URL(ciphertext),
+    nonce: bytesToBase64URL(nonce),
+    authTag: bytesToBase64URL(authTag),
+    contentHash: await contentHash(nonce, ciphertext, authTag, crypto),
+  };
+}
+
+export async function decryptVaultEnvelope(vaultKey, envelope, cryptoValue = globalThis.crypto) {
+  if (!envelope || envelope.envelopeVersion !== vaultEnvelopeVersion) throw new Error("invalid_vault_envelope");
+  validatedWrappedKey(envelope.wrappedKey);
+  const crypto = webCrypto(cryptoValue);
+  const nonce = base64URLToBytes(envelope.nonce, 12);
+  const authTag = base64URLToBytes(envelope.authTag, 16);
+  if (typeof envelope.ciphertext !== "string" || envelope.ciphertext.length > maxCiphertextCharacters) {
+    throw new Error("vault_too_large");
+  }
+  const ciphertext = base64URLToBytes(envelope.ciphertext);
+  const expectedHash = await contentHash(nonce, ciphertext, authTag, crypto);
+  if (envelope.contentHash !== expectedHash) throw new Error("vault_content_hash_mismatch");
+  let decrypted;
+  try {
+    decrypted = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: nonce, additionalData, tagLength: 128 },
+      vaultKey,
+      concatenate(ciphertext, authTag),
+    );
+  } catch {
+    throw new Error("vault_decryption_failed");
+  }
+  try {
+    const payload = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(decrypted));
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) throw new Error();
+    return payload;
+  } catch {
+    throw new Error("invalid_vault_payload");
+  }
+}

--- a/cloud/public/vault-model.js
+++ b/cloud/public/vault-model.js
@@ -1,0 +1,282 @@
+export const vaultDocumentSchemaVersion = 1;
+
+const recordTypes = new Set(["host", "credential", "snippet", "forwarding"]);
+const exactUUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const forbiddenKeys = new Set(["__proto__", "constructor", "prototype"]);
+const maxDocumentBytes = 24 * 1024 * 1024;
+const maxEntities = 10_000;
+const maxVersionDevices = 128;
+
+function compareStrings(left, right) {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function exactKeys(value, expected, code) {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (actual.length !== wanted.length || actual.some((key, index) => key !== wanted[index])) {
+    throw new Error(code);
+  }
+}
+
+function normalizedUUID(value, code) {
+  const normalized = String(value ?? "").toLowerCase();
+  if (!exactUUID.test(normalized)) throw new Error(code);
+  return normalized;
+}
+
+function normalizedTimestamp(value, code) {
+  if (typeof value !== "string") throw new Error(code);
+  const parsed = new Date(value);
+  if (!Number.isFinite(parsed.valueOf()) || parsed.toISOString() !== value) throw new Error(code);
+  return value;
+}
+
+function normalizedJSON(value, depth = 0) {
+  if (depth > 32) throw new Error("invalid_record_data");
+  if (value === null || typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new Error("invalid_record_data");
+    return value;
+  }
+  if (Array.isArray(value)) {
+    if (value.length > maxEntities) throw new Error("invalid_record_data");
+    return value.map((item) => normalizedJSON(item, depth + 1));
+  }
+  if (!value || typeof value !== "object") throw new Error("invalid_record_data");
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) throw new Error("invalid_record_data");
+  const keys = Object.keys(value).sort();
+  if (keys.length > 1_000 || keys.some((key) => forbiddenKeys.has(key))) throw new Error("invalid_record_data");
+  return Object.fromEntries(keys.map((key) => [key, normalizedJSON(value[key], depth + 1)]));
+}
+
+function normalizedVersion(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("invalid_record_version");
+  const entries = Object.entries(value);
+  if (entries.length < 1 || entries.length > maxVersionDevices) throw new Error("invalid_record_version");
+  const result = {};
+  for (const [deviceID, counter] of entries.sort(([left], [right]) => compareStrings(left, right))) {
+    const normalizedDeviceID = normalizedUUID(deviceID, "invalid_record_version");
+    if (!Number.isSafeInteger(counter) || counter < 1) throw new Error("invalid_record_version");
+    result[normalizedDeviceID] = counter;
+  }
+  return result;
+}
+
+function normalizedRecord(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("invalid_vault_record");
+  exactKeys(value, ["id", "type", "version", "modifiedAt", "data"], "invalid_vault_record");
+  if (!recordTypes.has(value.type)) throw new Error("invalid_record_type");
+  return {
+    id: normalizedUUID(value.id, "invalid_record_id"),
+    type: value.type,
+    version: normalizedVersion(value.version),
+    modifiedAt: normalizedTimestamp(value.modifiedAt, "invalid_modified_at"),
+    data: normalizedJSON(value.data),
+  };
+}
+
+function normalizedTombstone(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("invalid_vault_tombstone");
+  exactKeys(value, ["id", "version", "deletedAt"], "invalid_vault_tombstone");
+  return {
+    id: normalizedUUID(value.id, "invalid_record_id"),
+    version: normalizedVersion(value.version),
+    deletedAt: normalizedTimestamp(value.deletedAt, "invalid_deleted_at"),
+  };
+}
+
+function sortedDocument(records, tombstones) {
+  return {
+    schemaVersion: vaultDocumentSchemaVersion,
+    records: [...records].sort((left, right) => compareStrings(left.id, right.id)),
+    tombstones: [...tombstones].sort((left, right) => compareStrings(left.id, right.id)),
+  };
+}
+
+function documentSize(document) {
+  return new TextEncoder().encode(JSON.stringify(document)).length;
+}
+
+function checkedDocument(records, tombstones) {
+  if (records.length + tombstones.length > maxEntities) throw new Error("vault_too_large");
+  const ids = new Set();
+  for (const entity of [...records, ...tombstones]) {
+    if (ids.has(entity.id)) throw new Error("duplicate_record_id");
+    ids.add(entity.id);
+  }
+  const document = sortedDocument(records, tombstones);
+  if (documentSize(document) > maxDocumentBytes) throw new Error("vault_too_large");
+  return document;
+}
+
+function incrementedVersion(value, deviceID) {
+  const normalizedDeviceID = normalizedUUID(deviceID, "invalid_device");
+  const current = value ? normalizedVersion(value) : {};
+  const next = (current[normalizedDeviceID] ?? 0) + 1;
+  if (!Number.isSafeInteger(next)) throw new Error("invalid_record_version");
+  return Object.fromEntries(
+    [...Object.entries(current), [normalizedDeviceID, next]]
+      .reduce((entries, [key, counter]) => entries.set(key, counter), new Map())
+      .entries(),
+  );
+}
+
+function entityMap(document) {
+  const result = new Map();
+  for (const record of document.records) result.set(record.id, { kind: "record", value: record });
+  for (const tombstone of document.tombstones) result.set(tombstone.id, { kind: "tombstone", value: tombstone });
+  return result;
+}
+
+function vectorRelation(left, right) {
+  const deviceIDs = new Set([...Object.keys(left), ...Object.keys(right)]);
+  let leftAhead = false;
+  let rightAhead = false;
+  for (const deviceID of deviceIDs) {
+    const comparison = (left[deviceID] ?? 0) - (right[deviceID] ?? 0);
+    if (comparison > 0) leftAhead = true;
+    if (comparison < 0) rightAhead = true;
+  }
+  if (leftAhead && rightAhead) return "concurrent";
+  if (leftAhead) return "left";
+  if (rightAhead) return "right";
+  return "equal";
+}
+
+function canonicalEntity(entity) {
+  return JSON.stringify(normalizedJSON(entity));
+}
+
+function mergedVersion(left, right, deviceID) {
+  const combined = {};
+  for (const key of new Set([...Object.keys(left), ...Object.keys(right)])) {
+    combined[key] = Math.max(left[key] ?? 0, right[key] ?? 0);
+  }
+  return incrementedVersion(combined, deviceID);
+}
+
+function normalizedConflictEntity(entity, id) {
+  if (!entity || typeof entity !== "object" || Array.isArray(entity)) throw new Error("invalid_vault_conflict");
+  exactKeys(entity, ["kind", "value"], "invalid_vault_conflict");
+  let value;
+  if (entity.kind === "record") value = normalizedRecord(entity.value);
+  else if (entity.kind === "tombstone") value = normalizedTombstone(entity.value);
+  else throw new Error("invalid_vault_conflict");
+  if (value.id !== id) throw new Error("invalid_vault_conflict");
+  return { kind: entity.kind, value };
+}
+
+export function createEmptyVaultDocument() {
+  return { schemaVersion: vaultDocumentSchemaVersion, records: [], tombstones: [] };
+}
+
+export function validateVaultDocument(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("invalid_vault_document");
+  exactKeys(value, ["schemaVersion", "records", "tombstones"], "invalid_vault_document");
+  if (value.schemaVersion !== vaultDocumentSchemaVersion) throw new Error("invalid_vault_schema_version");
+  if (!Array.isArray(value.records) || !Array.isArray(value.tombstones)) throw new Error("invalid_vault_document");
+  return checkedDocument(value.records.map(normalizedRecord), value.tombstones.map(normalizedTombstone));
+}
+
+export function upsertVaultRecord(documentValue, {
+  id,
+  type,
+  data,
+  deviceID,
+  modifiedAt = new Date().toISOString(),
+  cryptoValue = globalThis.crypto,
+}) {
+  const document = validateVaultDocument(documentValue);
+  const recordID = id === undefined
+    ? normalizedUUID(cryptoValue?.randomUUID?.(), "invalid_record_id")
+    : normalizedUUID(id, "invalid_record_id");
+  const existing = entityMap(document).get(recordID);
+  const version = incrementedVersion(existing?.value.version, deviceID);
+  const record = normalizedRecord({ id: recordID, type, version, modifiedAt, data });
+  const records = document.records.filter((value) => value.id !== recordID);
+  const tombstones = document.tombstones.filter((value) => value.id !== recordID);
+  records.push(record);
+  return checkedDocument(records, tombstones);
+}
+
+export function deleteVaultRecord(documentValue, {
+  id,
+  deviceID,
+  deletedAt = new Date().toISOString(),
+}) {
+  const document = validateVaultDocument(documentValue);
+  const recordID = normalizedUUID(id, "invalid_record_id");
+  const existing = entityMap(document).get(recordID);
+  if (!existing || existing.kind !== "record") throw new Error("record_not_found");
+  const tombstone = normalizedTombstone({
+    id: recordID,
+    version: incrementedVersion(existing.value.version, deviceID),
+    deletedAt,
+  });
+  return checkedDocument(
+    document.records.filter((value) => value.id !== recordID),
+    [...document.tombstones, tombstone],
+  );
+}
+
+export function mergeVaultDocuments(localValue, remoteValue) {
+  const local = validateVaultDocument(localValue);
+  const remote = validateVaultDocument(remoteValue);
+  const localEntities = entityMap(local);
+  const remoteEntities = entityMap(remote);
+  const records = [];
+  const tombstones = [];
+  const conflicts = [];
+  const ids = [...new Set([...localEntities.keys(), ...remoteEntities.keys()])].sort();
+
+  for (const id of ids) {
+    const localEntity = localEntities.get(id);
+    const remoteEntity = remoteEntities.get(id);
+    let selected = localEntity ?? remoteEntity;
+    if (localEntity && remoteEntity) {
+      const relation = vectorRelation(localEntity.value.version, remoteEntity.value.version);
+      if (relation === "left") selected = localEntity;
+      else if (relation === "right") selected = remoteEntity;
+      else if (relation === "equal" && canonicalEntity(localEntity) === canonicalEntity(remoteEntity)) selected = localEntity;
+      else {
+        selected = null;
+        conflicts.push({ id, local: localEntity, remote: remoteEntity });
+      }
+    }
+    if (selected?.kind === "record") records.push(selected.value);
+    if (selected?.kind === "tombstone") tombstones.push(selected.value);
+  }
+
+  return { document: checkedDocument(records, tombstones), conflicts };
+}
+
+export function resolveVaultConflict(documentValue, conflict, {
+  choice,
+  deviceID,
+  resolvedAt = new Date().toISOString(),
+}) {
+  const document = validateVaultDocument(documentValue);
+  if (!conflict || typeof conflict !== "object" || !["local", "remote"].includes(choice)) {
+    throw new Error("invalid_vault_conflict");
+  }
+  const id = normalizedUUID(conflict.id, "invalid_vault_conflict");
+  if (entityMap(document).has(id)) throw new Error("conflict_record_present");
+  const local = normalizedConflictEntity(conflict.local, id);
+  const remote = normalizedConflictEntity(conflict.remote, id);
+  const selected = choice === "local" ? local : remote;
+  const version = mergedVersion(
+    normalizedVersion(local.value.version),
+    normalizedVersion(remote.value.version),
+    deviceID,
+  );
+  if (selected.kind === "record") {
+    const record = normalizedRecord({ ...selected.value, version, modifiedAt: resolvedAt });
+    return checkedDocument([...document.records, record], document.tombstones);
+  }
+  const tombstone = normalizedTombstone({ id, version, deletedAt: resolvedAt });
+  return checkedDocument(document.records, [...document.tombstones, tombstone]);
+}

--- a/cloud/public/vault-model.js
+++ b/cloud/public/vault-model.js
@@ -6,6 +6,7 @@ const forbiddenKeys = new Set(["__proto__", "constructor", "prototype"]);
 const maxDocumentBytes = 24 * 1024 * 1024;
 const maxEntities = 10_000;
 const maxVersionDevices = 128;
+const maxJSONNodes = 100_000;
 
 function compareStrings(left, right) {
   if (left < right) return -1;
@@ -34,7 +35,9 @@ function normalizedTimestamp(value, code) {
   return value;
 }
 
-function normalizedJSON(value, depth = 0) {
+function normalizedJSON(value, depth = 0, budget = { remaining: maxJSONNodes }) {
+  budget.remaining -= 1;
+  if (budget.remaining < 0) throw new Error("invalid_record_data");
   if (depth > 32) throw new Error("invalid_record_data");
   if (value === null || typeof value === "string" || typeof value === "boolean") return value;
   if (typeof value === "number") {
@@ -43,14 +46,14 @@ function normalizedJSON(value, depth = 0) {
   }
   if (Array.isArray(value)) {
     if (value.length > maxEntities) throw new Error("invalid_record_data");
-    return value.map((item) => normalizedJSON(item, depth + 1));
+    return value.map((item) => normalizedJSON(item, depth + 1, budget));
   }
   if (!value || typeof value !== "object") throw new Error("invalid_record_data");
   const prototype = Object.getPrototypeOf(value);
   if (prototype !== Object.prototype && prototype !== null) throw new Error("invalid_record_data");
   const keys = Object.keys(value).sort();
   if (keys.length > 1_000 || keys.some((key) => forbiddenKeys.has(key))) throw new Error("invalid_record_data");
-  return Object.fromEntries(keys.map((key) => [key, normalizedJSON(value[key], depth + 1)]));
+  return Object.fromEntries(keys.map((key) => [key, normalizedJSON(value[key], depth + 1, budget)]));
 }
 
 function normalizedVersion(value) {
@@ -66,7 +69,7 @@ function normalizedVersion(value) {
   return result;
 }
 
-function normalizedRecord(value) {
+function normalizedRecord(value, budget = { remaining: maxJSONNodes }) {
   if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("invalid_vault_record");
   exactKeys(value, ["id", "type", "version", "modifiedAt", "data"], "invalid_vault_record");
   if (!recordTypes.has(value.type)) throw new Error("invalid_record_type");
@@ -75,7 +78,7 @@ function normalizedRecord(value) {
     type: value.type,
     version: normalizedVersion(value.version),
     modifiedAt: normalizedTimestamp(value.modifiedAt, "invalid_modified_at"),
-    data: normalizedJSON(value.data),
+    data: normalizedJSON(value.data, 0, budget),
   };
 }
 
@@ -179,7 +182,12 @@ export function validateVaultDocument(value) {
   exactKeys(value, ["schemaVersion", "records", "tombstones"], "invalid_vault_document");
   if (value.schemaVersion !== vaultDocumentSchemaVersion) throw new Error("invalid_vault_schema_version");
   if (!Array.isArray(value.records) || !Array.isArray(value.tombstones)) throw new Error("invalid_vault_document");
-  return checkedDocument(value.records.map(normalizedRecord), value.tombstones.map(normalizedTombstone));
+  if (value.records.length + value.tombstones.length > maxEntities) throw new Error("vault_too_large");
+  const budget = { remaining: maxJSONNodes };
+  return checkedDocument(
+    value.records.map((record) => normalizedRecord(record, budget)),
+    value.tombstones.map(normalizedTombstone),
+  );
 }
 
 export function upsertVaultRecord(documentValue, {

--- a/cloud/tests/public-vault-crypto.test.mjs
+++ b/cloud/tests/public-vault-crypto.test.mjs
@@ -78,6 +78,10 @@ test("wrong recovery passphrases and downgraded KDF metadata fail closed", async
     unwrapVaultKey({ ...wrappedKey, iterations: 10_000 }, passphrase, webcrypto),
     (error) => error.message === "invalid_wrapped_key",
   );
+  await assert.rejects(
+    unwrapVaultKey({ ...wrappedKey, serverHint: "unexpected" }, passphrase, webcrypto),
+    (error) => error.message === "invalid_wrapped_key",
+  );
 });
 
 test("canonically equivalent Unicode recovery passphrases are interoperable", async () => {
@@ -112,6 +116,16 @@ test("ciphertext, tag and hash tampering is rejected before plaintext is returne
   await assert.rejects(
     decryptVaultEnvelope(vaultKey, { ...envelope, ciphertext: tamperedCiphertext }, webcrypto),
     (error) => error.message === "vault_content_hash_mismatch",
+  );
+});
+
+test("a valid content hash cannot bypass AES-GCM authentication with the wrong Vault key", async () => {
+  const { envelope } = await fixture();
+  const wrongVaultKey = await generateVaultKey(webcrypto);
+
+  await assert.rejects(
+    decryptVaultEnvelope(wrongVaultKey, envelope, webcrypto),
+    (error) => error.message === "vault_decryption_failed",
   );
 });
 

--- a/cloud/tests/public-vault-crypto.test.mjs
+++ b/cloud/tests/public-vault-crypto.test.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { webcrypto } from "node:crypto";
+import test from "node:test";
+import {
+  decryptVaultEnvelope,
+  encryptVaultPayload,
+  generateVaultKey,
+  recoveryKDFIterations,
+  unwrapVaultKey,
+  vaultEnvelopeVersion,
+  wrapVaultKey,
+} from "../public/vault-crypto.js";
+import { validateVaultEnvelope } from "../src/security.mjs";
+
+const passphrase = "correct horse battery staple for recovery";
+
+async function fixture() {
+  const vaultKey = await generateVaultKey(webcrypto);
+  const wrappedKey = await wrapVaultKey(vaultKey, passphrase, webcrypto);
+  const payload = {
+    schemaVersion: 1,
+    records: [{ id: "018f2d22-bb75-7d2a-8e72-d6ad9f5c2180", type: "host", title: "Synthetic host" }],
+    tombstones: [],
+  };
+  const envelope = await encryptVaultPayload({
+    vaultKey,
+    payload,
+    baseRevision: 0,
+    wrappedKey,
+    cryptoValue: webcrypto,
+  });
+  return { vaultKey, wrappedKey, payload, envelope };
+}
+
+test("browser Vault envelope round-trips only through the recovery-wrapped key", async () => {
+  const { wrappedKey, payload, envelope } = await fixture();
+  const recoveredVaultKey = await unwrapVaultKey(wrappedKey, passphrase, webcrypto);
+
+  assert.deepEqual(await decryptVaultEnvelope(recoveredVaultKey, envelope, webcrypto), payload);
+  assert.equal(envelope.envelopeVersion, vaultEnvelopeVersion);
+  assert.equal(envelope.baseRevision, 0);
+  assert.equal(envelope.nonce.length, 16);
+  assert.equal(envelope.authTag.length, 22);
+  assert.equal(envelope.contentHash.length, 43);
+  assert.equal(wrappedKey.algorithm, "PBKDF2-SHA256+A256KW");
+  assert.equal(wrappedKey.iterations, recoveryKDFIterations);
+  assert.equal(wrappedKey.salt.length, 22);
+  assert.equal(wrappedKey.value.length, 54);
+  assert.deepEqual(validateVaultEnvelope(envelope), envelope);
+});
+
+test("ciphertext and recovery metadata never contain Vault plaintext", async () => {
+  const { envelope } = await fixture();
+  const serialized = JSON.stringify(envelope);
+
+  assert.equal(serialized.includes("Synthetic host"), false);
+  assert.equal(serialized.includes("records"), false);
+  assert.equal(serialized.includes(passphrase), false);
+});
+
+test("fresh nonces make equal Vault payloads produce different encrypted revisions", async () => {
+  const { vaultKey, wrappedKey, payload } = await fixture();
+  const first = await encryptVaultPayload({ vaultKey, wrappedKey, payload, baseRevision: 1, cryptoValue: webcrypto });
+  const second = await encryptVaultPayload({ vaultKey, wrappedKey, payload, baseRevision: 1, cryptoValue: webcrypto });
+
+  assert.notEqual(first.nonce, second.nonce);
+  assert.notEqual(first.ciphertext, second.ciphertext);
+  assert.notEqual(first.contentHash, second.contentHash);
+});
+
+test("wrong recovery passphrases and downgraded KDF metadata fail closed", async () => {
+  const { wrappedKey } = await fixture();
+  await assert.rejects(
+    unwrapVaultKey(wrappedKey, "a different recovery passphrase", webcrypto),
+    (error) => error.message === "invalid_recovery_passphrase",
+  );
+  await assert.rejects(
+    unwrapVaultKey({ ...wrappedKey, iterations: 10_000 }, passphrase, webcrypto),
+    (error) => error.message === "invalid_wrapped_key",
+  );
+});
+
+test("canonically equivalent Unicode recovery passphrases are interoperable", async () => {
+  const vaultKey = await generateVaultKey(webcrypto);
+  const decomposed = "long recovery cafe\u0301 passphrase";
+  const composed = "long recovery café passphrase";
+  const wrappedKey = await wrapVaultKey(vaultKey, decomposed, webcrypto);
+  const recoveredVaultKey = await unwrapVaultKey(wrappedKey, composed, webcrypto);
+  const envelope = await encryptVaultPayload({
+    vaultKey,
+    wrappedKey,
+    payload: { schemaVersion: 1, records: [], tombstones: [] },
+    baseRevision: 0,
+    cryptoValue: webcrypto,
+  });
+
+  assert.deepEqual(
+    await decryptVaultEnvelope(recoveredVaultKey, envelope, webcrypto),
+    { schemaVersion: 1, records: [], tombstones: [] },
+  );
+});
+
+test("ciphertext, tag and hash tampering is rejected before plaintext is returned", async () => {
+  const { vaultKey, envelope } = await fixture();
+  const tamperedHash = `${envelope.contentHash.startsWith("A") ? "B" : "A"}${envelope.contentHash.slice(1)}`;
+  await assert.rejects(
+    decryptVaultEnvelope(vaultKey, { ...envelope, contentHash: tamperedHash }, webcrypto),
+    (error) => error.message === "vault_content_hash_mismatch",
+  );
+
+  const tamperedCiphertext = `${envelope.ciphertext.slice(0, -1)}${envelope.ciphertext.endsWith("A") ? "B" : "A"}`;
+  await assert.rejects(
+    decryptVaultEnvelope(vaultKey, { ...envelope, ciphertext: tamperedCiphertext }, webcrypto),
+    (error) => error.message === "vault_content_hash_mismatch",
+  );
+});
+
+test("invalid payloads and revisions never enter encryption", async () => {
+  const vaultKey = await generateVaultKey(webcrypto);
+  const wrappedKey = await wrapVaultKey(vaultKey, passphrase, webcrypto);
+
+  await assert.rejects(
+    encryptVaultPayload({ vaultKey, wrappedKey, payload: [], baseRevision: 0, cryptoValue: webcrypto }),
+    (error) => error.message === "invalid_vault_payload",
+  );
+  await assert.rejects(
+    encryptVaultPayload({ vaultKey, wrappedKey, payload: {}, baseRevision: -1, cryptoValue: webcrypto }),
+    (error) => error.message === "invalid_base_revision",
+  );
+});

--- a/cloud/tests/public-vault-model.test.mjs
+++ b/cloud/tests/public-vault-model.test.mjs
@@ -118,6 +118,35 @@ test("validation rejects duplicate identities, unknown fields and unsafe record 
     }),
     /invalid_record_data/,
   );
+  assert.throws(
+    () => validateVaultDocument({ schemaVersion: 1, records: Array(10_001), tombstones: [] }),
+    /vault_too_large/,
+  );
+  const oversizedData = Array.from({ length: 1_000 }, () => Array(101).fill(0));
+  assert.throws(
+    () => upsertVaultRecord(createEmptyVaultDocument(), {
+      id: recordID,
+      type: "host",
+      data: { oversizedData },
+      deviceID: deviceA,
+      modifiedAt: firstTime,
+    }),
+    /invalid_record_data/,
+  );
+});
+
+test("conflict-free merges are idempotent and order-independent", () => {
+  const first = host();
+  const second = upsertVaultRecord(first, {
+    id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    type: "snippet",
+    data: { body: "Synthetic snippet" },
+    deviceID: deviceB,
+    modifiedAt: secondTime,
+  });
+
+  assert.deepEqual(mergeVaultDocuments(first, second), mergeVaultDocuments(second, first));
+  assert.deepEqual(mergeVaultDocuments(second, second), { document: second, conflicts: [] });
 });
 
 test("documents are normalized into deterministic entity and object-key order", () => {

--- a/cloud/tests/public-vault-model.test.mjs
+++ b/cloud/tests/public-vault-model.test.mjs
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createEmptyVaultDocument,
+  deleteVaultRecord,
+  mergeVaultDocuments,
+  resolveVaultConflict,
+  upsertVaultRecord,
+  validateVaultDocument,
+} from "../public/vault-model.js";
+
+const deviceA = "11111111-1111-4111-8111-111111111111";
+const deviceB = "22222222-2222-4222-8222-222222222222";
+const deviceC = "33333333-3333-4333-8333-333333333333";
+const recordID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const firstTime = "2026-09-02T10:00:00.000Z";
+const secondTime = "2026-09-02T11:00:00.000Z";
+const thirdTime = "2026-09-02T12:00:00.000Z";
+
+function host(document = createEmptyVaultDocument(), title = "Synthetic host", deviceID = deviceA, modifiedAt = firstTime) {
+  return upsertVaultRecord(document, {
+    id: recordID,
+    type: "host",
+    data: { hostname: "example.invalid", title },
+    deviceID,
+    modifiedAt,
+  });
+}
+
+test("record CRUD is immutable and advances the editing device version", () => {
+  const empty = createEmptyVaultDocument();
+  const created = host(empty);
+  const updated = host(created, "Updated synthetic host", deviceA, secondTime);
+
+  assert.deepEqual(empty, { schemaVersion: 1, records: [], tombstones: [] });
+  assert.equal(created.records[0].version[deviceA], 1);
+  assert.equal(updated.records[0].version[deviceA], 2);
+  assert.equal(updated.records[0].data.title, "Updated synthetic host");
+  assert.equal(created.records[0].data.title, "Synthetic host");
+});
+
+test("deletion creates a dominating tombstone instead of erasing history", () => {
+  const created = host();
+  const deleted = deleteVaultRecord(created, { id: recordID, deviceID: deviceB, deletedAt: secondTime });
+
+  assert.equal(deleted.records.length, 0);
+  assert.deepEqual(deleted.tombstones[0].version, { [deviceA]: 1, [deviceB]: 1 });
+  assert.equal(deleted.tombstones[0].deletedAt, secondTime);
+});
+
+test("a causally newer version wins without a conflict", () => {
+  const first = host();
+  const second = host(first, "Remote update", deviceB, secondTime);
+  const result = mergeVaultDocuments(first, second);
+
+  assert.equal(result.conflicts.length, 0);
+  assert.deepEqual(result.document, second);
+});
+
+test("concurrent offline edits are surfaced and omitted from the merge preview", () => {
+  const base = host();
+  const local = host(base, "Local edit", deviceA, secondTime);
+  const remote = host(base, "Remote edit", deviceB, secondTime);
+  const result = mergeVaultDocuments(local, remote);
+
+  assert.equal(result.document.records.length, 0);
+  assert.equal(result.conflicts.length, 1);
+  assert.equal(result.conflicts[0].local.value.data.title, "Local edit");
+  assert.equal(result.conflicts[0].remote.value.data.title, "Remote edit");
+});
+
+test("conflict resolution joins both histories before recording the resolver edit", () => {
+  const base = host();
+  const local = host(base, "Local edit", deviceA, secondTime);
+  const remote = host(base, "Remote edit", deviceB, secondTime);
+  const merge = mergeVaultDocuments(local, remote);
+  const resolved = resolveVaultConflict(merge.document, merge.conflicts[0], {
+    choice: "remote",
+    deviceID: deviceC,
+    resolvedAt: thirdTime,
+  });
+
+  assert.equal(resolved.records[0].data.title, "Remote edit");
+  assert.deepEqual(resolved.records[0].version, { [deviceA]: 2, [deviceB]: 1, [deviceC]: 1 });
+  assert.equal(mergeVaultDocuments(resolved, local).conflicts.length, 0);
+});
+
+test("concurrent edit and deletion require an explicit resolution", () => {
+  const base = host();
+  const edited = host(base, "Edited offline", deviceA, secondTime);
+  const deleted = deleteVaultRecord(base, { id: recordID, deviceID: deviceB, deletedAt: secondTime });
+  const result = mergeVaultDocuments(edited, deleted);
+
+  assert.equal(result.conflicts.length, 1);
+  assert.equal(result.conflicts[0].local.kind, "record");
+  assert.equal(result.conflicts[0].remote.kind, "tombstone");
+});
+
+test("validation rejects duplicate identities, unknown fields and unsafe record data", () => {
+  const created = host();
+  const unsafeData = Object.create(null);
+  Object.defineProperty(unsafeData, "__proto__", { value: { polluted: true }, enumerable: true });
+  assert.throws(
+    () => validateVaultDocument({ ...created, tombstones: [{ id: recordID, version: { [deviceA]: 2 }, deletedAt: secondTime }] }),
+    /duplicate_record_id/,
+  );
+  assert.throws(
+    () => validateVaultDocument({ ...created, unexpected: true }),
+    /invalid_vault_document/,
+  );
+  assert.throws(
+    () => upsertVaultRecord(createEmptyVaultDocument(), {
+      id: recordID,
+      type: "host",
+      data: unsafeData,
+      deviceID: deviceA,
+      modifiedAt: firstTime,
+    }),
+    /invalid_record_data/,
+  );
+});
+
+test("documents are normalized into deterministic entity and object-key order", () => {
+  const anotherID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+  let document = upsertVaultRecord(createEmptyVaultDocument(), {
+    id: anotherID,
+    type: "snippet",
+    data: { z: 1, a: { y: 2, b: 3 } },
+    deviceID: deviceA,
+    modifiedAt: firstTime,
+  });
+  document = host(document);
+  const normalized = validateVaultDocument(document);
+
+  assert.deepEqual(normalized.records.map((record) => record.id), [recordID, anotherID]);
+  assert.deepEqual(Object.keys(normalized.records[1].data), ["a", "z"]);
+  assert.deepEqual(Object.keys(normalized.records[1].data.a), ["b", "y"]);
+});

--- a/docs/cloud-v0.32-architecture.md
+++ b/docs/cloud-v0.32-architecture.md
@@ -62,6 +62,30 @@ Envelope v1 uses unpadded base64url fields, a 12-byte AES-GCM nonce, a 16-byte
 authentication tag and a 32-byte content hash. Every uploaded revision includes
 the wrapped Vault key so a later write cannot accidentally erase recovery data.
 
+### Envelope v1 interoperability profile
+
+The browser implementation uses Web Crypto without Node-only dependencies:
+
+- the Vault key is a random extractable 256-bit AES-GCM key;
+- the recovery passphrase is normalized to Unicode NFC, encoded as UTF-8 and is
+  never sent to the service;
+- PBKDF2-HMAC-SHA256 uses a random 16-byte salt and exactly 600,000 iterations
+  to derive a non-extractable 256-bit AES-KW key;
+- `wrappedKey` contains only `algorithm=PBKDF2-SHA256+A256KW`,
+  `iterations=600000`, the unpadded base64url salt and the 40-byte AES-KW
+  wrapped Vault key;
+- Vault JSON is encrypted with AES-256-GCM, a fresh 12-byte nonce, a 16-byte tag
+  and UTF-8 additional authenticated data
+  `selective-remote:vault-envelope:v1`;
+- `contentHash` is unpadded base64url SHA-256 over
+  `0x01 || nonce || ciphertext || authTag`, in that byte order.
+
+Clients must reject changed KDF parameters, malformed lengths, content-hash
+mismatches and AES-GCM authentication failures. The account password is not a
+Vault or recovery key. PBKDF2 does not make a weak recovery passphrase safe;
+the UI must require and confirm a strong independent recovery passphrase and
+must not persist plaintext, the passphrase or raw Vault keys in web storage.
+
 The client downloads the latest revision, decrypts it locally, performs a
 record-level merge by stable UUID and modification timestamp, then uploads a
 new revision based on the latest server value. Deletions use tombstones so

--- a/docs/cloud-v0.32-architecture.md
+++ b/docs/cloud-v0.32-architecture.md
@@ -86,10 +86,26 @@ Vault or recovery key. PBKDF2 does not make a weak recovery passphrase safe;
 the UI must require and confirm a strong independent recovery passphrase and
 must not persist plaintext, the passphrase or raw Vault keys in web storage.
 
-The client downloads the latest revision, decrypts it locally, performs a
-record-level merge by stable UUID and modification timestamp, then uploads a
-new revision based on the latest server value. Deletions use tombstones so
-that another device cannot resurrect removed records.
+The decrypted Vault document uses `schemaVersion=1`, deterministically sorted
+`records` and `tombstones`. Records have a stable UUID, one of the initial
+types `host`, `credential`, `snippet` or `forwarding`, JSON-safe local
+data, a canonical UTC `modifiedAt` value for display and a version vector
+keyed by device UUID. Tombstones retain the stable UUID, deletion time and the
+same version-vector format.
+
+Every local edit or deletion increments the current device's vector entry.
+During merge, a vector that causally dominates another wins. Equal vectors
+must describe identical entities. Concurrent vectors, including concurrent
+edit/delete operations, are omitted from the merge preview and returned as an
+explicit conflict; no timestamp silently chooses a winner. Resolution joins
+both vectors and increments the resolving device before the chosen record or
+tombstone can be uploaded. Modification timestamps are informational and do
+not establish causality, avoiding data loss from clock skew.
+
+The client downloads the latest revision, decrypts and validates it locally,
+performs this record-level merge, resolves any conflicts locally, then uploads
+a new encrypted revision based on the latest server revision. Tombstones
+prevent another device from resurrecting a causally older deleted record.
 
 The Cloud payload is separate from `.srbackup`. Backup archives remain manual,
 portable rollback artifacts; Cloud revisions are small synchronization units.


### PR DESCRIPTION
Begins Phase 4 with browser-local personal Vault cryptography and a causal record model.

Implemented:
- random extractable AES-256-GCM Vault keys;
- recovery wrapping via NFC UTF-8 passphrase, PBKDF2-HMAC-SHA256 (600,000, random 16-byte salt) and AES-256-KW;
- strict four-field wrapped-key schema, fixed protocol AAD, detached tag and encrypted-content hash validation;
- schema-v1 records for hosts, credentials, snippets and forwarding plus tombstones;
- per-record device version vectors, immutable CRUD, causal dominance and explicit concurrent edit/delete conflicts;
- conflict resolution that joins both histories before incrementing the resolver device;
- deterministic normalization, entity/document size bounds and rejection of unknown/unsafe data structures;
- no plaintext, passphrase or raw key persistence and no Node-only dependency in browser runtime modules;
- exact cross-platform envelope and merge rules in the architecture document.

Verification for exact head `57215e7c7a7815c471906a5b4a32aad40feb3b75`:
- local Node 24.19.0 focused tests: 17/17 passed;
- CI run `33668460368` (#469): completed successfully;
- Test DMG run `33668460364` (#173): completed successfully;
- artifact `SelectiveRemote-test-39-arm64`, id `9861782492`, 32,389,602 bytes;
- artifact digest `sha256:9acbde32c5173869cbf38ca6e7498a83c8fda1a80b79ad3b490f3ce1a9c4fd58`.

This PR does not add login/Vault UI, upload data, enable registration, deploy to the server or change `main`.