### PR TITLE
Cloud: add Vault conflict resolution and recovery UX

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -15,8 +15,17 @@ exists only in page memory. IndexedDB contains ciphertext, a random device UUID
 and non-secret revision acknowledgement metadata, never the session token,
 recovery passphrase, raw Vault key or decrypted records. Concurrent record
 conflicts and server revision conflicts stop upload instead of overwriting.
-Registration, Team endpoints, conflict-resolution UI and complete clean-browser
-recovery UX remain disabled or unfinished.
+The browser requires an explicit choice for every concurrent record or
+tombstone, joins both causal histories locally, and leaves the resolution dirty
+until the next conditional upload. A clean browser can import the encrypted
+remote Vault through a dedicated recovery form; the phrase is cleared after
+each attempt and never sent or persisted. Registration and Team endpoints
+remain disabled or unfinished.
+
+The mandatory Team/shared-Vault security contract is documented in
+`docs/cloud-v0.32-team-threat-model.md`. It fixes the four-role matrix,
+invitation lifecycle, device-bound wrappers, membership epochs and fail-closed
+key rotation. This is a design gate, not an implemented Team feature.
 
 ## Local verification
 

--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -79,6 +79,14 @@ export function localVaultRecordSummary(record) {
   return summary.length > 240 ? `${summary.slice(0, 237)}…` : summary;
 }
 
+export function localVaultConflictSideSummary(entity) {
+  if (entity?.kind === "tombstone") return `Удалено · ${String(entity.value?.deletedAt ?? "")}`;
+  if (entity?.kind !== "record") throw new Error("invalid_vault_conflict");
+  const title = String(entity.value?.data?.title ?? "Без названия");
+  const boundedTitle = title.length > 120 ? `${title.slice(0, 117)}…` : title;
+  return `${boundedTitle} · ${String(entity.value?.type ?? "record")} · ${String(entity.value?.modifiedAt ?? "")}`;
+}
+
 function setText(element, value) {
   if (element) element.textContent = value;
 }
