### PR TITLE
Cloud: add browser-local personal Vault UI

### DIFF
--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -1,3 +1,5 @@
+import { createIndexedDBVaultRepository, createLocalVaultController } from "./vault-local.js";
+
 const verificationPrefix = "#verify-email?";
 const passwordResetPrefix = "#reset-password?";
 
@@ -46,6 +48,201 @@ export async function submitPasswordReset(token, password, fetchValue = fetch) {
   if (!response.ok) throw new Error("password_reset_failed");
   const result = await response.json();
   if (result?.reset !== true) throw new Error("password_reset_failed");
+}
+
+export function localVaultRecordData(type, { title, target, secret }) {
+  const normalizedTitle = String(title ?? "").trim();
+  const normalizedTarget = String(target ?? "").trim();
+  const normalizedSecret = String(secret ?? "");
+  if (!normalizedTitle || normalizedTitle.length > 120 || normalizedTarget.length > 2048 || normalizedSecret.length > 32_768) {
+    throw new Error("invalid_local_record");
+  }
+  if (type === "host" && normalizedTarget) return { title: normalizedTitle, address: normalizedTarget };
+  if (type === "credential" && normalizedTarget && normalizedSecret) {
+    return { title: normalizedTitle, username: normalizedTarget, secret: normalizedSecret };
+  }
+  if (type === "snippet" && normalizedSecret) return { title: normalizedTitle, body: normalizedSecret };
+  if (type === "forwarding" && normalizedTarget) {
+    return { title: normalizedTitle, destination: normalizedTarget, configuration: normalizedSecret };
+  }
+  throw new Error("invalid_local_record");
+}
+
+export function localVaultRecordSummary(record) {
+  const data = record?.data ?? {};
+  let summary = "";
+  if (record?.type === "host") summary = String(data.address ?? "");
+  if (record?.type === "credential") summary = `${String(data.username ?? "")} · секрет скрыт`;
+  if (record?.type === "snippet") summary = String(data.body ?? "");
+  if (record?.type === "forwarding") summary = String(data.destination ?? "");
+  return summary.length > 240 ? `${summary.slice(0, 237)}…` : summary;
+}
+
+function setText(element, value) {
+  if (element) element.textContent = value;
+}
+
+export async function initializeLocalVault({
+  documentValue = document,
+  repository = createIndexedDBVaultRepository(),
+  confirmValue = (message) => globalThis.confirm(message),
+} = {}) {
+  const section = documentValue.querySelector("#local-vault");
+  if (!section) return null;
+  const setup = documentValue.querySelector("#local-vault-setup");
+  const unlock = documentValue.querySelector("#local-vault-unlock");
+  const workspace = documentValue.querySelector("#local-vault-workspace");
+  const message = documentValue.querySelector("#local-vault-message");
+  const records = documentValue.querySelector("#local-vault-records");
+  const setupForm = documentValue.querySelector("#local-vault-setup-form");
+  const unlockForm = documentValue.querySelector("#local-vault-unlock-form");
+  const recordForm = documentValue.querySelector("#local-vault-record-form");
+  const lockButton = documentValue.querySelector("#local-vault-lock");
+  const type = documentValue.querySelector("#local-record-type");
+  const title = documentValue.querySelector("#local-record-title");
+  const target = documentValue.querySelector("#local-record-target");
+  const secret = documentValue.querySelector("#local-record-secret");
+  const targetLabel = documentValue.querySelector("#local-record-target-label");
+  const secretLabel = documentValue.querySelector("#local-record-secret-label");
+  const controller = createLocalVaultController({ repository });
+
+  function mode(value) {
+    setup.hidden = value !== "empty";
+    unlock.hidden = value !== "locked";
+    workspace.hidden = value !== "unlocked";
+  }
+
+  function updateLabels() {
+    const labels = {
+      host: ["Адрес", "Дополнительные данные не требуются"],
+      credential: ["Имя пользователя", "Секрет"],
+      snippet: ["Не используется", "Текст Snippet"],
+      forwarding: ["Назначение", "Параметры"],
+    };
+    const [targetText, secretText] = labels[type.value] ?? labels.host;
+    setText(targetLabel, targetText);
+    setText(secretLabel, secretText);
+    target.required = type.value !== "snippet";
+    secret.required = type.value === "credential" || type.value === "snippet";
+  }
+
+  function render() {
+    const current = controller.document();
+    records.replaceChildren();
+    if (current.records.length === 0) {
+      const empty = documentValue.createElement("p");
+      empty.className = "vault-empty";
+      empty.textContent = "Vault пока пуст.";
+      records.append(empty);
+      return;
+    }
+    for (const record of current.records) {
+      const card = documentValue.createElement("article");
+      const heading = documentValue.createElement("h4");
+      const summary = documentValue.createElement("p");
+      const metadata = documentValue.createElement("small");
+      const remove = documentValue.createElement("button");
+      heading.textContent = String(record.data.title ?? "Без названия");
+      summary.textContent = localVaultRecordSummary(record);
+      metadata.textContent = `${record.type} · ${record.modifiedAt}`;
+      remove.type = "button";
+      remove.className = "danger";
+      remove.textContent = "Удалить";
+      remove.addEventListener("click", async () => {
+        if (!confirmValue(`Удалить «${heading.textContent}»?`)) return;
+        remove.disabled = true;
+        try {
+          await controller.delete(record.id);
+          setText(message, "Запись удалена. Tombstone сохранён в зашифрованном Vault.");
+          render();
+        } catch {
+          setText(message, "Не удалось сохранить удаление.");
+          remove.disabled = false;
+        }
+      });
+      card.append(heading, summary, metadata, remove);
+      records.append(card);
+    }
+  }
+
+  setupForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const passphrase = setupForm.elements.passphrase.value;
+    const confirmation = setupForm.elements.confirmation.value;
+    if (passphrase !== confirmation) {
+      setText(message, "Recovery-фразы не совпадают.");
+      return;
+    }
+    const button = setupForm.querySelector("button");
+    button.disabled = true;
+    try {
+      await controller.create(passphrase);
+      setupForm.reset();
+      mode("unlocked");
+      setText(message, "Локальный Vault создан и разблокирован только в памяти этой вкладки.");
+      render();
+    } catch {
+      setText(message, "Не удалось создать Vault. Проверьте recovery-фразу и доступ к локальному хранилищу.");
+      button.disabled = false;
+    }
+  });
+
+  unlockForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const button = unlockForm.querySelector("button");
+    button.disabled = true;
+    try {
+      await controller.unlock(unlockForm.elements.passphrase.value);
+      unlockForm.reset();
+      button.disabled = false;
+      mode("unlocked");
+      setText(message, "Vault расшифрован локально. Ключ существует только в памяти вкладки.");
+      render();
+    } catch {
+      setText(message, "Не удалось разблокировать Vault. Recovery-фраза неверна или данные повреждены.");
+      button.disabled = false;
+    }
+  });
+
+  recordForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const button = recordForm.querySelector("button");
+    button.disabled = true;
+    try {
+      await controller.upsert({
+        type: type.value,
+        data: localVaultRecordData(type.value, { title: title.value, target: target.value, secret: secret.value }),
+      });
+      recordForm.reset();
+      updateLabels();
+      setText(message, "Запись локально зашифрована и сохранена.");
+      render();
+    } catch {
+      setText(message, "Не удалось сохранить запись. Заполните обязательные поля.");
+    } finally {
+      button.disabled = false;
+    }
+  });
+
+  type.addEventListener("change", updateLabels);
+  lockButton.addEventListener("click", () => {
+    controller.lock();
+    mode("locked");
+    records.replaceChildren();
+    setText(message, "Vault заблокирован; ключ удалён из состояния страницы.");
+  });
+
+  updateLabels();
+  try {
+    mode(await controller.status());
+    setText(message, "Данные остаются на этом устройстве в зашифрованном виде; синхронизация ещё не подключена.");
+  } catch {
+    setup.hidden = true;
+    unlock.hidden = true;
+    workspace.hidden = true;
+    setText(message, "Локальное защищённое хранилище недоступно в этом браузере.");
+  }
+  return controller;
 }
 
 async function updateServiceStatus(documentValue, fetchValue) {
@@ -132,6 +329,7 @@ export async function initializePortal({
       });
     }
   }
