### PR TITLE
Cloud: add authenticated encrypted Vault sync

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -8,6 +8,16 @@ The final v0.32 product scope also includes Teams and shared Vaults. This
 foundation milestone does not yet implement membership, roles, shared-key
 distribution or shared-record APIs.
 
+The browser portal can create and unlock a client-encrypted personal Vault,
+perform local CRUD, sign in with an existing verified account and manually
+synchronize opaque revisions through the personal-Vault API. The bearer session
+exists only in page memory. IndexedDB contains ciphertext, a random device UUID
+and non-secret revision acknowledgement metadata, never the session token,
+recovery passphrase, raw Vault key or decrypted records. Concurrent record
+conflicts and server revision conflicts stop upload instead of overwriting.
+Registration, Team endpoints, conflict-resolution UI and complete clean-browser
+recovery UX remain disabled or unfinished.
+
 ## Local verification
 
 ```bash

--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -1,4 +1,5 @@
 import { createIndexedDBVaultRepository, createLocalVaultController } from "./vault-local.js";
+import { createAuthenticatedVaultClient, synchronizeVault } from "./vault-sync.js";
 
 const verificationPrefix = "#verify-email?";
 const passwordResetPrefix = "#reset-password?";
@@ -245,6 +246,94 @@ export async function initializeLocalVault({
   return controller;
 }
 
+export async function initializeCloudAccount({
+  documentValue = document,
+  vault,
+  fetchValue = fetch,
+} = {}) {
+  const section = documentValue.querySelector("#cloud-account");
+  if (!section || !vault) return null;
+  const form = documentValue.querySelector("#cloud-login-form");
+  const signedIn = documentValue.querySelector("#cloud-signed-in");
+  const accountName = documentValue.querySelector("#cloud-account-name");
+  const message = documentValue.querySelector("#cloud-account-message");
+  const logoutButton = documentValue.querySelector("#cloud-logout");
+  const syncButton = documentValue.querySelector("#cloud-vault-sync");
+  const vaultMessage = documentValue.querySelector("#local-vault-message");
+  const client = createAuthenticatedVaultClient({ fetchValue });
+
+  function showSession(user) {
+    form.hidden = Boolean(user);
+    signedIn.hidden = !user;
+    syncButton.disabled = !user;
+    setText(accountName, user ? `${user.displayName || user.email} · ${user.email}` : "");
+  }
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const button = form.querySelector("button");
+    button.disabled = true;
+    try {
+      const user = await client.login({
+        email: form.elements.email.value,
+        password: form.elements.password.value,
+        deviceID: await vault.deviceID(),
+      });
+      form.elements.password.value = "";
+      showSession(user);
+      setText(message, "Вход выполнен. Сессионный токен хранится только в памяти этой вкладки.");
+    } catch {
+      setText(message, "Не удалось войти. Проверьте email, пароль и подтверждение аккаунта.");
+    } finally {
+      button.disabled = false;
+    }
+  });
+
+  logoutButton.addEventListener("click", async () => {
+    logoutButton.disabled = true;
+    try {
+      await client.logout();
+    } finally {
+      showSession(null);
+      logoutButton.disabled = false;
+      setText(message, "Сессия завершена, токен удалён из памяти вкладки.");
+    }
+  });
+
+  syncButton.addEventListener("click", async () => {
+    syncButton.disabled = true;
+    try {
+      const result = await synchronizeVault({ client, vault });
+      const messages = {
+        empty: "Сначала создайте локальный Vault.",
+        uploaded: `Зашифрованная ревизия ${result.revision} загружена.`,
+        uploaded_with_new_local_changes: `Ревизия ${result.revision} загружена; появились новые локальные изменения — синхронизируйте ещё раз.`,
+        downloaded: `Зашифрованная ревизия ${result.revision} загружена и объединена локально.`,
+        up_to_date: `Vault уже синхронизирован на ревизии ${result.revision}.`,
+        remote_changed: `Удалённый Vault изменился до ревизии ${result.remoteRevision}. Повторите синхронизацию для безопасного merge.`,
+        conflict: `Обнаружено конфликтов: ${result.conflicts.length}. Upload остановлен; требуется явное разрешение конфликтов.`,
+      };
+      setText(vaultMessage, messages[result.status] ?? "Синхронизация завершена.");
+    } catch (error) {
+      const code = String(error?.message ?? "");
+      if (code === "local_vault_locked") setText(vaultMessage, "Сначала разблокируйте локальный Vault.");
+      else if (code === "authentication_required") {
+        showSession(null);
+        setText(vaultMessage, "Сессия истекла. Войдите снова.");
+      } else if (code === "recovery_passphrase_required") {
+        setText(vaultMessage, "На сервере есть Vault. Импорт в чистый браузер требует recovery-фразу и будет добавлен отдельным шагом.");
+      } else {
+        setText(vaultMessage, "Синхронизация не выполнена; локальные данные не потеряны.");
+      }
+    } finally {
+      syncButton.disabled = !client.session();
+    }
+  });
+
+  showSession(null);
+  return client;
+}
+
 async function updateServiceStatus(documentValue, fetchValue) {
   const status = documentValue.querySelector("#service-status");
   try {
@@ -329,7 +418,8 @@ export async function initializePortal({
       });
     }
   }
-  await initializeLocalVault({ documentValue });
+  const vault = await initializeLocalVault({ documentValue });
+  await initializeCloudAccount({ documentValue, vault, fetchValue });
   await updateServiceStatus(documentValue, fetchValue);
 }
 

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -58,6 +58,25 @@
       <article><span>03</span><h3>Локальный режим</h3><p>Аккаунт необязателен: приложение продолжает полноценно работать автономно.</p></article>
     </section>
 
+    <section class="cloud-account" id="cloud-account" aria-labelledby="cloud-account-title">
+      <div>
+        <p class="eyebrow">CLOUD SESSION · MEMORY ONLY</p>
+        <h2 id="cloud-account-title">Вход для зашифрованной синхронизации</h2>
+        <p id="cloud-account-message" aria-live="polite">Токен не сохраняется в localStorage, sessionStorage или IndexedDB.</p>
+      </div>
+      <form id="cloud-login-form" method="post" action="/v1/auth/login">
+        <label for="cloud-email">Email</label>
+        <input id="cloud-email" name="email" type="email" maxlength="254" autocomplete="username" required>
+        <label for="cloud-password">Пароль аккаунта</label>
+        <input id="cloud-password" name="password" type="password" minlength="12" maxlength="1024" autocomplete="current-password" required>
+        <button type="submit">Войти</button>
+      </form>
+      <div id="cloud-signed-in" hidden>
+        <p id="cloud-account-name"></p>
+        <button type="button" class="secondary" id="cloud-logout">Выйти и удалить токен из памяти</button>
+      </div>
+    </section>
+
     <section class="local-vault" id="local-vault" aria-labelledby="local-vault-title">
       <div class="vault-heading">
         <div>
@@ -91,8 +110,11 @@
 
       <div class="vault-workspace" id="local-vault-workspace" hidden>
         <div class="vault-toolbar">
-          <div><h3>Личный Vault</h3><p>Локальная версия без Cloud-синхронизации.</p></div>
-          <button type="button" class="secondary" id="local-vault-lock">Заблокировать</button>
+          <div><h3>Личный Vault</h3><p>Зашифрованная локальная копия с ручной Cloud-синхронизацией.</p></div>
+          <div class="vault-actions">
+            <button type="button" id="cloud-vault-sync" disabled>Синхронизировать</button>
+            <button type="button" class="secondary" id="local-vault-lock">Заблокировать</button>
+          </div>
         </div>
         <form class="record-form" id="local-vault-record-form">
           <label for="local-record-type">Тип записи</label>

--- a/cloud/public/styles.css
+++ b/cloud/public/styles.css
@@ -22,6 +22,12 @@ body { margin:0; min-height:100vh; background:radial-gradient(circle at 70% 15%,
 .vault-core span { font-size:38px; font-weight:800; line-height:1; }.vault-core small { font-size:10px; letter-spacing:.12em; margin-top:6px; }
 .grid { display:grid; grid-template-columns:repeat(3,1fr); gap:1px; background:var(--line); border:1px solid var(--line); margin:50px 0; }
 .grid article { background:var(--panel); padding:30px; min-height:210px; }.grid span { color:var(--accent); font-family:ui-monospace,monospace; }.grid h3 { margin:38px 0 12px; font-size:20px; }.grid p,.access p { color:var(--muted); line-height:1.55; }
+.cloud-account { margin:50px 0; padding:34px; display:grid; grid-template-columns:minmax(0,1fr) minmax(300px,.8fr); gap:34px; border:1px solid var(--line); border-radius:22px; background:#0c1714e8; }
+.cloud-account h2 { margin:8px 0 12px; }.cloud-account p { color:var(--muted); line-height:1.55; }
+.cloud-account form { display:grid; gap:10px; }.cloud-account label { color:var(--muted); font-size:13px; }
+.cloud-account input { width:100%; border:1px solid var(--line); border-radius:10px; padding:12px 14px; background:#07100d; color:var(--ink); font:inherit; }
+.cloud-account button { justify-self:start; border:0; border-radius:10px; padding:12px 18px; background:var(--accent); color:#082016; font:inherit; font-weight:750; cursor:pointer; }
+.cloud-account button.secondary { background:transparent; border:1px solid var(--line); color:var(--ink); }.cloud-account button:disabled { opacity:.6; cursor:wait; }
 .local-vault { margin:50px 0; padding:34px; border:1px solid var(--line); border-radius:22px; background:#0c1714e8; }
 .vault-heading,.vault-toolbar { display:flex; align-items:flex-start; justify-content:space-between; gap:32px; }
 .vault-heading h2,.vault-toolbar h3 { margin:8px 0 0; }.vault-heading>p,.vault-toolbar p,.vault-panel>p { max-width:520px; color:var(--muted); line-height:1.55; margin:0; }
@@ -31,13 +37,14 @@ body { margin:0; min-height:100vh; background:radial-gradient(circle at 70% 15%,
 .vault-panel input,.record-form input,.record-form select,.record-form textarea { width:100%; border:1px solid var(--line); border-radius:10px; padding:12px 14px; background:#07100d; color:var(--ink); font:inherit; }
 .record-form textarea { resize:vertical; }.record-form select { color-scheme:dark; }
 .vault-panel button,.record-form button,.vault-toolbar button,.vault-records button { border:0; border-radius:10px; padding:12px 18px; background:var(--accent); color:#082016; font:inherit; font-weight:750; cursor:pointer; }
+.vault-actions { display:flex; gap:10px; flex-wrap:wrap; justify-content:flex-end; }
 .vault-panel button,.record-form button { grid-column:2; justify-self:start; margin-top:6px; }.vault-toolbar button.secondary { background:transparent; border:1px solid var(--line); color:var(--ink); }
-.vault-panel button:disabled,.record-form button:disabled,.vault-records button:disabled { opacity:.6; cursor:wait; }
+.vault-panel button:disabled,.record-form button:disabled,.vault-toolbar button:disabled,.vault-records button:disabled { opacity:.6; cursor:wait; }
 .vault-records { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:14px; margin-top:28px; }
 .vault-records article { display:grid; grid-template-columns:1fr auto; gap:8px 16px; align-items:center; padding:20px; border:1px solid var(--line); border-radius:14px; background:#08110e; }
 .vault-records h4,.vault-records p { margin:0; overflow-wrap:anywhere; }.vault-records p,.vault-records small,.vault-empty { color:var(--muted); }.vault-records small { font-family:ui-monospace,monospace; }
 .vault-records button.danger { grid-column:2; grid-row:1 / span 3; align-self:center; padding:9px 12px; background:transparent; border:1px solid #ff8f7a66; color:#ffb4a6; }
 .access { display:flex; justify-content:space-between; gap:40px; align-items:end; padding:34px; border:1px solid var(--line); border-radius:18px; background:#0c1714cc; }.access h2 { margin:8px 0 0; }.access>p { max-width:500px; margin:0; }
 @keyframes spin { to { transform:rotate(360deg); } }
-@media (max-width:760px) { .shell{width:min(100% - 24px,1180px);padding-top:18px}.hero{grid-template-columns:1fr;padding:64px 0;gap:30px}.vault-visual{width:230px}.grid{grid-template-columns:1fr}.vault-heading,.vault-toolbar,.access{align-items:start;flex-direction:column}.vault-panel form,.record-form{grid-template-columns:1fr}.vault-panel button,.record-form button{grid-column:1}.vault-records{grid-template-columns:1fr}.status{font-size:0}.status::after{content:"●";font-size:16px} }
+@media (max-width:760px) { .shell{width:min(100% - 24px,1180px);padding-top:18px}.hero{grid-template-columns:1fr;padding:64px 0;gap:30px}.vault-visual{width:230px}.grid,.cloud-account{grid-template-columns:1fr}.vault-heading,.vault-toolbar,.access{align-items:start;flex-direction:column}.vault-actions{justify-content:flex-start}.vault-panel form,.record-form{grid-template-columns:1fr}.vault-panel button,.record-form button{grid-column:1}.vault-records{grid-template-columns:1fr}.status{font-size:0}.status::after{content:"●";font-size:16px} }
 @media (prefers-reduced-motion:reduce) { .orbit{animation:none} }

--- a/cloud/public/vault-local.js
+++ b/cloud/public/vault-local.js
@@ -8,6 +8,7 @@ import {
 import {
   createEmptyVaultDocument,
   deleteVaultRecord,
+  mergeVaultDocuments,
   upsertVaultRecord,
   validateVaultDocument,
 } from "./vault-model.js";
@@ -15,10 +16,13 @@ import {
 const databaseName = "selective-remote-cloud";
 const storeName = "local-vault";
 const snapshotKey = "personal";
+const syncKey = "personal-sync";
+const deviceKey = "browser-device";
 const exactUUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
 const recordTypes = new Set(["host", "credential", "snippet", "forwarding"]);
 const snapshotKeys = ["deviceID", "envelope", "revision"];
 const envelopeKeys = ["authTag", "baseRevision", "ciphertext", "contentHash", "envelopeVersion", "nonce", "wrappedKey"];
+const syncKeys = ["localRevision", "serverRevision"];
 
 function exactKeys(value, expected, code) {
   if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(code);
@@ -37,6 +41,28 @@ function validatedSnapshot(value) {
   const deviceID = String(value.deviceID ?? "").toLowerCase();
   if (!exactUUID.test(deviceID)) throw new Error("invalid_local_vault");
   return { revision: value.revision, deviceID, envelope: value.envelope };
+}
+
+function validatedSyncMetadata(value) {
+  exactKeys(value, syncKeys, "invalid_local_vault_sync");
+  if (!Number.isSafeInteger(value.localRevision) || value.localRevision < 1) {
+    throw new Error("invalid_local_vault_sync");
+  }
+  if (!Number.isSafeInteger(value.serverRevision) || value.serverRevision < 0) {
+    throw new Error("invalid_local_vault_sync");
+  }
+  return { localRevision: value.localRevision, serverRevision: value.serverRevision };
+}
+
+function normalizedDeviceID(value) {
+  const deviceID = String(value ?? "").toLowerCase();
+  if (!exactUUID.test(deviceID)) throw new Error("invalid_local_device");
+  return deviceID;
+}
+
+function sameWrappedKey(left, right) {
+  const keys = ["algorithm", "iterations", "salt", "value"];
+  return keys.every((key) => left?.[key] === right?.[key]);
 }
 
 function clone(value) {
@@ -86,6 +112,22 @@ export function createIndexedDBVaultRepository(indexedDBValue = globalThis.index
       const snapshot = validatedSnapshot(value);
       await transaction(indexedDBValue, "readwrite", (store) => store.put(clone(snapshot), snapshotKey));
     },
+    async loadSync() {
+      const value = await transaction(indexedDBValue, "readonly", (store) => store.get(syncKey));
+      return value === null || value === undefined ? null : validatedSyncMetadata(value);
+    },
+    async saveSync(value) {
+      const metadata = validatedSyncMetadata(value);
+      await transaction(indexedDBValue, "readwrite", (store) => store.put(clone(metadata), syncKey));
+    },
+    async loadDeviceID() {
+      const value = await transaction(indexedDBValue, "readonly", (store) => store.get(deviceKey));
+      return value === null || value === undefined ? null : normalizedDeviceID(value);
+    },
+    async saveDeviceID(value) {
+      const deviceID = normalizedDeviceID(value);
+      await transaction(indexedDBValue, "readwrite", (store) => store.put(deviceID, deviceKey));
+    },
   };
 }
 
@@ -102,6 +144,26 @@ export function createLocalVaultController({
   let snapshot = null;
   let vaultKey = null;
   let document = null;
+
+  async function stableDeviceID() {
+    if (snapshot?.deviceID) return snapshot.deviceID;
+    const stored = typeof repository.loadDeviceID === "function" ? await repository.loadDeviceID() : null;
+    if (stored) return normalizedDeviceID(stored);
+    const generated = normalizedDeviceID(randomUUID());
+    if (typeof repository.saveDeviceID === "function") await repository.saveDeviceID(generated);
+    return generated;
+  }
+
+  async function syncMetadata() {
+    if (typeof repository.loadSync !== "function") return null;
+    const value = await repository.loadSync();
+    return value ? validatedSyncMetadata(value) : null;
+  }
+
+  async function saveSyncMetadata(value) {
+    if (typeof repository.saveSync !== "function") throw new Error("local_vault_sync_storage_unavailable");
+    await repository.saveSync(validatedSyncMetadata(value));
+  }
 
   function requireUnlocked() {
     if (!snapshot || !vaultKey || !document) throw new Error("local_vault_locked");
@@ -146,7 +208,7 @@ export function createLocalVaultController({
         wrappedKey,
         cryptoValue,
       });
-      const nextSnapshot = validatedSnapshot({ revision: 1, deviceID: randomUUID(), envelope });
+      const nextSnapshot = validatedSnapshot({ revision: 1, deviceID: await stableDeviceID(), envelope });
       await repository.save(nextSnapshot);
       snapshot = nextSnapshot;
       vaultKey = nextVaultKey;
@@ -179,6 +241,85 @@ export function createLocalVaultController({
 
     document() {
       requireUnlocked();
+      return clone(document);
+    },
+
+    async deviceID() {
+      return stableDeviceID();
+    },
+
+    async syncState() {
+      requireUnlocked();
+      const metadata = await syncMetadata();
+      return {
+        localRevision: snapshot.revision,
+        serverRevision: metadata?.serverRevision ?? 0,
+        dirty: !metadata || metadata.localRevision !== snapshot.revision,
+      };
+    },
+
+    async prepareUpload(baseRevision) {
+      requireUnlocked();
+      if (!Number.isSafeInteger(baseRevision) || baseRevision < 0) throw new Error("invalid_base_revision");
+      return {
+        localRevision: snapshot.revision,
+        envelope: await encryptVaultPayload({
+          vaultKey,
+          payload: document,
+          baseRevision,
+          wrappedKey: snapshot.envelope.wrappedKey,
+          cryptoValue,
+        }),
+      };
+    },
+
+    async markSynced({ serverRevision, localRevision }) {
+      requireUnlocked();
+      if (!Number.isSafeInteger(localRevision) || localRevision < 1 || localRevision > snapshot.revision) {
+        throw new Error("invalid_local_vault_sync");
+      }
+      await saveSyncMetadata({ serverRevision, localRevision });
+      return {
+        localRevision: snapshot.revision,
+        serverRevision,
+        dirty: localRevision !== snapshot.revision,
+      };
+    },
+
+    async mergeRemote({ revision, envelope }) {
+      requireUnlocked();
+      const remoteSnapshot = validatedSnapshot({ revision, deviceID: snapshot.deviceID, envelope });
+      const remoteDocument = validateVaultDocument(
+        await decryptVaultEnvelope(vaultKey, remoteSnapshot.envelope, cryptoValue),
+      );
+      if (!sameWrappedKey(remoteSnapshot.envelope.wrappedKey, snapshot.envelope.wrappedKey)) {
+        throw new Error("remote_wrapped_key_changed");
+      }
+      const merged = mergeVaultDocuments(document, remoteDocument);
+      if (merged.conflicts.length > 0) return { conflicts: clone(merged.conflicts) };
+      const matchesRemote = JSON.stringify(merged.document) === JSON.stringify(remoteDocument);
+      const localChanged = JSON.stringify(merged.document) !== JSON.stringify(document);
+      if (localChanged) await persist(merged.document);
+      return {
+        conflicts: [],
+        matchesRemote,
+        localChanged,
+      };
+    },
+
+    async importRemote({ revision, envelope }, passphrase) {
+      if (await repository.load()) throw new Error("local_vault_exists");
+      const deviceID = await stableDeviceID();
+      const remoteSnapshot = validatedSnapshot({ revision, deviceID, envelope });
+      const nextVaultKey = await unwrapVaultKey(remoteSnapshot.envelope.wrappedKey, passphrase, cryptoValue);
+      const nextDocument = validateVaultDocument(
+        await decryptVaultEnvelope(nextVaultKey, remoteSnapshot.envelope, cryptoValue),
+      );
+      await repository.save(remoteSnapshot);
+      await saveSyncMetadata({ serverRevision: revision, localRevision: revision });
+      snapshot = remoteSnapshot;
+      vaultKey = nextVaultKey;
+      document = nextDocument;
       return clone(document);
     },
 

--- a/cloud/public/vault-sync.js
+++ b/cloud/public/vault-sync.js
@@ -1,0 +1,236 @@
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
+const base64URLPattern = /^[A-Za-z0-9_-]+$/u;
+const envelopeKeys = ["authTag", "baseRevision", "ciphertext", "contentHash", "envelopeVersion", "nonce", "wrappedKey"];
+
+export const personalVaultScope = Object.freeze({ type: "personal", id: "self" });
+
+function exactKeys(value, expected, code) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(code);
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (actual.length !== wanted.length || actual.some((key, index) => key !== wanted[index])) {
+    throw new Error(code);
+  }
+}
+
+function normalizedScope(value) {
+  exactKeys(value, ["id", "type"], "invalid_vault_scope");
+  if (value.type !== "personal" || value.id !== "self") throw new Error("unsupported_vault_scope");
+  return personalVaultScope;
+}
+
+function normalizedEnvelope(value, expectedBaseRevision = null) {
+  exactKeys(value, envelopeKeys, "invalid_remote_vault");
+  if (!Number.isSafeInteger(value.baseRevision) || value.baseRevision < 0) throw new Error("invalid_remote_vault");
+  if (expectedBaseRevision !== null && value.baseRevision !== expectedBaseRevision) {
+    throw new Error("invalid_remote_vault");
+  }
+  if (value.envelopeVersion !== 1) throw new Error("invalid_remote_vault");
+  for (const key of ["ciphertext", "nonce", "authTag", "contentHash"]) {
+    if (typeof value[key] !== "string" || !base64URLPattern.test(value[key])) {
+      throw new Error("invalid_remote_vault");
+    }
+  }
+  if (!value.wrappedKey || typeof value.wrappedKey !== "object" || Array.isArray(value.wrappedKey)) {
+    throw new Error("invalid_remote_vault");
+  }
+  return structuredClone(value);
+}
+
+function normalizedRemoteVault(value) {
+  exactKeys(value, ["authTag", "ciphertext", "contentHash", "envelopeVersion", "id", "nonce", "revision", "updatedAt", "wrappedKey"], "invalid_remote_vault");
+  if (!uuidPattern.test(String(value.id ?? ""))) throw new Error("invalid_remote_vault");
+  if (!Number.isSafeInteger(value.revision) || value.revision < 0) throw new Error("invalid_remote_vault");
+  if (value.revision === 0) {
+    for (const key of ["wrappedKey", "ciphertext", "nonce", "authTag", "contentHash"]) {
+      if (value[key] !== null) throw new Error("invalid_remote_vault");
+    }
+    return { id: value.id.toLowerCase(), revision: 0, envelope: null, updatedAt: value.updatedAt };
+  }
+  return {
+    id: value.id.toLowerCase(),
+    revision: value.revision,
+    envelope: normalizedEnvelope({
+      baseRevision: value.revision - 1,
+      envelopeVersion: value.envelopeVersion,
+      wrappedKey: value.wrappedKey,
+      ciphertext: value.ciphertext,
+      nonce: value.nonce,
+      authTag: value.authTag,
+      contentHash: value.contentHash,
+    }, value.revision - 1),
+    updatedAt: value.updatedAt,
+  };
+}
+
+async function responseJSON(response, code) {
+  try {
+    const value = await response.json();
+    if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(code);
+    return value;
+  } catch {
+    throw new Error(code);
+  }
+}
+
+export function createAuthenticatedVaultClient({ fetchValue = globalThis.fetch } = {}) {
+  if (typeof fetchValue !== "function") throw new Error("invalid_fetch");
+  let token = null;
+  let user = null;
+
+  async function authorizedRequest(path, options = {}) {
+    if (!token) throw new Error("authentication_required");
+    const response = await fetchValue(path, {
+      ...options,
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${token}`,
+        ...(options.body ? { "Content-Type": "application/json" } : {}),
+      },
+      cache: "no-store",
+      credentials: "omit",
+      referrerPolicy: "no-referrer",
+    });
+    if (response.status === 401) {
+      token = null;
+      user = null;
+      throw new Error("authentication_required");
+    }
+    return response;
+  }
+
+  return {
+    async login({ email, password, deviceID }) {
+      const normalizedDeviceID = String(deviceID ?? "").toLowerCase();
+      if (!uuidPattern.test(normalizedDeviceID)) throw new Error("invalid_device");
+      const response = await fetchValue("/v1/auth/login", {
+        method: "POST",
+        headers: { Accept: "application/json", "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: String(email ?? "").trim(),
+          password: String(password ?? ""),
+          device: {
+            id: normalizedDeviceID,
+            name: "Web browser",
+            platform: "web",
+            appVersion: "0.32",
+            publicKey: null,
+          },
+        }),
+        cache: "no-store",
+        credentials: "omit",
+        referrerPolicy: "no-referrer",
+      });
+      if (!response.ok) throw new Error("login_failed");
+      const result = await responseJSON(response, "login_failed");
+      if (typeof result.token !== "string" || result.token.length < 32 || result.token.length > 256) {
+        throw new Error("login_failed");
+      }
+      if (!result.user || typeof result.user !== "object" || !uuidPattern.test(String(result.user.id ?? ""))) {
+        throw new Error("login_failed");
+      }
+      if (String(result.deviceID ?? "").toLowerCase() !== normalizedDeviceID) throw new Error("login_failed");
+      token = result.token;
+      user = {
+        id: String(result.user.id).toLowerCase(),
+        email: String(result.user.email ?? ""),
+        displayName: String(result.user.displayName ?? ""),
+      };
+      return structuredClone(user);
+    },
+
+    session() {
+      return user ? structuredClone(user) : null;
+    },
+
+    async logout() {
+      if (!token) return;
+      try {
+        await authorizedRequest("/v1/auth/logout", { method: "POST" });
+      } finally {
+        token = null;
+        user = null;
+      }
+    },
+
+    async getVault(scope = personalVaultScope) {
+      normalizedScope(scope);
+      const response = await authorizedRequest("/v1/vault");
+      if (!response.ok) throw new Error("vault_download_failed");
+      return normalizedRemoteVault(await responseJSON(response, "vault_download_failed"));
+    },
+
+    async putVault(scope = personalVaultScope, envelope) {
+      normalizedScope(scope);
+      const normalized = normalizedEnvelope(envelope);
+      const response = await authorizedRequest("/v1/vault", {
+        method: "PUT",
+        body: JSON.stringify(normalized),
+      });
+      const result = await responseJSON(response, "vault_upload_failed");
+      if (response.status === 409) {
+        if (result.conflict !== true || !Number.isSafeInteger(result.revision) || result.revision < 0) {
+          throw new Error("vault_upload_failed");
+        }
+        return { conflict: true, revision: result.revision };
+      }
+      if (!response.ok || result.conflict !== false || !Number.isSafeInteger(result.revision) || result.revision < 1) {
+        throw new Error("vault_upload_failed");
+      }
+      return { conflict: false, revision: result.revision };
+    },
+  };
+}
+
+async function uploadCurrent(client, vault, scope, baseRevision) {
+  const prepared = await vault.prepareUpload(baseRevision);
+  const result = await client.putVault(scope, prepared.envelope);
+  if (result.conflict) return { status: "remote_changed", remoteRevision: result.revision };
+  if (result.revision !== baseRevision + 1) throw new Error("invalid_remote_revision");
+  const state = await vault.markSynced({
+    serverRevision: result.revision,
+    localRevision: prepared.localRevision,
+  });
+  return { status: state.dirty ? "uploaded_with_new_local_changes" : "uploaded", revision: result.revision };
+}
+
+export async function synchronizeVault({
+  client,
+  vault,
+  scope = personalVaultScope,
+  recoveryPassphrase = null,
+} = {}) {
+  normalizedScope(scope);
+  if (!client?.session()) throw new Error("authentication_required");
+  if (!vault || typeof vault.status !== "function") throw new Error("invalid_local_vault");
+
+  const remote = await client.getVault(scope);
+  const localStatus = await vault.status();
+  if (localStatus === "empty") {
+    if (remote.revision === 0) return { status: "empty" };
+    if (!recoveryPassphrase) throw new Error("recovery_passphrase_required");
+    await vault.importRemote(remote, recoveryPassphrase);
+    return { status: "downloaded", revision: remote.revision };
+  }
+  if (localStatus !== "unlocked") throw new Error("local_vault_locked");
+
+  const state = await vault.syncState();
+  if (remote.revision < state.serverRevision) throw new Error("remote_revision_regressed");
+  if (remote.revision === 0) return uploadCurrent(client, vault, scope, 0);
+  if (remote.revision === state.serverRevision) {
+    return state.dirty
+      ? uploadCurrent(client, vault, scope, remote.revision)
+      : { status: "up_to_date", revision: remote.revision };
+  }
+
+  const merged = await vault.mergeRemote(remote);
+  if (merged.conflicts.length > 0) {
+    return { status: "conflict", revision: remote.revision, conflicts: merged.conflicts };
+  }
+  const afterMerge = await vault.syncState();
+  if (merged.matchesRemote) {
+    await vault.markSynced({ serverRevision: remote.revision, localRevision: afterMerge.localRevision });
+    return { status: "downloaded", revision: remote.revision };
+  }
+  return uploadCurrent(client, vault, scope, remote.revision);
+}