@@ -105,7 +113,32 @@ export async function initializeLocalVault({
   const secret = documentValue.querySelector("#local-record-secret");
   const targetLabel = documentValue.querySelector("#local-record-target-label");
   const secretLabel = documentValue.querySelector("#local-record-secret-label");
+  const recoveryPanel = documentValue.querySelector("#cloud-vault-recovery");
+  const recoveryForm = documentValue.querySelector("#cloud-vault-recovery-form");
+  const conflictPanel = documentValue.querySelector("#local-vault-conflicts");
+  const conflictForm = documentValue.querySelector("#local-vault-conflicts-form");
+  const conflictList = documentValue.querySelector("#local-vault-conflicts-list");
   const controller = createLocalVaultController({ repository });
+  let conflictResetListener = () => {};
+
+  function clearConflictUI() {
+    conflictPanel.hidden = true;
+    conflictForm.reset();
+    conflictList.replaceChildren();
+    for (const control of recordForm.querySelectorAll("input, select, textarea, button")) control.disabled = false;
+    for (const button of records.querySelectorAll("button")) button.disabled = false;
+    conflictResetListener();
+  }
+
+  function setConflictMode(active) {
+    for (const control of recordForm.querySelectorAll("input, select, textarea, button")) control.disabled = active;
+    for (const button of records.querySelectorAll("button")) button.disabled = active;
+  }
+
+  function hideRecovery() {
+    recoveryPanel.hidden = true;
+    recoveryForm.reset();
+  }
 
   function mode(value) {
     setup.hidden = value !== "empty";
@@ -154,6 +187,7 @@ export async function initializeLocalVault({
         remove.disabled = true;
         try {
           await controller.delete(record.id);
+          clearConflictUI();
           setText(message, "Запись удалена. Tombstone сохранён в зашифрованном Vault.");
           render();
         } catch {
@@ -179,6 +213,8 @@ export async function initializeLocalVault({
     try {
       await controller.create(passphrase);
       setupForm.reset();
+      hideRecovery();
+      clearConflictUI();
       mode("unlocked");
       setText(message, "Локальный Vault создан и разблокирован только в памяти этой вкладки.");
       render();
@@ -197,6 +233,7 @@ export async function initializeLocalVault({
       unlockForm.reset();
       button.disabled = false;
       mode("unlocked");
+      clearConflictUI();
       setText(message, "Vault расшифрован локально. Ключ существует только в памяти вкладки.");
       render();
     } catch {
@@ -215,6 +252,7 @@ export async function initializeLocalVault({
         data: localVaultRecordData(type.value, { title: title.value, target: target.value, secret: secret.value }),
       });
       recordForm.reset();
+      clearConflictUI();
       updateLabels();
       setText(message, "Запись локально зашифрована и сохранена.");
       render();
@@ -228,6 +266,8 @@ export async function initializeLocalVault({
   type.addEventListener("change", updateLabels);
   lockButton.addEventListener("click", () => {
     controller.lock();
+    hideRecovery();
+    clearConflictUI();
     mode("locked");
     records.replaceChildren();
     setText(message, "Vault заблокирован; ключ удалён из состояния страницы.");
@@ -236,21 +276,42 @@ export async function initializeLocalVault({
   updateLabels();
   try {
     mode(await controller.status());
-    setText(message, "Данные остаются на этом устройстве в зашифрованном виде; синхронизация ещё не подключена.");
+    setText(message, "Данные зашифрованы локально; после входа доступна ручная Cloud-синхронизация.");
   } catch {
     setup.hidden = true;
     unlock.hidden = true;
     workspace.hidden = true;
     setText(message, "Локальное защищённое хранилище недоступно в этом браузере.");
   }
-  return controller;
+  return {
+    controller,
+    mode,
+    render,
+    clearConflictUI,
+    setConflictMode,
+    setConflictResetListener(listener) {
+      conflictResetListener = typeof listener === "function" ? listener : () => {};
+    },
+    showRecovery() {
+      setup.hidden = true;
+      unlock.hidden = true;
+      workspace.hidden = true;
+      recoveryPanel.hidden = false;
+      recoveryForm.elements.passphrase.focus();
+    },
+    async hideRecoveryAndRestoreMode() {
+      hideRecovery();
+      mode(await controller.status());
+    },
+  };
 }
 
 export async function initializeCloudAccount({
   documentValue = document,
-  vault,
+  vaultUI,
   fetchValue = fetch,
 } = {}) {
+  const vault = vaultUI?.controller;
   const section = documentValue.querySelector("#cloud-account");
   if (!section || !vault) return null;
   const form = documentValue.querySelector("#cloud-login-form");
@@ -260,7 +321,60 @@ export async function initializeCloudAccount({
   const logoutButton = documentValue.querySelector("#cloud-logout");
   const syncButton = documentValue.querySelector("#cloud-vault-sync");
   const vaultMessage = documentValue.querySelector("#local-vault-message");
+  const recoveryForm = documentValue.querySelector("#cloud-vault-recovery-form");
+  const recoveryCancel = documentValue.querySelector("#cloud-vault-recovery-cancel");
+  const conflictPanel = documentValue.querySelector("#local-vault-conflicts");
+  const conflictForm = documentValue.querySelector("#local-vault-conflicts-form");
+  const conflictList = documentValue.querySelector("#local-vault-conflicts-list");
+  const conflictApply = documentValue.querySelector("#local-vault-conflicts-apply");
   const client = createAuthenticatedVaultClient({ fetchValue });
+  let activeConflicts = null;
+  vaultUI.setConflictResetListener(() => {
+    activeConflicts = null;
+    conflictApply.disabled = true;
+  });
+
+  function hideConflicts() {
+    activeConflicts = null;
+    vaultUI.clearConflictUI();
+    conflictApply.disabled = true;
+  }
+
+  function renderConflicts(result) {
+    activeConflicts = { revision: result.revision, ids: result.conflicts.map((conflict) => conflict.id) };
+    conflictForm.reset();
+    conflictList.replaceChildren();
+    conflictApply.disabled = true;
+    result.conflicts.forEach((conflict, index) => {
+      const fieldset = documentValue.createElement("fieldset");
+      const legend = documentValue.createElement("legend");
+      legend.textContent = `Конфликт ${index + 1}`;
+      fieldset.append(legend);
+      for (const [choice, prefix] of [["local", "Оставить локальную"], ["remote", "Принять Cloud-версию"]]) {
+        const label = documentValue.createElement("label");
+        const input = documentValue.createElement("input");
+        input.type = "radio";
+        input.name = `conflict-${index}`;
+        input.value = choice;
+        input.required = true;
+        label.append(input, ` ${prefix}: ${localVaultConflictSideSummary(conflict[choice])}`);
+        fieldset.append(label);
+      }
+      conflictList.append(fieldset);
+    });
+    vaultUI.setConflictMode(true);
+    conflictPanel.hidden = false;
+  }
+
+  function updateConflictApplyState() {
+    if (!activeConflicts) {
+      conflictApply.disabled = true;
+      return;
+    }
+    conflictApply.disabled = activeConflicts.ids.some((_id, index) => (
+      !conflictForm.querySelector(`input[name="conflict-${index}"]:checked`)
+    ));
+  }
 
   function showSession(user) {
     form.hidden = Boolean(user);
@@ -295,6 +409,8 @@ export async function initializeCloudAccount({
       await client.logout();
     } finally {
       showSession(null);
+      hideConflicts();
+      await vaultUI.hideRecoveryAndRestoreMode();
       logoutButton.disabled = false;
       setText(message, "Сессия завершена, токен удалён из памяти вкладки.");
     }
@@ -313,6 +429,8 @@ export async function initializeCloudAccount({
         remote_changed: `Удалённый Vault изменился до ревизии ${result.remoteRevision}. Повторите синхронизацию для безопасного merge.`,
         conflict: `Обнаружено конфликтов: ${result.conflicts.length}. Upload остановлен; требуется явное разрешение конфликтов.`,
       };
+      if (result.status === "conflict") renderConflicts(result);
+      else hideConflicts();
       setText(vaultMessage, messages[result.status] ?? "Синхронизация завершена.");
     } catch (error) {
       const code = String(error?.message ?? "");
@@ -321,10 +439,65 @@ export async function initializeCloudAccount({
         showSession(null);
         setText(vaultMessage, "Сессия истекла. Войдите снова.");
       } else if (code === "recovery_passphrase_required") {
-        setText(vaultMessage, "На сервере есть Vault. Импорт в чистый браузер требует recovery-фразу и будет добавлен отдельным шагом.");
+        hideConflicts();
+        vaultUI.showRecovery();
+        setText(vaultMessage, "На сервере есть зашифрованный Vault. Введите recovery-фразу для локального импорта.");
       } else {
         setText(vaultMessage, "Синхронизация не выполнена; локальные данные не потеряны.");
       }
+    } finally {
+      syncButton.disabled = !client.session();
+    }
+  });
+
+  recoveryForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const button = recoveryForm.querySelector('button[type="submit"]');
+    const passphrase = recoveryForm.elements.passphrase.value;
+    button.disabled = true;
+    try {
+      const result = await synchronizeVault({ client, vault, recoveryPassphrase: passphrase });
+      recoveryForm.reset();
+      await vaultUI.hideRecoveryAndRestoreMode();
+      vaultUI.mode("unlocked");
+      vaultUI.render();
+      setText(vaultMessage, `Зашифрованная ревизия ${result.revision} восстановлена и расшифрована только в этой вкладке.`);
+    } catch (error) {
+      recoveryForm.elements.passphrase.value = "";
+      if (String(error?.message ?? "") === "authentication_required") {
+        showSession(null);
+        await vaultUI.hideRecoveryAndRestoreMode();
+        setText(vaultMessage, "Сессия истекла. Войдите снова.");
+      } else {
+        setText(vaultMessage, "Не удалось восстановить Vault. Recovery-фраза неверна или зашифрованные данные повреждены.");
+      }
+    } finally {
+      button.disabled = false;
+    }
+  });
+
+  recoveryCancel.addEventListener("click", async () => {
+    await vaultUI.hideRecoveryAndRestoreMode();
+    setText(vaultMessage, "Восстановление отменено; удалённый Vault не изменён.");
+  });
+
+  conflictForm.addEventListener("change", updateConflictApplyState);
+  conflictForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    if (!activeConflicts) return;
+    conflictApply.disabled = true;
+    try {
+      const resolutions = activeConflicts.ids.map((id, index) => ({
+        id,
+        choice: conflictForm.querySelector(`input[name="conflict-${index}"]:checked`)?.value,
+      }));
+      const result = await vault.resolveConflicts({ revision: activeConflicts.revision, resolutions });
+      hideConflicts();
+      vaultUI.render();
+      setText(vaultMessage, `${result.conflictsResolved} конфликт(а) разрешено локально. Синхронизируйте ещё раз для условной загрузки.`);
+    } catch {
+      setText(vaultMessage, "Набор конфликтов устарел или выбран не полностью. Запустите синхронизацию ещё раз.");
+      hideConflicts();
     } finally {
       syncButton.disabled = !client.session();
     }
@@ -418,8 +591,8 @@ export async function initializePortal({
       });
     }
   }
-  const vault = await initializeLocalVault({ documentValue });
-  await initializeCloudAccount({ documentValue, vault, fetchValue });
+  const vaultUI = await initializeLocalVault({ documentValue });
+  await initializeCloudAccount({ documentValue, vaultUI, fetchValue });
   await updateServiceStatus(documentValue, fetchValue);
 }
 

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -86,6 +86,19 @@
         <p id="local-vault-message" aria-live="polite">Проверяем локальное хранилище…</p>
       </div>
 
+      <div class="vault-panel" id="cloud-vault-recovery" hidden>
+        <h3>Восстановить Vault из Cloud</h3>
+        <p>Зашифрованная ревизия уже существует. Введите независимую recovery-фразу: она используется только локально и не отправляется на сервер.</p>
+        <form id="cloud-vault-recovery-form">
+          <label for="cloud-vault-recovery-passphrase">Recovery-фраза</label>
+          <input id="cloud-vault-recovery-passphrase" name="passphrase" type="password" minlength="16" maxlength="1024" autocomplete="off" required>
+          <div class="vault-actions">
+            <button type="submit">Расшифровать и импортировать</button>
+            <button type="button" class="secondary" id="cloud-vault-recovery-cancel">Отмена</button>
+          </div>
+        </form>
+      </div>
+
       <div class="vault-panel" id="local-vault-setup" hidden>
         <h3>Создать локальный Vault</h3>
         <p>Recovery-фраза не отправляется на сервер и не сохраняется в браузере. Потерянную фразу пока восстановить невозможно.</p>
@@ -133,6 +146,14 @@
           <button type="submit">Зашифровать и сохранить</button>
         </form>
         <div class="vault-records" id="local-vault-records"></div>
+        <section class="vault-conflicts" id="local-vault-conflicts" aria-labelledby="local-vault-conflicts-title" hidden>
+          <h3 id="local-vault-conflicts-title">Требуется разрешить конфликты</h3>
+          <p>Выберите одну версию для каждой записи. Секретные поля и содержимое записей здесь не показываются.</p>
+          <form id="local-vault-conflicts-form">
+            <div id="local-vault-conflicts-list"></div>
+            <button type="submit" id="local-vault-conflicts-apply" disabled>Сохранить выбранные версии локально</button>
+          </form>
+        </section>
       </div>
     </section>
 

--- a/cloud/public/styles.css
+++ b/cloud/public/styles.css
@@ -44,6 +44,12 @@ body { margin:0; min-height:100vh; background:radial-gradient(circle at 70% 15%,
 .vault-records article { display:grid; grid-template-columns:1fr auto; gap:8px 16px; align-items:center; padding:20px; border:1px solid var(--line); border-radius:14px; background:#08110e; }
 .vault-records h4,.vault-records p { margin:0; overflow-wrap:anywhere; }.vault-records p,.vault-records small,.vault-empty { color:var(--muted); }.vault-records small { font-family:ui-monospace,monospace; }
 .vault-records button.danger { grid-column:2; grid-row:1 / span 3; align-self:center; padding:9px 12px; background:transparent; border:1px solid #ff8f7a66; color:#ffb4a6; }
+.vault-conflicts { margin-top:28px; padding:22px; border:1px solid #ffb86b66; border-radius:14px; background:#1a120a; }
+.vault-conflicts h3,.vault-conflicts p { margin-top:0; }.vault-conflicts p { color:var(--muted); line-height:1.55; }
+.vault-conflicts form { display:block; margin-top:20px; }.vault-conflicts fieldset { display:grid; gap:10px; margin:0 0 14px; padding:16px; border:1px solid var(--line); border-radius:12px; }
+.vault-conflicts legend { padding:0 6px; font-weight:750; }.vault-conflicts label { display:flex; gap:8px; align-items:flex-start; color:var(--ink); overflow-wrap:anywhere; }
+.vault-conflicts input { margin-top:3px; }.vault-conflicts button { border:0; border-radius:10px; padding:12px 18px; background:var(--accent); color:#082016; font:inherit; font-weight:750; cursor:pointer; }
+.vault-conflicts button:disabled { opacity:.6; cursor:not-allowed; }
 .access { display:flex; justify-content:space-between; gap:40px; align-items:end; padding:34px; border:1px solid var(--line); border-radius:18px; background:#0c1714cc; }.access h2 { margin:8px 0 0; }.access>p { max-width:500px; margin:0; }
 @keyframes spin { to { transform:rotate(360deg); } }
 @media (max-width:760px) { .shell{width:min(100% - 24px,1180px);padding-top:18px}.hero{grid-template-columns:1fr;padding:64px 0;gap:30px}.vault-visual{width:230px}.grid,.cloud-account{grid-template-columns:1fr}.vault-heading,.vault-toolbar,.access{align-items:start;flex-direction:column}.vault-actions{justify-content:flex-start}.vault-panel form,.record-form{grid-template-columns:1fr}.vault-panel button,.record-form button{grid-column:1}.vault-records{grid-template-columns:1fr}.status{font-size:0}.status::after{content:"●";font-size:16px} }

--- a/cloud/public/vault-local.js
+++ b/cloud/public/vault-local.js
@@ -9,6 +9,7 @@ import {
   createEmptyVaultDocument,
   deleteVaultRecord,
   mergeVaultDocuments,
+  resolveVaultConflict,
   upsertVaultRecord,
   validateVaultDocument,
 } from "./vault-model.js";
@@ -144,6 +145,7 @@ export function createLocalVaultController({
   let snapshot = null;
   let vaultKey = null;
   let document = null;
+  let pendingConflicts = null;
 
   async function stableDeviceID() {
     if (snapshot?.deviceID) return snapshot.deviceID;
@@ -213,6 +215,7 @@ export function createLocalVaultController({
       snapshot = nextSnapshot;
       vaultKey = nextVaultKey;
       document = nextDocument;
+      pendingConflicts = null;
       return clone(document);
     },
 
@@ -230,6 +233,7 @@ export function createLocalVaultController({
       snapshot = nextSnapshot;
       vaultKey = nextVaultKey;
       document = nextDocument;
+      pendingConflicts = null;
       return clone(document);
     },
 
@@ -237,6 +241,7 @@ export function createLocalVaultController({
       snapshot = null;
       vaultKey = null;
       document = null;
+      pendingConflicts = null;
     },
 
     document() {
@@ -296,7 +301,15 @@ export function createLocalVaultController({
         throw new Error("remote_wrapped_key_changed");
       }
       const merged = mergeVaultDocuments(document, remoteDocument);
-      if (merged.conflicts.length > 0) return { conflicts: clone(merged.conflicts) };
+      if (merged.conflicts.length > 0) {
+        pendingConflicts = {
+          revision,
+          document: merged.document,
+          conflicts: clone(merged.conflicts),
+        };
+        return { conflicts: clone(merged.conflicts) };
+      }
+      pendingConflicts = null;
       const matchesRemote = JSON.stringify(merged.document) === JSON.stringify(remoteDocument);
       const localChanged = JSON.stringify(merged.document) !== JSON.stringify(document);
       if (localChanged) await persist(merged.document);
@@ -304,6 +317,56 @@ export function createLocalVaultController({
         conflicts: [],
         matchesRemote,
         localChanged,
+      };
+    },
+
+    pendingConflicts() {
+      requireUnlocked();
+      return pendingConflicts
+        ? { revision: pendingConflicts.revision, conflicts: clone(pendingConflicts.conflicts) }
+        : null;
+    },
+
+    async resolveConflicts({ revision, resolutions }) {
+      requireUnlocked();
+      if (!pendingConflicts || revision !== pendingConflicts.revision || !Array.isArray(resolutions)) {
+        throw new Error("invalid_pending_conflicts");
+      }
+      if (resolutions.length !== pendingConflicts.conflicts.length) {
+        throw new Error("incomplete_conflict_resolution");
+      }
+      const choices = new Map();
+      for (const resolution of resolutions) {
+        exactKeys(resolution, ["choice", "id"], "invalid_conflict_resolution");
+        const id = String(resolution.id ?? "").toLowerCase();
+        if (!exactUUID.test(id) || !["local", "remote"].includes(resolution.choice) || choices.has(id)) {
+          throw new Error("invalid_conflict_resolution");
+        }
+        choices.set(id, resolution.choice);
+      }
+      const expectedIDs = new Set(pendingConflicts.conflicts.map((conflict) => conflict.id));
+      if (choices.size !== expectedIDs.size || [...choices.keys()].some((id) => !expectedIDs.has(id))) {
+        throw new Error("invalid_conflict_resolution");
+      }
+
+      let resolvedDocument = pendingConflicts.document;
+      const deviceID = snapshot.deviceID;
+      const resolvedAt = now();
+      for (const conflict of pendingConflicts.conflicts) {
+        resolvedDocument = resolveVaultConflict(resolvedDocument, conflict, {
+          choice: choices.get(conflict.id),
+          deviceID,
+          resolvedAt,
+        });
+      }
+      const previousLocalRevision = snapshot.revision;
+      await persist(resolvedDocument);
+      pendingConflicts = null;
+      await saveSyncMetadata({ serverRevision: revision, localRevision: previousLocalRevision });
+      return {
+        revision,
+        localRevision: snapshot.revision,
+        conflictsResolved: resolutions.length,
       };
     },
 
@@ -320,6 +383,7 @@ export function createLocalVaultController({
       snapshot = remoteSnapshot;
       vaultKey = nextVaultKey;
       document = nextDocument;
+      pendingConflicts = null;
       return clone(document);
     },
 
@@ -334,16 +398,19 @@ export function createLocalVaultController({
         modifiedAt: now(),
       });
       await persist(next);
+      pendingConflicts = null;
       return id;
     },
 
     async delete(id) {
       requireUnlocked();
-      return persist(deleteVaultRecord(document, {
+      const result = await persist(deleteVaultRecord(document, {
         id,
         deviceID: snapshot.deviceID,
         deletedAt: now(),
       }));
+      pendingConflicts = null;
+      return result;
     },
   };
 }

--- a/cloud/tests/public-vault-sync.test.mjs
+++ b/cloud/tests/public-vault-sync.test.mjs
@@ -209,6 +209,86 @@ test("concurrent record conflict blocks upload and preserves the local document"
   assert.equal(vaultA.document().records[0].data.address, "local.invalid");
 });
 
+test("an explicit complete conflict choice joins histories and uploads from the observed remote revision", async () => {
+  const repoA = memoryRepository();
+  const repoB = memoryRepository();
+  const vaultA = localVault(repoA, [deviceA]);
+  const vaultB = localVault(repoB, [deviceB]);
+  await vaultA.create(passphrase);
+  const initial = await vaultA.prepareUpload(0);
+  await vaultA.markSynced({ serverRevision: 1, localRevision: initial.localRevision });
+  await vaultB.importRemote({ revision: 1, envelope: initial.envelope }, passphrase);
+
+  await vaultA.upsert({ id: recordA, type: "host", data: { title: "Local", address: "local.invalid" } });
+  await vaultB.upsert({ id: recordA, type: "host", data: { title: "Remote", address: "remote.invalid" } });
+  await vaultB.upsert({ id: recordB, type: "snippet", data: { title: "Remote only", body: "uptime" } });
+  const remote = await vaultB.prepareUpload(1);
+  let serverRevision = 2;
+  let uploadedBase = null;
+  const client = {
+    session: () => ({ id: userID }),
+    getVault: async () => remoteValue(serverRevision, remote.envelope),
+    putVault: async (_scope, envelope) => {
+      uploadedBase = envelope.baseRevision;
+      serverRevision += 1;
+      return { conflict: false, revision: serverRevision };
+    },
+  };
+
+  const conflict = await synchronizeVault({ client, vault: vaultA });
+  assert.equal(conflict.status, "conflict");
+  assert.deepEqual(vaultA.pendingConflicts(), { revision: 2, conflicts: conflict.conflicts });
+  assert.equal(vaultA.document().records.some((record) => record.id === recordB), false);
+
+  await assert.rejects(
+    vaultA.resolveConflicts({ revision: 2, resolutions: [] }),
+    /incomplete_conflict_resolution/,
+  );
+  assert.deepEqual(
+    await vaultA.resolveConflicts({
+      revision: 2,
+      resolutions: [{ id: recordA, choice: "local" }],
+    }),
+    { revision: 2, localRevision: 3, conflictsResolved: 1 },
+  );
+  assert.equal(vaultA.pendingConflicts(), null);
+  assert.deepEqual(vaultA.document().records.map((record) => record.id), [recordA, recordB]);
+  assert.equal(vaultA.document().records[0].data.address, "local.invalid");
+  assert.deepEqual(await vaultA.syncState(), { localRevision: 3, serverRevision: 2, dirty: true });
+
+  assert.deepEqual(await synchronizeVault({ client, vault: vaultA }), { status: "uploaded", revision: 3 });
+  assert.equal(uploadedBase, 2);
+  assert.deepEqual(await vaultA.syncState(), { localRevision: 3, serverRevision: 3, dirty: false });
+});
+
+test("local edits invalidate a pending conflict set instead of applying a stale choice", async () => {
+  const repoA = memoryRepository();
+  const repoB = memoryRepository();
+  const vaultA = localVault(repoA, [deviceA]);
+  const vaultB = localVault(repoB, [deviceB]);
+  await vaultA.create(passphrase);
+  const initial = await vaultA.prepareUpload(0);
+  await vaultA.markSynced({ serverRevision: 1, localRevision: initial.localRevision });
+  await vaultB.importRemote({ revision: 1, envelope: initial.envelope }, passphrase);
+  await vaultA.upsert({ id: recordA, type: "host", data: { title: "Local", address: "local.invalid" } });
+  await vaultB.upsert({ id: recordA, type: "host", data: { title: "Remote", address: "remote.invalid" } });
+  const remote = await vaultB.prepareUpload(1);
+  const client = {
+    session: () => ({ id: userID }),
+    getVault: async () => remoteValue(2, remote.envelope),
+    putVault: async () => { throw new Error("must_not_upload"); },
+  };
+
+  const conflict = await synchronizeVault({ client, vault: vaultA });
+  assert.equal(conflict.status, "conflict");
+  await vaultA.upsert({ id: recordB, type: "snippet", data: { title: "New local edit", body: "date" } });
+  assert.equal(vaultA.pendingConflicts(), null);
+  await assert.rejects(
+    vaultA.resolveConflicts({ revision: 2, resolutions: [{ id: recordA, choice: "remote" }] }),
+    /invalid_pending_conflicts/,
+  );
+});
+
 test("a server-side optimistic conflict never marks local data as synchronized", async () => {
   const repository = memoryRepository();
   const vault = localVault(repository, [deviceA]);

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
-import { localVaultRecordData, localVaultRecordSummary } from "../public/app.js";
+import {
+  localVaultConflictSideSummary,
+  localVaultRecordData,
+  localVaultRecordSummary,
+} from "../public/app.js";
 
 test("Vault form values map to the four versioned record types", () => {
   assert.deepEqual(
@@ -48,6 +52,34 @@ test("credential summaries never expose their secret", () => {
   assert.equal(summary.includes(record.data.secret), false);
 });
 
+test("conflict choices expose only bounded metadata and never record secrets or bodies", () => {
+  const credential = {
+    kind: "record",
+    value: {
+      type: "credential",
+      modifiedAt: "2026-09-04T00:00:00.000Z",
+      data: { title: "Administrator", username: "root", secret: "must-not-render" },
+    },
+  };
+  const snippet = {
+    kind: "record",
+    value: {
+      type: "snippet",
+      modifiedAt: "2026-09-04T00:00:00.000Z",
+      data: { title: "Status", body: "sensitive command body" },
+    },
+  };
+  const rendered = `${localVaultConflictSideSummary(credential)} ${localVaultConflictSideSummary(snippet)}`;
+
+  assert.match(rendered, /Administrator · credential/u);
+  assert.match(rendered, /Status · snippet/u);
+  assert.doesNotMatch(rendered, /must-not-render|sensitive command body|root/u);
+  assert.match(
+    localVaultConflictSideSummary({ kind: "tombstone", value: { deletedAt: "2026-09-04T00:00:00.000Z" } }),
+    /Удалено/u,
+  );
+});
+
 test("portal exposes memory-only login and explicit manual synchronization controls", async () => {
   const [html, application, synchronization] = await Promise.all([
     readFile(new URL("../public/index.html", import.meta.url), "utf8"),
@@ -58,8 +90,13 @@ test("portal exposes memory-only login and explicit manual synchronization contr
   assert.match(html, /id="cloud-login-form"/u);
   assert.match(html, /id="cloud-vault-sync"/u);
   assert.match(html, /id="cloud-logout"/u);
+  assert.match(html, /id="cloud-vault-recovery-form"/u);
+  assert.match(html, /id="local-vault-conflicts-form"/u);
+  assert.match(html, /id="local-vault-conflicts-apply"[^>]*disabled/u);
   assert.match(application, /createAuthenticatedVaultClient/u);
   assert.match(application, /synchronizeVault/u);
+  assert.match(application, /resolveConflicts/u);
+  assert.match(application, /recoveryPassphrase/u);
   assert.doesNotMatch(`${application}\n${synchronization}`, /localStorage|sessionStorage/u);
   assert.match(synchronization, /unsupported_vault_scope/u);
   assert.match(synchronization, /credentials: "omit"/u);

--- a/docs/cloud-v0.32-architecture.md
+++ b/docs/cloud-v0.32-architecture.md
@@ -135,16 +135,23 @@ local acknowledgement. If the remote revision advanced, the client decrypts
 and causally merges it in memory before upload; unresolved concurrent entities
 block upload and are reported explicitly rather than timestamp-resolved.
 
-This milestone does not enable registration, persist account sessions, resolve
-conflicts in the UI, or complete clean-browser recovery. A remote Vault in a
-browser with no local snapshot requires the independent recovery passphrase;
-the import primitive is implemented, while the recovery UX remains a separate
-acceptance step.
+This milestone does not enable registration or persist account sessions. A
+remote Vault in a browser with no local snapshot requires the independent
+recovery passphrase; the import primitive and explicit recovery form are
+implemented. The phrase is cleared after each attempt and is never sent to the
+server or persisted.
 
 The client downloads the latest revision, decrypts and validates it locally,
 performs this record-level merge, resolves any conflicts locally, then uploads
 a new encrypted revision based on the latest server revision. Tombstones
 prevent another device from resurrecting a causally older deleted record.
+
+The browser conflict UI requires one explicit local-or-Cloud choice for every
+concurrent record/tombstone pair. It displays only bounded record metadata, not
+credential secrets, snippet bodies or other record content. The controller
+rejects incomplete, duplicate and stale resolution sets, joins both version
+vectors, persists one encrypted result and leaves it dirty until a subsequent
+conditional upload succeeds.
 
 The Cloud payload is separate from `.srbackup`. Backup archives remain manual,
 portable rollback artifacts; Cloud revisions are small synchronization units.
@@ -152,13 +159,19 @@ portable rollback artifacts; Cloud revisions are small synchronization units.
 Shared Vaults use independent random Vault keys. The final design must wrap a
 shared key separately for authorized members/devices, enforce roles in both
 the API and clients, and rotate the key (or use an equivalently reviewed
-revocation design) when access is removed. The exact invitation, role and key
-rotation protocol must be threat-modelled before those endpoints are added.
+revocation design) when access is removed. The invitation, role and key
+rotation contract is specified before those endpoints are added.
 The browser sync client accepts an explicit Vault scope and currently permits
 only `{type: "personal", id: "self"}`. Team scopes fail before any network
 request until authenticated Team endpoints and authorization are implemented.
 This keeps the ownership seam visible without pretending the personal endpoint
 already enforces Team roles.
+
+The mandatory role matrix, invitation lifecycle, device-bound key
+distribution, membership epochs and fail-closed rotation protocol are defined
+in [cloud-v0.32-team-threat-model.md](cloud-v0.32-team-threat-model.md). Shared
+data will use explicit Team/Vault-scoped endpoints and independent keys rather
+than overloading the personal route.
 
 ## API v1
 

--- a/docs/cloud-v0.32-team-threat-model.md
+++ b/docs/cloud-v0.32-team-threat-model.md
@@ -1,0 +1,188 @@
+# Cloud 0.32 Team and shared Vault threat model
+
+Status: design contract for the mandatory Team/shared-Vault milestone. None of
+the Team API, membership or key-distribution behavior described here is
+implemented by the personal-Vault browser client.
+
+## Security outcome
+
+An authorized Team member can use the same shared Hosts, Credentials,
+Snippets and Forwarding records in the browser and macOS client. The Cloud API
+authorizes every operation but cannot decrypt record content. Removing a
+member stops access to later revisions and key generations. Data that the
+member legitimately decrypted or cached before removal cannot be made secret
+again and is outside that guarantee.
+
+## Trust boundaries and threats
+
+| Actor or component | Trusted for | Never trusted for |
+|---|---|---|
+| Browser/macOS client | Local plaintext handling, encryption, signature and key-generation checks | Another member's authorization or server revision order |
+| Cloud API | Authentication, membership/role enforcement, revision serialization and durable audit metadata | Vault plaintext, Vault keys or silently selecting a conflict winner |
+| PostgreSQL | Durable ciphertext, authorization state, sessions, invitations, generations and outbox jobs | Confidentiality when the application/database host is compromised |
+| Team Owner/Admin | Membership actions allowed by role | Reading a Vault for which no key wrapper was granted |
+| Removed/compromised member | Nothing after revocation | New revisions, current key generations or new wrappers |
+
+The protocol must address stolen database backups, malicious cross-Team IDs,
+replayed invitations, revoked sessions, concurrent edits, an offline removed
+device, partial rotation, a compromised member device and multiple stateless
+API replicas. It does not claim protection from malware running inside an
+unlocked authorized client.
+
+## Durable ownership model
+
+- A Team has an immutable random ID, display metadata and at least one Owner.
+- A Team owns one or more shared Vaults. A record belongs to exactly one Vault;
+  personal and shared records never share encryption keys.
+- Membership, role, invitation, device authorization, Vault revision and key
+  generation are durable database state. API process memory is not
+  authoritative.
+- Every read/write names the Team and shared Vault scope explicitly. The API
+  derives the authenticated user from the session and never accepts an owner
+  user ID from the request body.
+- Authorization is checked transactionally against the requested Team, Vault,
+  membership status, role and current generation. Possession of ciphertext or
+  a wrapper is not sufficient authorization.
+
+## Role matrix
+
+Cloud 0.32 uses four roles. A custom-role system is out of scope for 0.32.
+
+| Operation | Owner | Admin | Editor | Viewer |
+|---|:---:|:---:|:---:|:---:|
+| Read shared ciphertext/current wrappers | Yes | Yes | Yes | Yes |
+| Create/update/delete shared records | Yes | Yes | Yes | No |
+| Create/rename shared Vault | Yes | Yes | No | No |
+| Archive shared Vault | Yes | Yes | No | No |
+| Invite Editor/Viewer | Yes | Yes | No | No |
+| Invite/promote/demote Admin | Yes | No | No | No |
+| Remove Editor/Viewer | Yes | Yes | No | No |
+| Remove/demote Admin | Yes | No | No | No |
+| Assign/remove Owner | Yes | No | No | No |
+| Transfer ownership/delete Team | Yes | No | No | No |
+| Start/complete key rotation | Yes | Yes | No | No |
+
+An actor cannot change their own role, remove themselves as the last Owner or
+remove/demote another Owner through an Admin permission. Team deletion and
+ownership transfer require recent re-authentication. A Viewer who has a Vault
+key can technically produce ciphertext, so the API must still reject Viewer
+writes.
+
+## Invitation lifecycle
+
+1. Owner/Admin creates an invitation for one normalized email and an allowed
+   role. Only an Owner can invite an Admin.
+2. The server creates at least 256 bits of random token material, stores only a
+   keyed hash, and sends the opaque token through the durable outbox.
+3. An invitation expires after 48 hours and has explicit `pending`, `accepted`,
+   `cancelled` or `expired` state. It is single-use.
+4. Acceptance requires a verified account whose normalized email matches the
+   invitation. The transaction locks the invite and membership uniqueness
+   rows so two requests cannot accept it twice.
+5. Cancellation and expiry make the token unusable immediately. Re-inviting
+   creates a new token and does not revive an old one.
+6. Acceptance creates membership but does not fabricate a Vault key. Each
+   shared Vault remains unavailable until an authorized client publishes a
+   wrapper for an authorized device.
+
+Invitation endpoints use uniform public errors and rate limits. Audit events
+contain actor, Team, target, role and timestamps but no token or Vault data.
+
+## Device-bound key distribution
+
+Each authorized device owns a non-exportable P-256 ECDH private key when the
+platform supports it; its public key and attestation metadata are registered
+with the account. Before implementation, browser/macOS interoperability
+fixtures must lock the exact encoding and algorithms:
+
+- P-256 ECDH;
+- HKDF-SHA-256;
+- AES-256-GCM key wrapping;
+- canonical context containing protocol version, Team ID, Vault ID, key
+  generation, member ID and device ID.
+
+For every shared Vault generation, an authorized client creates one random
+256-bit Vault key, encrypts the normalized Vault document locally, and creates
+a context-bound wrapper for each authorized member device. The server stores
+the ciphertext, public metadata and wrappers but never the Vault key or ECDH
+shared secret. A wrapper for one Team/Vault/generation/device must fail when
+replayed in any other context.
+
+A newly registered device requires approval from an existing authorized
+device or a separately reviewed account-recovery flow. Email/password login
+alone does not grant old shared-Vault keys. Device revocation invalidates its
+sessions and excludes it from all later wrapper sets.
+
+## Removal and rotation
+
+Membership removal is a fail-closed state transition:
+
+1. In one database transaction, mark membership revoked, revoke its sessions,
+   reject its reads/writes immediately, mark every affected shared Vault
+   `rotation_required`, and enqueue durable idempotent rotation work.
+2. Until an Owner/Admin client completes rotation, existing authorized members
+   may download the last authorized ciphertext but shared writes are frozen.
+   The removed member receives neither reads nor wrappers even during this
+   interval.
+3. An authorized rotating client downloads the latest ciphertext, decrypts it
+   locally, generates a new Vault key/generation, re-encrypts the full current
+   document and builds wrappers only for currently authorized devices.
+4. The API conditionally commits the new ciphertext, generation and complete
+   wrapper set against the locked prior revision/generation. Partial wrapper
+   sets and stale rotations are rejected.
+5. Retry uses an idempotency key. Competing rotations produce one committed
+   generation; losers refetch and stop or retry from current state.
+
+This guarantees that a removed member cannot obtain revisions encrypted under
+the new generation. It cannot erase plaintext, keys or old ciphertext already
+cached by that member. Re-invitation creates a new membership epoch and only
+receives current-generation wrappers; it does not reactivate revoked sessions
+or wrappers.
+
+## Revision and conflict rules
+
+- Each shared Vault has one monotonically increasing server revision and one
+  current key generation.
+- Writes use optimistic concurrency against both revision and generation.
+- Record version vectors and tombstones use the same causal model as the
+  personal Vault. Concurrent versions are returned to an authorized client;
+  timestamps never choose a winner.
+- Conflict resolution joins both histories, creates a new local causal event
+  and uploads conditionally. The server never sees the selected plaintext.
+- Role changes and rotation cannot be smuggled inside an encrypted record
+  revision; they use separate authorized endpoints and durable transactions.
+
+## API and storage invariants
+
+- Personal endpoints continue to accept only `personal/self`. Team APIs use a
+  separate explicit `/v1/teams/{teamID}/vaults/{vaultID}` scope.
+- Cross-Team identifiers return the same public not-found/forbidden shape and
+  never disclose membership or Vault existence.
+- Every mutation has an idempotency key and bounded payload. Database unique
+  constraints enforce membership epoch, invitation token hash, revision and
+  generation invariants.
+- Key/member/rotation mail or background work uses a durable outbox; no
+  authoritative queue lives in one Node process.
+- Logs and metrics exclude ciphertext bodies, wrappers, invitation tokens,
+  passphrases, record titles and decrypted fields.
+
+## Required acceptance tests
+
+- Allow/deny tests for every role and operation, including Viewer writes,
+  Admin-to-Owner escalation and cross-Team ID substitution.
+- Invitation expiry, cancellation, double acceptance, re-invitation and
+  verified-email mismatch.
+- Browser/macOS cryptographic fixtures for key agreement, context binding,
+  wrapping, ciphertext and malformed/downgraded envelopes.
+- Multiple devices per member, new-device approval and device revocation.
+- Concurrent record edits/deletes, explicit conflict resolution and stale
+  revision/generation rejection.
+- Removal during an active session and on an offline device; no later
+  ciphertext or wrapper is returned to the removed membership epoch.
+- Rotation retry, competing rotators, incomplete wrapper sets, process crash
+  and multi-replica outbox execution.
+- Server/database inspection proving no personal or shared plaintext/key is
+  present.
+
+Team/shared Vault status remains `planned_required` until these contracts are
+implemented and the acceptance suite passes in both browser and macOS clients.


### PR DESCRIPTION
## Summary

Completes the next browser personal-Vault UX milestone without changing public `main` or closed staging.

- requires an explicit local-or-Cloud choice for every concurrent record/tombstone
- joins both version histories locally and keeps the result dirty until a later conditional upload
- rejects incomplete, duplicate and stale resolution sets
- freezes record editing while a conflict set is active
- adds clean-browser encrypted recovery through the existing local-only recovery-passphrase primitive
- clears the recovery input after every attempt and never sends or persists it
- renders only bounded conflict metadata, never credential secrets, usernames or snippet bodies
- defines the mandatory Team/shared-Vault role, invitation, device-wrapper, membership-epoch and fail-closed rotation contract

## Exact source

- base `main`: `622546630241eda6292c38fa2ef7f6ae7ed18ab9`
- head: `cb812e5c246a009eae9ceeb1cbc54042b26c2edf`
- tree: `396bd93b35001a47c4f02a628aea73dcbc2959fe`
- 1 commit ahead, 0 behind
- 9 files, 612 additions, 18 deletions

## Verification

- focused Vault/model/local/sync/UI tests: 30/30 success
- full Cloud suite: 153/153 success
- JavaScript syntax, HTML parser, diff and static security checks: success
- npm audit --omit=dev: 0 vulnerabilities
- all remote blobs and the remote tree exactly match the locally tested commit
- CI 33917572241 (#476): completed/success
- Test DMG 33917572516 (#177): completed/success
- artifact `SelectiveRemote-test-42-arm64`: id 9953951182, 32,389,721 bytes
- artifact digest: `sha256:512d3a4ba85040ce158aba704eca3abdc1ac0e537357a89a0b2b1df4448fc11e`
- artifact expires: 2026-09-11T20:50:06Z
- artifact workflow head: `cb812e5c246a009eae9ceeb1cbc54042b26c2edf`

## Boundaries

- Team/shared Vault behavior is a reviewed design contract only; Team endpoints remain unimplemented and rejected by the personal client before network access
- no registration change, deployment, release, server mutation or public-main mutation
- closed staging remains on `60ba2148f2aadef766ae028bb92e117401670b85`
- public-main merge requires fresh exact Owner approval for this head