+  await initializeLocalVault({ documentValue });
   await updateServiceStatus(documentValue, fetchValue);
 }
 

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -58,6 +58,62 @@
       <article><span>03</span><h3>Локальный режим</h3><p>Аккаунт необязателен: приложение продолжает полноценно работать автономно.</p></article>
     </section>
 
+    <section class="local-vault" id="local-vault" aria-labelledby="local-vault-title">
+      <div class="vault-heading">
+        <div>
+          <p class="eyebrow">PERSONAL VAULT · LOCAL PREVIEW</p>
+          <h2 id="local-vault-title">Зашифрованное хранилище в браузере</h2>
+        </div>
+        <p id="local-vault-message" aria-live="polite">Проверяем локальное хранилище…</p>
+      </div>
+
+      <div class="vault-panel" id="local-vault-setup" hidden>
+        <h3>Создать локальный Vault</h3>
+        <p>Recovery-фраза не отправляется на сервер и не сохраняется в браузере. Потерянную фразу пока восстановить невозможно.</p>
+        <form id="local-vault-setup-form">
+          <label for="local-vault-passphrase">Независимая recovery-фраза</label>
+          <input id="local-vault-passphrase" name="passphrase" type="password" minlength="16" maxlength="1024" autocomplete="new-password" required>
+          <label for="local-vault-confirmation">Повторите recovery-фразу</label>
+          <input id="local-vault-confirmation" name="confirmation" type="password" minlength="16" maxlength="1024" autocomplete="new-password" required>
+          <button type="submit">Создать и разблокировать</button>
+        </form>
+      </div>
+
+      <div class="vault-panel" id="local-vault-unlock" hidden>
+        <h3>Разблокировать Vault</h3>
+        <p>Расшифровка выполняется локально. Ключ живёт только в памяти открытой вкладки.</p>
+        <form id="local-vault-unlock-form">
+          <label for="local-vault-unlock-passphrase">Recovery-фраза</label>
+          <input id="local-vault-unlock-passphrase" name="passphrase" type="password" minlength="16" maxlength="1024" autocomplete="off" required>
+          <button type="submit">Разблокировать</button>
+        </form>
+      </div>
+
+      <div class="vault-workspace" id="local-vault-workspace" hidden>
+        <div class="vault-toolbar">
+          <div><h3>Личный Vault</h3><p>Локальная версия без Cloud-синхронизации.</p></div>
+          <button type="button" class="secondary" id="local-vault-lock">Заблокировать</button>
+        </div>
+        <form class="record-form" id="local-vault-record-form">
+          <label for="local-record-type">Тип записи</label>
+          <select id="local-record-type" name="type">
+            <option value="host">Host</option>
+            <option value="credential">Credential</option>
+            <option value="snippet">Snippet</option>
+            <option value="forwarding">Forwarding</option>
+          </select>
+          <label for="local-record-title">Название</label>
+          <input id="local-record-title" name="title" maxlength="120" required>
+          <label for="local-record-target" id="local-record-target-label">Адрес</label>
+          <input id="local-record-target" name="target" maxlength="2048">
+          <label for="local-record-secret" id="local-record-secret-label">Дополнительные данные не требуются</label>
+          <textarea id="local-record-secret" name="secret" maxlength="32768" rows="3"></textarea>
+          <button type="submit">Зашифровать и сохранить</button>
+        </form>
+        <div class="vault-records" id="local-vault-records"></div>
+      </div>
+    </section>
+
     <section class="access">
       <div><p class="eyebrow">V0.32 FOUNDATION</p><h2>Портал готовится к первому входу</h2></div>
       <p>Регистрация будет открыта после завершения сброса пароля, ограничения запросов, защиты от злоупотреблений и ручной проверки безопасности.</p>