--- a/cloud/tests/public-vault-sync.test.mjs
+++ b/cloud/tests/public-vault-sync.test.mjs
@@ -1,0 +1,268 @@
+import assert from "node:assert/strict";
+import { webcrypto } from "node:crypto";
+import test from "node:test";
+import { createLocalVaultController } from "../public/vault-local.js";
+import {
+  createAuthenticatedVaultClient,
+  personalVaultScope,
+  synchronizeVault,
+} from "../public/vault-sync.js";
+
+const passphrase = "correct horse battery staple for synchronized recovery";
+const userID = "99999999-9999-4999-8999-999999999999";
+const vaultID = "88888888-8888-4888-8888-888888888888";
+const deviceA = "11111111-1111-4111-8111-111111111111";
+const deviceB = "22222222-2222-4222-8222-222222222222";
+const recordA = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const recordB = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+function memoryRepository() {
+  let snapshot = null;
+  let sync = null;
+  let deviceID = null;
+  return {
+    async load() { return snapshot ? structuredClone(snapshot) : null; },
+    async save(value) { snapshot = structuredClone(value); },
+    async loadSync() { return sync ? structuredClone(sync) : null; },
+    async saveSync(value) { sync = structuredClone(value); },
+    async loadDeviceID() { return deviceID; },
+    async saveDeviceID(value) { deviceID = value; },
+    snapshot() { return snapshot ? structuredClone(snapshot) : null; },
+  };
+}
+
+function localVault(repository, ids) {
+  let index = 0;
+  return createLocalVaultController({
+    repository,
+    cryptoValue: webcrypto,
+    randomUUID: () => ids[index++],
+    now: () => "2026-09-04T00:00:00.000Z",
+  });
+}
+
+function jsonResponse(status, value) {
+  return new Response(value === null ? null : JSON.stringify(value), {
+    status,
+    headers: value === null ? {} : { "Content-Type": "application/json" },
+  });
+}
+
+function remoteValue(revision, envelope = null) {
+  return {
+    id: vaultID,
+    revision,
+    envelope,
+    updatedAt: "2026-09-04T00:00:00.000Z",
+  };
+}
+
+test("authenticated client keeps its bearer token in memory and uses only the personal scope", async () => {
+  const calls = [];
+  const token = "t".repeat(43);
+  const envelope = {
+    baseRevision: 0,
+    envelopeVersion: 1,
+    wrappedKey: { algorithm: "test" },
+    ciphertext: "AA",
+    nonce: "AAAAAAAAAAAAAAAA",
+    authTag: "AAAAAAAAAAAAAAAAAAAAAA",
+    contentHash: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  };
+  const client = createAuthenticatedVaultClient({
+    fetchValue: async (path, options = {}) => {
+      calls.push({ path, options });
+      if (path === "/v1/auth/login") {
+        return jsonResponse(200, {
+          token,
+          user: { id: userID, email: "user@example.invalid", displayName: "User" },
+          deviceID: deviceA,
+        });
+      }
+      if (path === "/v1/vault" && options.method === "PUT") {
+        return jsonResponse(200, { conflict: false, revision: 1 });
+      }
+      if (path === "/v1/auth/logout") return jsonResponse(204, null);
+      throw new Error("unexpected_request");
+    },
+  });
+
+  const user = await client.login({ email: " user@example.invalid ", password: "synthetic-password", deviceID: deviceA });
+  assert.deepEqual(user, { id: userID, email: "user@example.invalid", displayName: "User" });
+  assert.equal(JSON.stringify(client.session()).includes(token), false);
+
+  await assert.rejects(
+    client.getVault({ type: "team", id: vaultID }),
+    /unsupported_vault_scope/,
+  );
+  assert.equal(calls.length, 1, "unsupported scopes must fail before a network request");
+
+  await client.putVault(personalVaultScope, envelope);
+  assert.equal(calls[1].options.headers.Authorization, `Bearer ${token}`);
+  assert.equal(calls[1].options.credentials, "omit");
+  await client.logout();
+  assert.equal(client.session(), null);
+});
+
+test("a 401 response clears the in-memory browser session", async () => {
+  let request = 0;
+  const client = createAuthenticatedVaultClient({
+    fetchValue: async (path) => {
+      request += 1;
+      if (path === "/v1/auth/login") {
+        return jsonResponse(200, {
+          token: "t".repeat(43),
+          user: { id: userID, email: "user@example.invalid", displayName: "User" },
+          deviceID: deviceA,
+        });
+      }
+      return jsonResponse(401, { error: "unauthorized" });
+    },
+  });
+
+  await client.login({ email: "user@example.invalid", password: "synthetic-password", deviceID: deviceA });
+  await assert.rejects(client.getVault(), /authentication_required/);
+  assert.equal(client.session(), null);
+  assert.equal(request, 2);
+});
+
+test("local encrypted changes upload against the last observed server revision", async () => {
+  const repository = memoryRepository();
+  const vault = localVault(repository, [deviceA, recordA]);
+  await vault.create(passphrase);
+  const uploadedBases = [];
+  let serverRevision = 0;
+  const client = {
+    session: () => ({ id: userID }),
+    getVault: async () => remoteValue(serverRevision),
+    putVault: async (_scope, envelope) => {
+      uploadedBases.push(envelope.baseRevision);
+      serverRevision += 1;
+      return { conflict: false, revision: serverRevision };
+    },
+  };
+
+  assert.deepEqual(await synchronizeVault({ client, vault }), { status: "uploaded", revision: 1 });
+  assert.deepEqual(await vault.syncState(), { localRevision: 1, serverRevision: 1, dirty: false });
+
+  await vault.upsert({ id: recordA, type: "host", data: { title: "A", address: "a.invalid" } });
+  assert.equal((await vault.syncState()).dirty, true);
+  assert.deepEqual(await synchronizeVault({ client, vault }), { status: "uploaded", revision: 2 });
+  assert.deepEqual(uploadedBases, [0, 1]);
+  assert.equal((await vault.syncState()).dirty, false);
+  assert.equal(JSON.stringify(repository.snapshot()).includes("a.invalid"), false);
+});
+
+test("remote and offline local changes merge locally before one conditional upload", async () => {
+  const repoA = memoryRepository();
+  const repoB = memoryRepository();
+  const vaultA = localVault(repoA, [deviceA]);
+  const vaultB = localVault(repoB, [deviceB]);
+  await vaultA.create(passphrase);
+  const initial = await vaultA.prepareUpload(0);
+  await vaultA.markSynced({ serverRevision: 1, localRevision: initial.localRevision });
+  await vaultB.importRemote({ revision: 1, envelope: initial.envelope }, passphrase);
+
+  await vaultA.upsert({ id: recordA, type: "host", data: { title: "A", address: "a.invalid" } });
+  await vaultB.upsert({ id: recordB, type: "snippet", data: { title: "B", body: "uptime" } });
+  const remote = await vaultB.prepareUpload(1);
+  let uploaded = null;
+  const client = {
+    session: () => ({ id: userID }),
+    getVault: async () => remoteValue(2, remote.envelope),
+    putVault: async (_scope, envelope) => {
+      uploaded = envelope;
+      return { conflict: false, revision: 3 };
+    },
+  };
+
+  assert.deepEqual(await synchronizeVault({ client, vault: vaultA }), { status: "uploaded", revision: 3 });
+  assert.equal(uploaded.baseRevision, 2);
+  assert.deepEqual(vaultA.document().records.map((record) => record.id), [recordA, recordB]);
+  assert.deepEqual(await vaultA.syncState(), { localRevision: 3, serverRevision: 3, dirty: false });
+});
+
+test("concurrent record conflict blocks upload and preserves the local document", async () => {
+  const repoA = memoryRepository();
+  const repoB = memoryRepository();
+  const vaultA = localVault(repoA, [deviceA]);
+  const vaultB = localVault(repoB, [deviceB]);
+  await vaultA.create(passphrase);
+  const initial = await vaultA.prepareUpload(0);
+  await vaultA.markSynced({ serverRevision: 1, localRevision: initial.localRevision });
+  await vaultB.importRemote({ revision: 1, envelope: initial.envelope }, passphrase);
+
+  await vaultA.upsert({ id: recordA, type: "host", data: { title: "Local", address: "local.invalid" } });
+  await vaultB.upsert({ id: recordA, type: "host", data: { title: "Remote", address: "remote.invalid" } });
+  const remote = await vaultB.prepareUpload(1);
+  let putCalls = 0;
+  const client = {
+    session: () => ({ id: userID }),
+    getVault: async () => remoteValue(2, remote.envelope),
+    putVault: async () => { putCalls += 1; throw new Error("must_not_upload"); },
+  };
+
+  const result = await synchronizeVault({ client, vault: vaultA });
+  assert.equal(result.status, "conflict");
+  assert.equal(result.conflicts.length, 1);
+  assert.equal(putCalls, 0);
+  assert.equal(vaultA.document().records[0].data.address, "local.invalid");
+});
+
+test("a server-side optimistic conflict never marks local data as synchronized", async () => {
+  const repository = memoryRepository();
+  const vault = localVault(repository, [deviceA]);
+  await vault.create(passphrase);
+  const client = {
+    session: () => ({ id: userID }),
+    getVault: async () => remoteValue(0),
+    putVault: async () => ({ conflict: true, revision: 4 }),
+  };
+
+  assert.deepEqual(
+    await synchronizeVault({ client, vault }),
+    { status: "remote_changed", remoteRevision: 4 },
+  );
+  assert.deepEqual(await vault.syncState(), { localRevision: 1, serverRevision: 0, dirty: true });
+});
+
+test("an empty browser can import an encrypted remote Vault only with its recovery passphrase", async () => {
+  const source = localVault(memoryRepository(), [deviceA]);
+  const destination = localVault(memoryRepository(), [deviceB]);
+  await source.create(passphrase);
+  const prepared = await source.prepareUpload(0);
+  const client = {
+    session: () => ({ id: userID }),
+    getVault: async () => remoteValue(1, prepared.envelope),
+  };
+
+  await assert.rejects(synchronizeVault({ client, vault: destination }), /recovery_passphrase_required/);
+  assert.deepEqual(
+    await synchronizeVault({ client, vault: destination, recoveryPassphrase: passphrase }),
+    { status: "downloaded", revision: 1 },
+  );
+  assert.deepEqual(destination.document(), { schemaVersion: 1, records: [], tombstones: [] });
+  assert.deepEqual(await destination.syncState(), { localRevision: 1, serverRevision: 1, dirty: false });
+});
+
+test("an unexpected remote recovery wrapper fails closed before local state changes", async () => {
+  const repository = memoryRepository();
+  const vault = localVault(repository, [deviceA]);
+  await vault.create(passphrase);
+  const prepared = await vault.prepareUpload(0);
+  await vault.markSynced({ serverRevision: 1, localRevision: prepared.localRevision });
+  const salt = prepared.envelope.wrappedKey.salt;
+  const changedSalt = `${salt[0] === "A" ? "B" : "A"}${salt.slice(1)}`;
+  const remoteEnvelope = {
+    ...prepared.envelope,
+    baseRevision: 1,
+    wrappedKey: { ...prepared.envelope.wrappedKey, salt: changedSalt },
+  };
+  const client = {
+    session: () => ({ id: userID }),
+    getVault: async () => remoteValue(2, remoteEnvelope),
+  };
+
+  await assert.rejects(synchronizeVault({ client, vault }), /remote_wrapped_key_changed/);
+  assert.deepEqual(await vault.syncState(), { localRevision: 1, serverRevision: 1, dirty: false });
+});

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { localVaultRecordData, localVaultRecordSummary } from "../public/app.js";
 
@@ -45,4 +46,21 @@ test("credential summaries never expose their secret", () => {
 
   assert.equal(summary, "root · секрет скрыт");
   assert.equal(summary.includes(record.data.secret), false);
+});
+
+test("portal exposes memory-only login and explicit manual synchronization controls", async () => {
+  const [html, application, synchronization] = await Promise.all([
+    readFile(new URL("../public/index.html", import.meta.url), "utf8"),
+    readFile(new URL("../public/app.js", import.meta.url), "utf8"),
+    readFile(new URL("../public/vault-sync.js", import.meta.url), "utf8"),
+  ]);
+
+  assert.match(html, /id="cloud-login-form"/u);
+  assert.match(html, /id="cloud-vault-sync"/u);
+  assert.match(html, /id="cloud-logout"/u);
+  assert.match(application, /createAuthenticatedVaultClient/u);
+  assert.match(application, /synchronizeVault/u);
+  assert.doesNotMatch(`${application}\n${synchronization}`, /localStorage|sessionStorage/u);
+  assert.match(synchronization, /unsupported_vault_scope/u);
+  assert.match(synchronization, /credentials: "omit"/u);
 });

--- a/docs/cloud-v0.32-architecture.md
+++ b/docs/cloud-v0.32-architecture.md
@@ -118,10 +118,26 @@ the IndexedDB transaction completes. Storage corruption, unknown snapshot
 fields, revision mismatch, unavailable IndexedDB and wrong recovery phrases
 fail closed. There is deliberately no plaintext or Web Storage fallback.
 