--- a/cloud/public/styles.css
+++ b/cloud/public/styles.css
@@ -22,7 +22,22 @@ body { margin:0; min-height:100vh; background:radial-gradient(circle at 70% 15%,
 .vault-core span { font-size:38px; font-weight:800; line-height:1; }.vault-core small { font-size:10px; letter-spacing:.12em; margin-top:6px; }
 .grid { display:grid; grid-template-columns:repeat(3,1fr); gap:1px; background:var(--line); border:1px solid var(--line); margin:50px 0; }
 .grid article { background:var(--panel); padding:30px; min-height:210px; }.grid span { color:var(--accent); font-family:ui-monospace,monospace; }.grid h3 { margin:38px 0 12px; font-size:20px; }.grid p,.access p { color:var(--muted); line-height:1.55; }
+.local-vault { margin:50px 0; padding:34px; border:1px solid var(--line); border-radius:22px; background:#0c1714e8; }
+.vault-heading,.vault-toolbar { display:flex; align-items:flex-start; justify-content:space-between; gap:32px; }
+.vault-heading h2,.vault-toolbar h3 { margin:8px 0 0; }.vault-heading>p,.vault-toolbar p,.vault-panel>p { max-width:520px; color:var(--muted); line-height:1.55; margin:0; }
+.vault-panel,.vault-workspace { margin-top:28px; padding-top:28px; border-top:1px solid var(--line); }.vault-panel h3 { margin-top:0; }
+.vault-panel form,.record-form { display:grid; grid-template-columns:minmax(150px,.45fr) minmax(240px,1fr); align-items:center; gap:12px 18px; margin-top:24px; }
+.vault-panel label,.record-form label { color:var(--muted); font-size:13px; }
+.vault-panel input,.record-form input,.record-form select,.record-form textarea { width:100%; border:1px solid var(--line); border-radius:10px; padding:12px 14px; background:#07100d; color:var(--ink); font:inherit; }
+.record-form textarea { resize:vertical; }.record-form select { color-scheme:dark; }
+.vault-panel button,.record-form button,.vault-toolbar button,.vault-records button { border:0; border-radius:10px; padding:12px 18px; background:var(--accent); color:#082016; font:inherit; font-weight:750; cursor:pointer; }
+.vault-panel button,.record-form button { grid-column:2; justify-self:start; margin-top:6px; }.vault-toolbar button.secondary { background:transparent; border:1px solid var(--line); color:var(--ink); }
+.vault-panel button:disabled,.record-form button:disabled,.vault-records button:disabled { opacity:.6; cursor:wait; }
+.vault-records { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:14px; margin-top:28px; }
+.vault-records article { display:grid; grid-template-columns:1fr auto; gap:8px 16px; align-items:center; padding:20px; border:1px solid var(--line); border-radius:14px; background:#08110e; }
+.vault-records h4,.vault-records p { margin:0; overflow-wrap:anywhere; }.vault-records p,.vault-records small,.vault-empty { color:var(--muted); }.vault-records small { font-family:ui-monospace,monospace; }
+.vault-records button.danger { grid-column:2; grid-row:1 / span 3; align-self:center; padding:9px 12px; background:transparent; border:1px solid #ff8f7a66; color:#ffb4a6; }
 .access { display:flex; justify-content:space-between; gap:40px; align-items:end; padding:34px; border:1px solid var(--line); border-radius:18px; background:#0c1714cc; }.access h2 { margin:8px 0 0; }.access>p { max-width:500px; margin:0; }
 @keyframes spin { to { transform:rotate(360deg); } }
-@media (max-width:760px) { .shell{width:min(100% - 24px,1180px);padding-top:18px}.hero{grid-template-columns:1fr;padding:64px 0;gap:30px}.vault-visual{width:230px}.grid{grid-template-columns:1fr}.access{align-items:start;flex-direction:column}.status{font-size:0}.status::after{content:"●";font-size:16px} }
+@media (max-width:760px) { .shell{width:min(100% - 24px,1180px);padding-top:18px}.hero{grid-template-columns:1fr;padding:64px 0;gap:30px}.vault-visual{width:230px}.grid{grid-template-columns:1fr}.vault-heading,.vault-toolbar,.access{align-items:start;flex-direction:column}.vault-panel form,.record-form{grid-template-columns:1fr}.vault-panel button,.record-form button{grid-column:1}.vault-records{grid-template-columns:1fr}.status{font-size:0}.status::after{content:"●";font-size:16px} }
 @media (prefers-reduced-motion:reduce) { .orbit{animation:none} }

--- a/cloud/public/vault-local.js
+++ b/cloud/public/vault-local.js
@@ -1,0 +1,208 @@
+import {
+  decryptVaultEnvelope,
+  encryptVaultPayload,
+  generateVaultKey,
+  unwrapVaultKey,
+  wrapVaultKey,
+} from "./vault-crypto.js";
+import {
+  createEmptyVaultDocument,
+  deleteVaultRecord,
+  upsertVaultRecord,
+  validateVaultDocument,
+} from "./vault-model.js";
+
+const databaseName = "selective-remote-cloud";
+const storeName = "local-vault";
+const snapshotKey = "personal";
+const exactUUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const recordTypes = new Set(["host", "credential", "snippet", "forwarding"]);
+const snapshotKeys = ["deviceID", "envelope", "revision"];
+const envelopeKeys = ["authTag", "baseRevision", "ciphertext", "contentHash", "envelopeVersion", "nonce", "wrappedKey"];
+
+function exactKeys(value, expected, code) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(code);
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (actual.length !== wanted.length || actual.some((key, index) => key !== wanted[index])) {
+    throw new Error(code);
+  }
+}
+
+function validatedSnapshot(value) {
+  exactKeys(value, snapshotKeys, "invalid_local_vault");
+  exactKeys(value.envelope, envelopeKeys, "invalid_local_vault");
+  if (!Number.isSafeInteger(value.revision) || value.revision < 1) throw new Error("invalid_local_vault");
+  if (value.envelope.baseRevision !== value.revision - 1) throw new Error("invalid_local_vault");
+  const deviceID = String(value.deviceID ?? "").toLowerCase();
+  if (!exactUUID.test(deviceID)) throw new Error("invalid_local_vault");
+  return { revision: value.revision, deviceID, envelope: value.envelope };
+}
+
+function clone(value) {
+  return globalThis.structuredClone
+    ? globalThis.structuredClone(value)
+    : JSON.parse(JSON.stringify(value));
+}
+
+function openDatabase(indexedDBValue) {
+  if (!indexedDBValue?.open) return Promise.reject(new Error("local_vault_storage_unavailable"));
+  return new Promise((resolve, reject) => {
+    const request = indexedDBValue.open(databaseName, 1);
+    request.onupgradeneeded = () => {
+      if (!request.result.objectStoreNames.contains(storeName)) request.result.createObjectStore(storeName);
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(new Error("local_vault_storage_unavailable"));
+    request.onblocked = () => reject(new Error("local_vault_storage_unavailable"));
+  });
+}
+
+async function transaction(indexedDBValue, mode, operation) {
+  const database = await openDatabase(indexedDBValue);
+  try {
+    return await new Promise((resolve, reject) => {
+      const tx = database.transaction(storeName, mode);
+      const request = operation(tx.objectStore(storeName));
+      let result = null;
+      request.onsuccess = () => { result = request.result ?? null; };
+      request.onerror = () => reject(new Error("local_vault_storage_failed"));
+      tx.onabort = () => reject(new Error("local_vault_storage_failed"));
+      tx.onerror = () => reject(new Error("local_vault_storage_failed"));
+      tx.oncomplete = () => resolve(result);
+    });
+  } finally {
+    database.close();
+  }
+}
+
+export function createIndexedDBVaultRepository(indexedDBValue = globalThis.indexedDB) {
+  return {
+    async load() {
+      const value = await transaction(indexedDBValue, "readonly", (store) => store.get(snapshotKey));
+      return value === null || value === undefined ? null : clone(value);
+    },
+    async save(value) {
+      const snapshot = validatedSnapshot(value);
+      await transaction(indexedDBValue, "readwrite", (store) => store.put(clone(snapshot), snapshotKey));
+    },
+  };
+}
+
+export function createLocalVaultController({
+  repository,
+  cryptoValue = globalThis.crypto,
+  now = () => new Date().toISOString(),
+  randomUUID = () => cryptoValue.randomUUID(),
+} = {}) {
+  if (!repository || typeof repository.load !== "function" || typeof repository.save !== "function") {
+    throw new Error("invalid_local_vault_repository");
+  }
+
+  let snapshot = null;
+  let vaultKey = null;
+  let document = null;
+
+  function requireUnlocked() {
+    if (!snapshot || !vaultKey || !document) throw new Error("local_vault_locked");
+  }
+
+  async function persist(nextDocument) {
+    requireUnlocked();
+    const normalized = validateVaultDocument(nextDocument);
+    const envelope = await encryptVaultPayload({
+      vaultKey,
+      payload: normalized,
+      baseRevision: snapshot.revision,
+      wrappedKey: snapshot.envelope.wrappedKey,
+      cryptoValue,
+    });
+    const nextSnapshot = validatedSnapshot({
+      revision: snapshot.revision + 1,
+      deviceID: snapshot.deviceID,
+      envelope,
+    });
+    await repository.save(nextSnapshot);
+    snapshot = nextSnapshot;
+    document = normalized;
+    return clone(document);
+  }
+
+  return {
+    async status() {
+      if (snapshot && vaultKey && document) return "unlocked";
+      return (await repository.load()) ? "locked" : "empty";
+    },
+
+    async create(passphrase) {
+      if (await repository.load()) throw new Error("local_vault_exists");
+      const nextVaultKey = await generateVaultKey(cryptoValue);
+      const wrappedKey = await wrapVaultKey(nextVaultKey, passphrase, cryptoValue);
+      const nextDocument = createEmptyVaultDocument();
+      const envelope = await encryptVaultPayload({
+        vaultKey: nextVaultKey,
+        payload: nextDocument,
+        baseRevision: 0,
+        wrappedKey,
+        cryptoValue,
+      });
+      const nextSnapshot = validatedSnapshot({ revision: 1, deviceID: randomUUID(), envelope });
+      await repository.save(nextSnapshot);
+      snapshot = nextSnapshot;
+      vaultKey = nextVaultKey;
+      document = nextDocument;
+      return clone(document);
+    },
+
+    async unlock(passphrase) {
+      snapshot = null;
+      vaultKey = null;
+      document = null;
+      const stored = await repository.load();
+      if (!stored) throw new Error("local_vault_missing");
+      const nextSnapshot = validatedSnapshot(stored);
+      const nextVaultKey = await unwrapVaultKey(nextSnapshot.envelope.wrappedKey, passphrase, cryptoValue);
+      const nextDocument = validateVaultDocument(
+        await decryptVaultEnvelope(nextVaultKey, nextSnapshot.envelope, cryptoValue),
+      );
+      snapshot = nextSnapshot;
+      vaultKey = nextVaultKey;
+      document = nextDocument;
+      return clone(document);
+    },
+
+    lock() {
+      snapshot = null;
+      vaultKey = null;
+      document = null;
+    },
+
+    document() {
+      requireUnlocked();
+      return clone(document);
+    },
+
+    async upsert({ id = randomUUID(), type, data }) {
+      requireUnlocked();
+      if (!recordTypes.has(type)) throw new Error("invalid_record_type");
+      const next = upsertVaultRecord(document, {
+        id,
+        type,
+        data,
+        deviceID: snapshot.deviceID,
+        modifiedAt: now(),
+      });
+      await persist(next);
+      return id;
+    },
+
+    async delete(id) {
+      requireUnlocked();
+      return persist(deleteVaultRecord(document, {
+        id,
+        deviceID: snapshot.deviceID,
+        deletedAt: now(),
+      }));
+    },
+  };
+}

--- a/cloud/tests/public-vault-local.test.mjs
+++ b/cloud/tests/public-vault-local.test.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { webcrypto } from "node:crypto";
+import test from "node:test";
+import { createLocalVaultController } from "../public/vault-local.js";
+
+const passphrase = "correct horse battery staple for local recovery";
+const deviceID = "11111111-1111-4111-8111-111111111111";
+const recordIDs = [
+  "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+  "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+  "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+  "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+];
+
+function memoryRepository(initial = null) {
+  let value = initial;
+  return {
+    async load() { return value ? structuredClone(value) : null; },
+    async save(next) { value = structuredClone(next); },
+    snapshot() { return value ? structuredClone(value) : null; },
+  };
+}
+
+function controller(repository, ids = [deviceID, ...recordIDs]) {
+  let index = 0;
+  return createLocalVaultController({
+    repository,
+    cryptoValue: webcrypto,
+    randomUUID: () => ids[index++],
+    now: () => "2026-09-03T06:30:00.000Z",
+  });
+}
+
+test("new local Vault persists only an encrypted envelope", async () => {
+  const repository = memoryRepository();
+  const vault = controller(repository);
+
+  assert.equal(await vault.status(), "empty");
+  assert.deepEqual(await vault.create(passphrase), { schemaVersion: 1, records: [], tombstones: [] });
+  assert.equal(await vault.status(), "unlocked");
+
+  const serialized = JSON.stringify(repository.snapshot());
+  assert.equal(serialized.includes(passphrase), false);
+  assert.equal(serialized.includes("records"), false);
+  assert.equal(serialized.includes("tombstones"), false);
+  assert.equal(repository.snapshot().revision, 1);
+  assert.equal(repository.snapshot().deviceID, deviceID);
+});
+
+test("lock drops the in-memory key and wrong recovery passphrases fail closed", async () => {
+  const repository = memoryRepository();
+  const vault = controller(repository);
+  await vault.create(passphrase);
+  vault.lock();
+
+  assert.throws(() => vault.document(), /local_vault_locked/);
+  await assert.rejects(vault.unlock("a different long recovery passphrase"), /invalid_recovery_passphrase/);
+  assert.throws(() => vault.document(), /local_vault_locked/);
+  assert.deepEqual(await vault.unlock(passphrase), { schemaVersion: 1, records: [], tombstones: [] });
+  await assert.rejects(vault.unlock("another incorrect recovery phrase"), /invalid_recovery_passphrase/);
+  assert.throws(() => vault.document(), /local_vault_locked/);
+});
+
+test("all personal record types round-trip and every mutation advances the encrypted revision", async () => {
+  const repository = memoryRepository();
+  const vault = controller(repository);
+  await vault.create(passphrase);
+
+  await vault.upsert({ type: "host", data: { title: "Host", address: "example.invalid" } });
+  await vault.upsert({ type: "credential", data: { title: "Admin", username: "root", secret: "synthetic-secret" } });
+  await vault.upsert({ type: "snippet", data: { title: "Check", body: "uptime" } });
+  await vault.upsert({ type: "forwarding", data: { title: "DB", destination: "db.invalid:5432" } });
+
+  assert.deepEqual(vault.document().records.map((record) => record.type), [
+    "host", "credential", "snippet", "forwarding",
+  ]);
+  assert.equal(repository.snapshot().revision, 5);
+  assert.equal(JSON.stringify(repository.snapshot()).includes("synthetic-secret"), false);
+
+  vault.lock();
+  await vault.unlock(passphrase);
+  assert.equal(vault.document().records[1].data.secret, "synthetic-secret");
+});
+
+test("deletion writes an encrypted tombstone and cannot resurrect the record after unlock", async () => {
+  const repository = memoryRepository();
+  const vault = controller(repository);
+  await vault.create(passphrase);
+  const id = await vault.upsert({ type: "host", data: { title: "Disposable", address: "test.invalid" } });
+  await vault.delete(id);
+
+  assert.equal(vault.document().records.length, 0);
+  assert.equal(vault.document().tombstones[0].id, id);
+  assert.equal(JSON.stringify(repository.snapshot()).includes("Disposable"), false);
+  vault.lock();
+  await vault.unlock(passphrase);
+  assert.equal(vault.document().records.length, 0);
+  assert.equal(vault.document().tombstones.length, 1);
+});
+
+test("malformed local snapshots and revision mismatches are rejected before decryption", async () => {
+  const repository = memoryRepository();
+  const vault = controller(repository);
+  await vault.create(passphrase);
+  const valid = repository.snapshot();
+
+  const extra = controller(memoryRepository({ ...valid, plaintext: {} }));
+  await assert.rejects(extra.unlock(passphrase), /invalid_local_vault/);
+
+  const mismatch = controller(memoryRepository({ ...valid, revision: valid.revision + 1 }));
+  await assert.rejects(mismatch.unlock(passphrase), /invalid_local_vault/);
+});
+
+test("failed storage commits leave the unlocked document unchanged", async () => {
+  const base = memoryRepository();
+  const vault = controller(base);
+  await vault.create(passphrase);
+  const failing = {
+    load: () => base.load(),
+    async save() { throw new Error("storage_failed"); },
+  };
+  const recovered = controller(failing, [recordIDs[0]]);
+  await recovered.unlock(passphrase);
+
+  await assert.rejects(
+    recovered.upsert({ type: "snippet", data: { title: "Never committed", body: "secret" } }),
+    /storage_failed/,
+  );
+  assert.deepEqual(recovered.document(), { schemaVersion: 1, records: [], tombstones: [] });
+});

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { localVaultRecordData, localVaultRecordSummary } from "../public/app.js";
+
+test("Vault form values map to the four versioned record types", () => {
+  assert.deepEqual(
+    localVaultRecordData("host", { title: " Production ", target: "host.invalid", secret: "" }),
+    { title: "Production", address: "host.invalid" },
+  );
+  assert.deepEqual(
+    localVaultRecordData("credential", { title: "Admin", target: "root", secret: "synthetic-secret" }),
+    { title: "Admin", username: "root", secret: "synthetic-secret" },
+  );
+  assert.deepEqual(
+    localVaultRecordData("snippet", { title: "Status", target: "", secret: "uptime" }),
+    { title: "Status", body: "uptime" },
+  );
+  assert.deepEqual(
+    localVaultRecordData("forwarding", { title: "Database", target: "db.invalid:5432", secret: "local 15432" }),
+    { title: "Database", destination: "db.invalid:5432", configuration: "local 15432" },
+  );
+});
+
+test("Vault form mapping rejects incomplete and oversized records", () => {
+  assert.throws(
+    () => localVaultRecordData("credential", { title: "Admin", target: "root", secret: "" }),
+    /invalid_local_record/,
+  );
+  assert.throws(
+    () => localVaultRecordData("unknown", { title: "Unknown", target: "value", secret: "value" }),
+    /invalid_local_record/,
+  );
+  assert.throws(
+    () => localVaultRecordData("host", { title: "x".repeat(121), target: "host.invalid", secret: "" }),
+    /invalid_local_record/,
+  );
+});
+
+test("credential summaries never expose their secret", () => {
+  const record = {
+    type: "credential",
+    data: { title: "Admin", username: "root", secret: "must-not-render" },
+  };
+  const summary = localVaultRecordSummary(record);
+
+  assert.equal(summary, "root · секрет скрыт");
+  assert.equal(summary.includes(record.data.secret), false);
+});

--- a/docs/cloud-v0.32-architecture.md
+++ b/docs/cloud-v0.32-architecture.md
@@ -102,6 +102,27 @@ both vectors and increments the resolving device before the chosen record or
 tombstone can be uploaded. Modification timestamps are informational and do
 not establish causality, avoiding data loss from clock skew.
 
+### Browser-local preview boundary
+
+The initial personal Vault preview persists one strict local snapshot in
+IndexedDB: a monotonically increasing local revision, a random device UUID and
+the encrypted envelope. Record titles, addresses, usernames, secrets, snippets
+and forwarding configuration remain inside the ciphertext. The revision and
+random device UUID are local metadata and are not secret content.
+
+The recovery passphrase and raw Vault key are never written by the
+application. The raw key exists only in the live controller; explicit locking,
+failed unlock and page teardown drop that reference. Every CRUD mutation is
+normalized, encrypted with a fresh nonce and treated as committed only after
+the IndexedDB transaction completes. Storage corruption, unknown snapshot
+fields, revision mismatch, unavailable IndexedDB and wrong recovery phrases
+fail closed. There is deliberately no plaintext or Web Storage fallback.
+
+This preview is local-only. It does not authenticate, upload, download or claim
+cross-device recovery. Cloud synchronization must later reconcile the local
+encrypted revision against the authenticated server revision without making
+IndexedDB a second source of truth.
+
 The client downloads the latest revision, decrypts and validates it locally,
 performs this record-level merge, resolves any conflicts locally, then uploads
 a new encrypted revision based on the latest server revision. Tombstones


### PR DESCRIPTION
Continues Phase 4 with a functional local-only personal Vault preview built on the merged PR #39 crypto and causal record model.

Implemented:
- strict IndexedDB snapshot repository with no plaintext/Web Storage fallback;
- in-memory Vault key lifecycle with create, recovery unlock and explicit lock;
- fail-closed handling for wrong recovery phrases, malformed snapshots, revision mismatch and unavailable storage;
- transaction-complete persistence before a CRUD mutation becomes visible;
- browser CRUD for Host, Credential, Snippet and Forwarding records;
- encrypted tombstones for deletion and fresh AES-GCM envelopes for every mutation;
- text-only DOM rendering; credential secrets are never shown in record summaries;
- responsive local Vault panels and documented local-preview privacy/sync boundary.

Verification for exact head `a76f2f2a9ccd1f7d65b1e48c29bde1a667adc11f`:
- local Node focused crypto/model/storage/UI tests: 26/26 passed;
- JavaScript syntax checks and HTML parser check passed;
- remote bytes and Git blob SHA values match all six locally tested code/test/UI files;
- branch is 7 commits ahead and 0 behind public main `f8e418b9fcacd6f0aada2b0f6a5d08e37eb6f281`;
- CI run `33723445882` (#471): completed successfully;
- Test DMG run `33723445914` (#174): completed successfully;
- artifact `SelectiveRemote-test-40-arm64`, id `9881258638`, 32,389,750 bytes;
- artifact digest `sha256:496dd295d211d845de7a08cfc8f2730979719a974352d16077c190721c6285bb`.

This PR does not authenticate, synchronize with Cloud, upload Vault data, enable registration, deploy to the server, change `main` or claim cross-device recovery.