-This preview is local-only. It does not authenticate, upload, download or claim
-cross-device recovery. Cloud synchronization must later reconcile the local
-encrypted revision against the authenticated server revision without making
-IndexedDB a second source of truth.
+The first preview was local-only. The next bounded browser milestone adds
+password login through the existing account API and manual personal-Vault
+synchronization. The opaque bearer token exists only in the live page closure:
+it is never written to IndexedDB, localStorage or sessionStorage. Reloading or
+explicit logout drops the client reference, and logout also revokes the server
+session when the endpoint is reachable.
+
+IndexedDB continues to hold only the encrypted local snapshot, a random browser
+device UUID and non-secret sync counters (`serverRevision` plus the local
+revision last acknowledged by the service). Offline CRUD remains local and
+dirty until a conditional upload succeeds. A server `409` never advances the
+local acknowledgement. If the remote revision advanced, the client decrypts
+and causally merges it in memory before upload; unresolved concurrent entities
+block upload and are reported explicitly rather than timestamp-resolved.
+
+This milestone does not enable registration, persist account sessions, resolve
+conflicts in the UI, or complete clean-browser recovery. A remote Vault in a
+browser with no local snapshot requires the independent recovery passphrase;
+the import primitive is implemented, while the recovery UX remains a separate
+acceptance step.
 
 The client downloads the latest revision, decrypts and validates it locally,
 performs this record-level merge, resolves any conflicts locally, then uploads
@@ -136,6 +152,11 @@ shared key separately for authorized members/devices, enforce roles in both
 the API and clients, and rotate the key (or use an equivalently reviewed
 revocation design) when access is removed. The exact invitation, role and key
 rotation protocol must be threat-modelled before those endpoints are added.
+The browser sync client accepts an explicit Vault scope and currently permits
+only `{type: "personal", id: "self"}`. Team scopes fail before any network
+request until authenticated Team endpoints and authorization are implemented.
+This keeps the ownership seam visible without pretending the personal endpoint
+already enforces Team roles.
 
 ## API v1
 

--- a/docs/cloud-v0.32-architecture.md
+++ b/docs/cloud-v0.32-architecture.md
@@ -4,10 +4,12 @@
 
 Version 0.32 introduces optional self-hosted accounts, personal Vaults, Teams
 and shared Team Vaults for Selective Remote. The macOS application remains
-fully usable without an account. This foundation milestone implements account,
-device and opaque personal-Vault storage only; shared Vault data structures,
-membership, roles and key distribution are later milestones within the final
-0.32 scope. FIDO2 remains outside the initial 0.32 release scope.
+fully usable without an account. The current cumulative implementation includes
+account/device APIs, opaque personal-Vault storage, browser-local encryption and
+manual authenticated personal-Vault synchronization. Shared Vault data
+structures, membership, roles and key distribution remain required later
+milestones within the final 0.32 scope. FIDO2 remains outside the initial 0.32
+release scope.
 
 The first production deployment targets:
 


### PR DESCRIPTION
## Результат

Добавляет bounded browser milestone для Cloud 0.32:

- password login через существующий `/v1/auth/login`;
- bearer session только в памяти вкладки, без localStorage/sessionStorage/IndexedDB;
- стабильный несекретный browser device UUID в IndexedDB;
- ручной encrypted personal-Vault sync через существующие `GET/PUT /v1/vault`;
- отдельные `serverRevision`/acknowledged local revision metadata для offline edits;
- causal download/merge и conditional upload;
- server `409` и record conflicts останавливают upload без silent overwrite;
- encrypted clean-browser import primitive с независимой recovery-фразой;
- unexpected recovery-wrapper change fails closed.

## Team-ready boundary

Client API принимает явный Vault scope. Сейчас разрешён только `{type: "personal", id: "self"}`; Team scope отклоняется до network request, пока не реализованы Team auth/API/key lifecycle. Это сохраняет seam для shared Vaults, не выдавая personal endpoint за Team implementation.

## Проверки exact tree `6eebf3707f290bc2019159ba3470e3ab703c9ed7`

- focused browser Vault tests: 35/35 success;
- full Cloud tests: 150/150 success;
- JS syntax: success;
- HTML parser: success;
- `git diff --check`: success;
- `npm audit --omit=dev`: 0 vulnerabilities.

## Границы

- не включает registration, Team endpoints/roles/key distribution, persisted sessions или conflict-resolution UI;
- не развёртывается на closed staging;
- не меняет server schema/migrations, runtime secrets или public main;
- clean-browser recovery UI остаётся отдельным шагом.

Remote exact head: `14d990e385f4849dcb0012b24607b022d44e94c4`; 9 files, 829 additions, 14 deletions; 0 behind base.