### PR TITLE
Cloud 0.32: add encrypted Team Vault revision protocol

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -8,8 +8,10 @@ The final v0.32 product scope also includes Teams and shared Vaults. The backend
 foundation implements durable Teams, memberships, the fixed four-role policy,
 single-use 48-hour invitations, encrypted durable invitation delivery and
 explicit Team/shared-Vault metadata endpoints. Shared ciphertext revisions,
-device-bound key wrappers, rotation completion and client UI remain later
-milestones; a metadata-only shared Vault is not yet usable for records.
+P-256 device registration/approval, per-device key wrappers and fail-closed
+rotation completion are now implemented in the backend. Browser/macOS Team
+cryptography and UI remain later milestones, so shared records are not yet
+exposed by either client.
 
 The browser portal can create and unlock a client-encrypted personal Vault,
 perform local CRUD, sign in with an existing verified account and manually
@@ -28,8 +30,9 @@ closed-staging configuration.
 The mandatory Team/shared-Vault security contract is documented in
 `docs/cloud-v0.32-team-threat-model.md`. It fixes the four-role matrix,
 invitation lifecycle, device-bound wrappers, membership epochs and fail-closed
-key rotation. Migration `005_team_foundation.sql` implements only the durable
-identity/access and metadata portion of that contract.
+key rotation. Migration `005_team_foundation.sql` implements durable
+identity/access metadata; `006_team_vault_crypto.sql` adds the plaintext-blind
+ciphertext, device-wrapper and rotation transaction layer.
 
 ## Team API foundation
 
@@ -51,15 +54,27 @@ the database stores and replays the committed response atomically.
   Admin escalation and removal of the last Owner fail closed.
 - `GET|POST /v1/teams/{teamID}/vaults` lists or creates shared-Vault metadata.
   Only Owner/Admin may create one.
+- `POST /v1/devices/{deviceID}` approves a new device key from the current
+  already-approved device after the submitted canonical public JWK matches the
+  locked registered key. Password login alone never approves a Team key.
+- `GET /v1/teams/{teamID}/vaults/{vaultID}/key-devices` returns the exact
+  active approved device set to Owner/Admin clients preparing wrappers.
+- `GET|PUT /v1/teams/{teamID}/vaults/{vaultID}` downloads the current opaque
+  envelope/current-device wrapper or conditionally writes a ciphertext
+  revision. Viewer writes are rejected.
+- `POST /v1/teams/{teamID}/vaults/{vaultID}/wrappers` grants a current-
+  generation wrapper to one newly authorized device under Owner/Admin checks.
 
 The invitation table stores only an HMAC hash. The opaque token and recipient
 are held in an AES-256-GCM outbox envelope under an independent runtime key;
 multi-replica delivery uses a bounded `FOR UPDATE SKIP LOCKED` lease. Logs do
 not contain recipients, tokens or mail-provider responses. Revoking a member
-immediately marks every active shared Vault `rotation_required`; shared content
-writes are deliberately absent until the wrapper/rotation protocol is complete.
-The same revocation transaction creates one durable rotation task per affected
-Vault and removed membership epoch.
+immediately marks every active shared Vault `rotation_required`; revoking an
+approved device does the same and invalidates all of its sessions. Writes then
+remain frozen until Owner/Admin conditionally commits a new full ciphertext,
+the next key generation and exactly one wrapper for every currently active
+approved device in a single PostgreSQL transaction. Partial/stale rotation is
+rejected and the same transaction completes its durable rotation tasks.
 
 ## Local verification
 

--- a/cloud/migrations/006_team_vault_crypto.sql
+++ b/cloud/migrations/006_team_vault_crypto.sql
@@ -1,0 +1,89 @@
+ALTER TABLE devices
+    ADD COLUMN public_key_algorithm text,
+    ADD COLUMN key_registered_at timestamptz,
+    ADD COLUMN key_approved_at timestamptz,
+    ADD COLUMN key_approved_by_device_id uuid REFERENCES devices(id) ON DELETE SET NULL,
+    ADD CONSTRAINT devices_team_key_complete CHECK (
+        (public_key IS NULL AND public_key_algorithm IS NULL AND key_registered_at IS NULL
+          AND key_approved_at IS NULL AND key_approved_by_device_id IS NULL)
+        OR
+        (public_key IS NOT NULL AND public_key_algorithm IS NULL AND key_registered_at IS NULL
+          AND key_approved_at IS NULL AND key_approved_by_device_id IS NULL)
+        OR
+        (public_key IS NOT NULL AND public_key_algorithm = 'p256-ecdh-v1'
+          AND key_registered_at IS NOT NULL
+          AND ((key_approved_at IS NULL AND key_approved_by_device_id IS NULL)
+            OR key_approved_at IS NOT NULL))
+    );
+
+ALTER TABLE shared_vaults
+    ADD COLUMN envelope_version integer,
+    ADD COLUMN ciphertext text,
+    ADD COLUMN nonce text,
+    ADD COLUMN auth_tag text,
+    ADD COLUMN content_hash text,
+    ADD COLUMN updated_by_device_id uuid REFERENCES devices(id) ON DELETE SET NULL,
+    ADD CONSTRAINT shared_vault_payload_complete CHECK (
+        (revision = 0 AND envelope_version IS NULL AND ciphertext IS NULL AND nonce IS NULL
+          AND auth_tag IS NULL AND content_hash IS NULL AND updated_by_device_id IS NULL)
+        OR
+        (revision > 0 AND envelope_version = 1 AND ciphertext IS NOT NULL AND nonce IS NOT NULL
+          AND auth_tag IS NOT NULL AND content_hash IS NOT NULL AND updated_by_device_id IS NOT NULL)
+    );
+
+CREATE TABLE shared_vault_revisions (
+    vault_id uuid NOT NULL REFERENCES shared_vaults(id) ON DELETE CASCADE,
+    revision bigint NOT NULL CHECK (revision > 0),
+    key_generation bigint NOT NULL CHECK (key_generation > 0),
+    envelope_version integer NOT NULL CHECK (envelope_version = 1),
+    ciphertext text NOT NULL,
+    nonce text NOT NULL,
+    auth_tag text NOT NULL,
+    content_hash text NOT NULL,
+    updated_by_device_id uuid NOT NULL REFERENCES devices(id) ON DELETE RESTRICT,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (vault_id, revision)
+);
+
+CREATE UNIQUE INDEX team_memberships_id_epoch
+    ON team_memberships (id, epoch);
+
+CREATE TABLE shared_vault_key_wrappers (
+    vault_id uuid NOT NULL REFERENCES shared_vaults(id) ON DELETE CASCADE,
+    key_generation bigint NOT NULL CHECK (key_generation > 0),
+    membership_id uuid NOT NULL,
+    membership_epoch bigint NOT NULL CHECK (membership_epoch > 0),
+    device_id uuid NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+    wrapper_version integer NOT NULL CHECK (wrapper_version = 1),
+    ephemeral_public_key jsonb NOT NULL,
+    ciphertext text NOT NULL,
+    nonce text NOT NULL,
+    auth_tag text NOT NULL,
+    context_hash text NOT NULL,
+    created_by_device_id uuid NOT NULL REFERENCES devices(id) ON DELETE RESTRICT,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (vault_id, key_generation, device_id),
+    FOREIGN KEY (membership_id, membership_epoch)
+        REFERENCES team_memberships(id, epoch) ON DELETE CASCADE,
+    CONSTRAINT shared_vault_wrapper_context_hash CHECK (context_hash ~ '^[A-Za-z0-9_-]{43}$'),
+    CONSTRAINT shared_vault_wrapper_envelope_shape CHECK (
+        jsonb_typeof(ephemeral_public_key) = 'object'
+        AND ciphertext ~ '^[A-Za-z0-9_-]{43}$'
+        AND nonce ~ '^[A-Za-z0-9_-]{16}$'
+        AND auth_tag ~ '^[A-Za-z0-9_-]{22}$'
+    )
+);
+
+CREATE INDEX shared_vault_key_wrappers_device
+    ON shared_vault_key_wrappers (device_id, vault_id, key_generation);
+
+ALTER TABLE shared_vault_rotation_tasks
+    ALTER COLUMN removed_membership_id DROP NOT NULL,
+    ADD COLUMN removed_device_id uuid REFERENCES devices(id) ON DELETE CASCADE,
+    ADD CONSTRAINT shared_vault_rotation_subject CHECK (
+        (removed_membership_id IS NOT NULL)::integer + (removed_device_id IS NOT NULL)::integer = 1
+    );
+
+CREATE UNIQUE INDEX shared_vault_rotation_tasks_device_unique
+    ON shared_vault_rotation_tasks (vault_id, from_generation, removed_device_id)
+    WHERE removed_device_id IS NOT NULL;

--- a/cloud/src/postgres-store.mjs
+++ b/cloud/src/postgres-store.mjs
@@ -4,6 +4,7 @@ import {
   requireMembershipChange,
   requireTeamPermission,
 } from "./team-policy.mjs";
+import { teamVaultWrapperContextHash } from "./security.mjs";
 
 const { Pool } = pg;
 
@@ -29,7 +30,13 @@ export class PostgresStore {
         [user.id, email, passwordHash],
       );
       await client.query(
-        "INSERT INTO devices (id, user_id, name, platform, app_version, public_key) VALUES ($1, $2, $3, $4, $5, $6)",
+        `INSERT INTO devices
+          (id, user_id, name, platform, app_version, public_key, public_key_algorithm,
+           key_registered_at, key_approved_at)
+         VALUES ($1, $2, $3, $4, $5, $6,
+           CASE WHEN $6::text IS NULL THEN NULL ELSE 'p256-ecdh-v1' END,
+           CASE WHEN $6::text IS NULL THEN NULL ELSE now() END,
+           CASE WHEN $6::text IS NULL THEN NULL ELSE now() END)`,
         [device.id, user.id, device.name, device.platform, device.appVersion, device.publicKey],
       );
       await client.query("INSERT INTO personal_vaults (user_id) VALUES ($1)", [user.id]);
@@ -272,15 +279,29 @@ export class PostgresStore {
     const client = await this.pool.connect();
     try {
       await client.query("BEGIN");
-      await client.query(
-        `INSERT INTO devices (id, user_id, name, platform, app_version, public_key)
-         VALUES ($1, $2, $3, $4, $5, $6)
+      const deviceResult = await client.query(
+        `INSERT INTO devices
+          (id, user_id, name, platform, app_version, public_key, public_key_algorithm, key_registered_at)
+         VALUES ($1, $2, $3, $4, $5, $6,
+           CASE WHEN $6::text IS NULL THEN NULL ELSE 'p256-ecdh-v1' END,
+           CASE WHEN $6::text IS NULL THEN NULL ELSE now() END)
          ON CONFLICT (user_id, id) DO UPDATE SET
            name = EXCLUDED.name, platform = EXCLUDED.platform,
-           app_version = EXCLUDED.app_version, public_key = EXCLUDED.public_key,
-           last_seen_at = now(), revoked_at = NULL`,
+           app_version = EXCLUDED.app_version,
+           public_key = CASE WHEN devices.public_key_algorithm IS NULL AND EXCLUDED.public_key IS NOT NULL
+             THEN EXCLUDED.public_key ELSE devices.public_key END,
+           public_key_algorithm = CASE WHEN devices.public_key_algorithm IS NULL AND EXCLUDED.public_key IS NOT NULL
+             THEN EXCLUDED.public_key_algorithm ELSE devices.public_key_algorithm END,
+           key_registered_at = CASE WHEN devices.public_key_algorithm IS NULL AND EXCLUDED.public_key IS NOT NULL
+             THEN EXCLUDED.key_registered_at ELSE devices.key_registered_at END,
+           last_seen_at = now()
+         WHERE devices.revoked_at IS NULL
+           AND (devices.public_key_algorithm IS NULL OR EXCLUDED.public_key IS NULL
+             OR devices.public_key = EXCLUDED.public_key)
+         RETURNING id`,
         [device.id, userID, device.name, device.platform, device.appVersion, device.publicKey],
       );
+      if (!deviceResult.rows[0]) throw new Error("invalid_device");
       await client.query(
         "INSERT INTO sessions (user_id, device_id, token_hash, expires_at) VALUES ($1, $2, $3, $4)",
         [userID, device.id, sessionHash, expiresAt],
@@ -314,7 +335,9 @@ export class PostgresStore {
 
   async listDevices(userID) {
     const result = await this.pool.query(
-      `SELECT id, name, platform, app_version, created_at, last_seen_at, revoked_at
+      `SELECT id, name, platform, app_version, created_at, last_seen_at, revoked_at,
+         public_key IS NOT NULL AS key_registered, public_key_algorithm, public_key,
+         key_approved_at
        FROM devices WHERE user_id = $1 ORDER BY last_seen_at DESC`,
       [userID],
     );
@@ -322,13 +345,79 @@ export class PostgresStore {
   }
 
   async revokeDevice(userID, deviceID) {
-    const result = await this.pool.query(
-      "UPDATE devices SET revoked_at = now() WHERE user_id = $1 AND id = $2 AND revoked_at IS NULL RETURNING id",
-      [userID, deviceID],
-    );
-    if (result.rowCount === 0) return false;
-    await this.pool.query("UPDATE sessions SET revoked_at = now() WHERE user_id = $1 AND device_id = $2 AND revoked_at IS NULL", [userID, deviceID]);
-    return true;
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+      const result = await client.query(
+        `UPDATE devices SET revoked_at = now()
+         WHERE user_id = $1 AND id = $2 AND revoked_at IS NULL
+         RETURNING id, key_approved_at`,
+        [userID, deviceID],
+      );
+      if (!result.rows[0]) {
+        await client.query("COMMIT");
+        return false;
+      }
+      await client.query(
+        "UPDATE sessions SET revoked_at = now() WHERE user_id = $1 AND device_id = $2 AND revoked_at IS NULL",
+        [userID, deviceID],
+      );
+      if (result.rows[0].key_approved_at) {
+        await client.query(
+          `WITH affected AS (
+             UPDATE shared_vaults AS vault SET rotation_required = true, updated_at = now()
+             FROM team_memberships AS membership
+             WHERE membership.user_id = $1 AND membership.revoked_at IS NULL
+               AND vault.team_id = membership.team_id AND vault.archived_at IS NULL
+             RETURNING vault.id, vault.key_generation
+           )
+           INSERT INTO shared_vault_rotation_tasks
+             (vault_id, from_generation, removed_device_id)
+           SELECT id, key_generation, $2 FROM affected
+           ON CONFLICT (vault_id, from_generation, removed_device_id)
+             WHERE removed_device_id IS NOT NULL DO NOTHING`,
+          [userID, deviceID],
+        );
+      }
+      await client.query("COMMIT");
+      return true;
+    } catch (error) {
+      try { await client.query("ROLLBACK"); } catch {}
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async approveDeviceKey({ actorUserID, actorDeviceID, deviceID, expectedPublicKey, idempotencyKey }) {
+    return this.withTeamMutation(actorUserID, "device.key.approve", idempotencyKey, async (client) => {
+      const actor = await client.query(
+        `SELECT id FROM devices
+         WHERE id = $1 AND user_id = $2 AND revoked_at IS NULL
+           AND public_key IS NOT NULL AND public_key_algorithm = 'p256-ecdh-v1'
+           AND key_approved_at IS NOT NULL
+         FOR UPDATE`,
+        [actorDeviceID, actorUserID],
+      );
+      if (!actor.rows[0]) throw new Error("device_approval_required");
+      const target = await client.query(
+        `SELECT id, public_key FROM devices
+         WHERE id = $1 AND user_id = $2 AND revoked_at IS NULL
+           AND public_key IS NOT NULL AND public_key_algorithm = 'p256-ecdh-v1'
+         FOR UPDATE`,
+        [deviceID, actorUserID],
+      );
+      if (!target.rows[0]) throw new Error("device_not_found");
+      if (target.rows[0].public_key !== expectedPublicKey) throw new Error("device_public_key_mismatch");
+      const approved = await client.query(
+        `UPDATE devices SET key_approved_at = COALESCE(key_approved_at, now()),
+           key_approved_by_device_id = COALESCE(key_approved_by_device_id, $1)
+         WHERE id = $2 AND user_id = $3
+         RETURNING id, key_approved_at`,
+        [actorDeviceID, deviceID, actorUserID],
+      );
+      return { approved: true, deviceID: approved.rows[0].id };
+    });
   }
 
   async getVault(userID) {
@@ -690,6 +779,194 @@ export class PostgresStore {
     });
   }
 
+  async listTeamKeyDevices(teamID, vaultID, actorUserID) {
+    const access = await this.pool.query(
+      `SELECT membership.role
+       FROM team_memberships AS membership
+       JOIN teams AS team ON team.id = membership.team_id AND team.archived_at IS NULL
+       JOIN shared_vaults AS vault ON vault.team_id = team.id AND vault.archived_at IS NULL
+       WHERE membership.team_id = $1 AND vault.id = $2 AND membership.user_id = $3
+         AND membership.revoked_at IS NULL`,
+      [teamID, vaultID, actorUserID],
+    );
+    if (!access.rows[0]) throw new Error("team_not_found");
+    requireTeamPermission(access.rows[0].role, "manage_vault_keys");
+    const result = await this.pool.query(
+      `SELECT membership.id AS membership_id, membership.epoch AS membership_epoch,
+         device.id AS device_id, device.public_key_algorithm, device.public_key
+       FROM team_memberships AS membership
+       JOIN devices AS device ON device.user_id = membership.user_id
+       WHERE membership.team_id = $1 AND membership.revoked_at IS NULL
+         AND device.revoked_at IS NULL AND device.key_approved_at IS NOT NULL
+         AND device.public_key IS NOT NULL
+       ORDER BY membership.id, device.id`,
+      [teamID],
+    );
+    return result.rows;
+  }
+
+  async getSharedVault(teamID, vaultID, actorUserID, actorDeviceID) {
+    const result = await this.pool.query(
+      `SELECT vault.id, vault.team_id, vault.name, vault.revision, vault.key_generation,
+         vault.rotation_required, vault.envelope_version, vault.ciphertext, vault.nonce,
+         vault.auth_tag, vault.content_hash, vault.created_at, vault.updated_at,
+         membership.id AS membership_id, membership.epoch AS membership_epoch,
+         device.id AS device_id, device.key_approved_at,
+         wrapper.wrapper_version, wrapper.ephemeral_public_key,
+         wrapper.ciphertext AS wrapper_ciphertext, wrapper.nonce AS wrapper_nonce,
+         wrapper.auth_tag AS wrapper_auth_tag, wrapper.context_hash
+       FROM team_memberships AS membership
+       JOIN teams AS team ON team.id = membership.team_id AND team.archived_at IS NULL
+       JOIN shared_vaults AS vault ON vault.team_id = team.id AND vault.archived_at IS NULL
+       JOIN devices AS device ON device.id = $4 AND device.user_id = membership.user_id
+         AND device.revoked_at IS NULL
+       LEFT JOIN shared_vault_key_wrappers AS wrapper
+         ON wrapper.vault_id = vault.id AND wrapper.key_generation = vault.key_generation
+         AND wrapper.membership_id = membership.id AND wrapper.membership_epoch = membership.epoch
+         AND wrapper.device_id = device.id
+       WHERE membership.team_id = $1 AND vault.id = $2 AND membership.user_id = $3
+         AND membership.revoked_at IS NULL`,
+      [teamID, vaultID, actorUserID, actorDeviceID],
+    );
+    const row = result.rows[0];
+    if (!row) throw new Error("team_not_found");
+    if (!row.key_approved_at) throw new Error("device_approval_required");
+    return row;
+  }
+
+  async putSharedVault({
+    actorUserID,
+    actorDeviceID,
+    teamID,
+    vaultID,
+    envelope,
+    idempotencyKey,
+  }) {
+    return this.withTeamMutation(actorUserID, "team.vault.put", idempotencyKey, async (client) => {
+      const context = await lockSharedVaultActor(client, teamID, vaultID, actorUserID, actorDeviceID);
+      if (!context) throw new Error("team_not_found");
+      if (!context.key_approved_at) throw new Error("device_approval_required");
+      requireTeamPermission(context.role, "write_vault");
+      const currentRevision = Number(context.revision);
+      const currentGeneration = Number(context.key_generation);
+      if (currentRevision !== envelope.baseRevision) {
+        return { conflict: true, revision: currentRevision, keyGeneration: currentGeneration };
+      }
+
+      const initializing = currentRevision === 0;
+      const rotating = context.rotation_required === true;
+      if (initializing || rotating) requireTeamPermission(context.role, "manage_vault_keys");
+      if (rotating && envelope.keyGeneration !== currentGeneration + 1) {
+        throw new Error("invalid_key_generation");
+      }
+      if (!rotating && envelope.keyGeneration !== currentGeneration) {
+        throw new Error("invalid_key_generation");
+      }
+      if ((initializing || rotating) !== (envelope.wrappers !== null)) {
+        throw new Error(initializing || rotating ? "incomplete_team_vault_wrappers" : "unexpected_team_vault_wrappers");
+      }
+      if (!initializing && !rotating) {
+        const actorWrapper = await client.query(
+          `SELECT 1 FROM shared_vault_key_wrappers
+           WHERE vault_id = $1 AND key_generation = $2 AND membership_id = $3
+             AND membership_epoch = $4 AND device_id = $5`,
+          [vaultID, currentGeneration, context.membership_id, context.epoch, actorDeviceID],
+        );
+        if (!actorWrapper.rows[0]) throw new Error("team_vault_key_unavailable");
+      }
+
+      const nextGeneration = envelope.keyGeneration;
+      if (envelope.wrappers) {
+        const eligible = await lockEligibleTeamDevices(client, teamID);
+        requireCompleteWrapperSet(eligible, envelope.wrappers);
+        requireWrapperContextHashes(teamID, vaultID, nextGeneration, envelope.wrappers);
+        await insertSharedVaultWrappers(
+          client,
+          vaultID,
+          nextGeneration,
+          actorDeviceID,
+          envelope.wrappers,
+        );
+      }
+
+      const revision = currentRevision + 1;
+      await client.query(
+        `INSERT INTO shared_vault_revisions
+          (vault_id, revision, key_generation, envelope_version, ciphertext, nonce,
+           auth_tag, content_hash, updated_by_device_id)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
+        [vaultID, revision, nextGeneration, envelope.envelopeVersion, envelope.ciphertext,
+          envelope.nonce, envelope.authTag, envelope.contentHash, actorDeviceID],
+      );
+      await client.query(
+        `UPDATE shared_vaults SET revision = $2, key_generation = $3, envelope_version = $4,
+           ciphertext = $5, nonce = $6, auth_tag = $7, content_hash = $8,
+           updated_by_device_id = $9, rotation_required = false, updated_at = now()
+         WHERE id = $1`,
+        [vaultID, revision, nextGeneration, envelope.envelopeVersion, envelope.ciphertext,
+          envelope.nonce, envelope.authTag, envelope.contentHash, actorDeviceID],
+      );
+      if (rotating) {
+        await client.query(
+          `UPDATE shared_vault_rotation_tasks SET status = 'completed', completed_at = now()
+           WHERE vault_id = $1 AND from_generation = $2 AND status = 'pending'`,
+          [vaultID, currentGeneration],
+        );
+      }
+      await writeTeamAudit(client, {
+        teamID,
+        actorUserID,
+        action: rotating ? "team.vault_rotated" : "team.vault_revision_created",
+        targetVaultID: vaultID,
+        metadata: { revision, keyGeneration: nextGeneration },
+      });
+      return { conflict: false, revision, keyGeneration: nextGeneration, rotationCompleted: rotating };
+    });
+  }
+
+  async grantSharedVaultWrapper({
+    actorUserID,
+    actorDeviceID,
+    teamID,
+    vaultID,
+    wrapper,
+    keyGeneration,
+    idempotencyKey,
+  }) {
+    return this.withTeamMutation(actorUserID, "team.vault.wrapper.grant", idempotencyKey, async (client) => {
+      const context = await lockSharedVaultActor(client, teamID, vaultID, actorUserID, actorDeviceID);
+      if (!context) throw new Error("team_not_found");
+      if (!context.key_approved_at) throw new Error("device_approval_required");
+      requireTeamPermission(context.role, "manage_vault_keys");
+      if (!Number.isSafeInteger(keyGeneration) || keyGeneration !== Number(context.key_generation)
+        || Number(context.revision) === 0 || context.rotation_required === true) {
+        throw new Error("invalid_key_generation");
+      }
+      const eligible = await lockEligibleTeamDevices(client, teamID);
+      const target = eligible.find((row) => row.device_id === wrapper.deviceID);
+      if (!target || target.membership_id !== wrapper.membershipID
+        || Number(target.membership_epoch) !== wrapper.membershipEpoch) {
+        throw new Error("team_not_found");
+      }
+      requireWrapperContextHashes(teamID, vaultID, keyGeneration, [wrapper]);
+      try {
+        await insertSharedVaultWrappers(client, vaultID, keyGeneration, actorDeviceID, [wrapper]);
+      } catch (error) {
+        if (error?.code === "23505") throw new Error("shared_vault_wrapper_exists");
+        throw error;
+      }
+      await writeTeamAudit(client, {
+        teamID,
+        actorUserID,
+        action: "team.vault_wrapper_granted",
+        targetMembershipID: wrapper.membershipID,
+        targetVaultID: vaultID,
+        metadata: { deviceID: wrapper.deviceID, keyGeneration },
+      });
+      return { granted: true, keyGeneration, deviceID: wrapper.deviceID };
+    });
+  }
+
   async claimTeamInvitationOutbox(claimOwner) {
     const result = await this.pool.query(
       `WITH candidate AS (
@@ -784,6 +1061,82 @@ async function lockTeamMembership(client, teamID, membershipID) {
     [teamID, membershipID],
   );
   return result.rows[0] ?? null;
+}
+
+async function lockSharedVaultActor(client, teamID, vaultID, actorUserID, actorDeviceID) {
+  const result = await client.query(
+    `SELECT membership.id AS membership_id, membership.role, membership.epoch,
+       device.key_approved_at, vault.revision, vault.key_generation, vault.rotation_required
+     FROM team_memberships AS membership
+     JOIN teams AS team ON team.id = membership.team_id AND team.archived_at IS NULL
+     JOIN shared_vaults AS vault ON vault.team_id = team.id AND vault.archived_at IS NULL
+     JOIN devices AS device ON device.id = $4 AND device.user_id = membership.user_id
+       AND device.revoked_at IS NULL
+     WHERE membership.team_id = $1 AND vault.id = $2 AND membership.user_id = $3
+       AND membership.revoked_at IS NULL
+     FOR UPDATE OF membership, team, vault, device`,
+    [teamID, vaultID, actorUserID, actorDeviceID],
+  );
+  return result.rows[0] ?? null;
+}
+
+async function lockEligibleTeamDevices(client, teamID) {
+  const result = await client.query(
+    `SELECT membership.id AS membership_id, membership.epoch AS membership_epoch,
+       device.id AS device_id
+     FROM team_memberships AS membership
+     JOIN devices AS device ON device.user_id = membership.user_id
+     WHERE membership.team_id = $1 AND membership.revoked_at IS NULL
+       AND device.revoked_at IS NULL AND device.key_approved_at IS NOT NULL
+       AND device.public_key IS NOT NULL
+     ORDER BY membership.id, device.id
+     FOR UPDATE OF membership, device`,
+    [teamID],
+  );
+  return result.rows;
+}
+
+function requireCompleteWrapperSet(eligible, wrappers) {
+  if (eligible.length === 0 || wrappers.length !== eligible.length) {
+    throw new Error("incomplete_team_vault_wrappers");
+  }
+  const byDevice = new Map(wrappers.map((wrapper) => [wrapper.deviceID, wrapper]));
+  for (const row of eligible) {
+    const wrapper = byDevice.get(row.device_id);
+    if (!wrapper || wrapper.membershipID !== row.membership_id
+      || wrapper.membershipEpoch !== Number(row.membership_epoch)) {
+      throw new Error("incomplete_team_vault_wrappers");
+    }
+  }
+}
+
+function requireWrapperContextHashes(teamID, vaultID, keyGeneration, wrappers) {
+  for (const wrapper of wrappers) {
+    const expected = teamVaultWrapperContextHash({
+      teamID,
+      vaultID,
+      keyGeneration,
+      membershipID: wrapper.membershipID,
+      membershipEpoch: wrapper.membershipEpoch,
+      deviceID: wrapper.deviceID,
+    });
+    if (wrapper.contextHash !== expected) throw new Error("invalid_team_vault_wrapper_context");
+  }
+}
+
+async function insertSharedVaultWrappers(client, vaultID, keyGeneration, actorDeviceID, wrappers) {
+  for (const wrapper of wrappers) {
+    await client.query(
+      `INSERT INTO shared_vault_key_wrappers
+        (vault_id, key_generation, membership_id, membership_epoch, device_id,
+         wrapper_version, ephemeral_public_key, ciphertext, nonce, auth_tag,
+         context_hash, created_by_device_id)
+       VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb,$8,$9,$10,$11,$12)`,
+      [vaultID, keyGeneration, wrapper.membershipID, wrapper.membershipEpoch,
+        wrapper.deviceID, wrapper.wrapperVersion, JSON.stringify(wrapper.ephemeralPublicKey),
+        wrapper.ciphertext, wrapper.nonce, wrapper.authTag, wrapper.contextHash, actorDeviceID],
+    );
+  }
 }
 
 async function requireAnotherOwner(client, teamID, excludedMembershipID) {

--- a/cloud/src/security.mjs
+++ b/cloud/src/security.mjs
@@ -14,6 +14,7 @@ const passwordKeyLength = 32;
 const scryptOptions = Object.freeze({ N: 1 << 17, r: 8, p: 1, maxmem: 256 * 1024 * 1024 });
 const base64URL = /^[A-Za-z0-9_-]+$/;
 const maxWrappedKeyBytes = 16 * 1024;
+const maxTeamWrappers = 1024;
 
 export function normalizeEmail(value) {
   const email = String(value ?? "").trim().toLowerCase();
@@ -176,6 +177,114 @@ export function validateVaultEnvelope(value) {
     baseRevision: envelope.baseRevision,
     envelopeVersion: envelope.envelopeVersion,
     wrappedKey,
+    ciphertext: envelope.ciphertext,
+    nonce: envelope.nonce,
+    authTag: envelope.authTag,
+    contentHash: envelope.contentHash,
+  };
+}
+
+export function validateDevicePublicKey(value) {
+  const key = value && typeof value === "object" && !Array.isArray(value) ? value : {};
+  if (key.kty !== "EC" || key.crv !== "P-256"
+    || typeof key.x !== "string" || key.x.length !== 43 || !base64URL.test(key.x)
+    || typeof key.y !== "string" || key.y.length !== 43 || !base64URL.test(key.y)) {
+    throw new Error("invalid_device_public_key");
+  }
+  if (("d" in key) || ("key_ops" in key && (!Array.isArray(key.key_ops) || key.key_ops.length !== 0))) {
+    throw new Error("invalid_device_public_key");
+  }
+  return JSON.stringify({ kty: "EC", crv: "P-256", x: key.x, y: key.y, ext: true, key_ops: [] });
+}
+
+export function validateTeamVaultEnvelope(value) {
+  const envelope = validateEncryptedPayload(value);
+  if (!Number.isSafeInteger(value?.keyGeneration) || value.keyGeneration < 1) {
+    throw new Error("invalid_key_generation");
+  }
+  const wrappers = value?.wrappers === undefined ? null : validateTeamVaultWrappers(value.wrappers);
+  return { ...envelope, keyGeneration: value.keyGeneration, wrappers };
+}
+
+export function validateTeamVaultWrapper(value) {
+  const wrapper = value && typeof value === "object" && !Array.isArray(value) ? value : {};
+  if (!isUUID(wrapper.membershipID) || !isUUID(wrapper.deviceID)
+    || !Number.isSafeInteger(wrapper.membershipEpoch) || wrapper.membershipEpoch < 1
+    || wrapper.wrapperVersion !== 1) {
+    throw new Error("invalid_team_vault_wrapper");
+  }
+  for (const [field, length] of [["ciphertext", 43], ["nonce", 16], ["authTag", 22], ["contextHash", 43]]) {
+    if (typeof wrapper[field] !== "string" || wrapper[field].length !== length || !base64URL.test(wrapper[field])) {
+      throw new Error("invalid_team_vault_wrapper");
+    }
+  }
+  return {
+    membershipID: wrapper.membershipID.toLowerCase(),
+    membershipEpoch: wrapper.membershipEpoch,
+    deviceID: wrapper.deviceID.toLowerCase(),
+    wrapperVersion: 1,
+    ephemeralPublicKey: JSON.parse(validateDevicePublicKey(wrapper.ephemeralPublicKey)),
+    ciphertext: wrapper.ciphertext,
+    nonce: wrapper.nonce,
+    authTag: wrapper.authTag,
+    contextHash: wrapper.contextHash,
+  };
+}
+
+export function teamVaultWrapperContextHash({
+  teamID,
+  vaultID,
+  keyGeneration,
+  membershipID,
+  membershipEpoch,
+  deviceID,
+}) {
+  if (!isUUID(teamID) || !isUUID(vaultID) || !isUUID(membershipID) || !isUUID(deviceID)
+    || !Number.isSafeInteger(keyGeneration) || keyGeneration < 1
+    || !Number.isSafeInteger(membershipEpoch) || membershipEpoch < 1) {
+    throw new Error("invalid_team_vault_wrapper");
+  }
+  const context = [
+    "selective-remote/team-vault-wrapper/v1",
+    teamID.toLowerCase(),
+    vaultID.toLowerCase(),
+    String(keyGeneration),
+    membershipID.toLowerCase(),
+    String(membershipEpoch),
+    deviceID.toLowerCase(),
+  ].join("\0");
+  return createHash("sha256").update(context, "utf8").digest("base64url");
+}
+
+function validateTeamVaultWrappers(value) {
+  if (!Array.isArray(value) || value.length === 0 || value.length > maxTeamWrappers) {
+    throw new Error("invalid_team_vault_wrappers");
+  }
+  const wrappers = value.map(validateTeamVaultWrapper);
+  if (new Set(wrappers.map((wrapper) => wrapper.deviceID)).size !== wrappers.length) {
+    throw new Error("invalid_team_vault_wrappers");
+  }
+  return wrappers;
+}
+
+function validateEncryptedPayload(value) {
+  const envelope = value && typeof value === "object" ? value : {};
+  for (const key of ["ciphertext", "nonce", "authTag", "contentHash"]) {
+    if (typeof envelope[key] !== "string" || !base64URL.test(envelope[key])) {
+      throw new Error("invalid_vault_envelope");
+    }
+  }
+  if (!Number.isSafeInteger(envelope.baseRevision) || envelope.baseRevision < 0) {
+    throw new Error("invalid_base_revision");
+  }
+  if (envelope.envelopeVersion !== 1) throw new Error("invalid_envelope_version");
+  if (envelope.ciphertext.length > 32 * 1024 * 1024) throw new Error("vault_too_large");
+  if (envelope.nonce.length !== 16 || envelope.authTag.length !== 22 || envelope.contentHash.length !== 43) {
+    throw new Error("invalid_vault_envelope");
+  }
+  return {
+    baseRevision: envelope.baseRevision,
+    envelopeVersion: 1,
     ciphertext: envelope.ciphertext,
     nonce: envelope.nonce,
     authTag: envelope.authTag,

--- a/cloud/src/server.mjs
+++ b/cloud/src/server.mjs
@@ -98,6 +98,18 @@ async function route(request, response) {
       return sendJSON(response, 200, { devices: await store.listDevices(session.user_id) });
     }
     const deviceMatch = url.pathname.match(/^\/v1\/devices\/([^/]+)$/i);
+    if (deviceMatch && method === "POST") {
+      if (!isUUID(deviceMatch[1])) return sendError(response, 400, "invalid_device");
+      return handleOperation(
+        response,
+        async () => service.approveDeviceKey(
+          session,
+          deviceMatch[1],
+          await readJSON(request, maxTeamBodyBytes),
+          idempotencyKey(request),
+        ),
+      );
+    }
     if (method === "DELETE" && deviceMatch) {
       if (!isUUID(deviceMatch[1])) return sendError(response, 400, "invalid_device");
       const revoked = await store.revokeDevice(session.user_id, deviceMatch[1]);
@@ -223,6 +235,63 @@ async function route(request, response) {
           ),
           201,
         );
+      }
+    }
+    const teamVaultDevicesMatch = url.pathname.match(
+      /^\/v1\/teams\/([^/]+)\/vaults\/([^/]+)\/key-devices$/i,
+    );
+    if (method === "GET" && teamVaultDevicesMatch) {
+      if (!isUUID(teamVaultDevicesMatch[1]) || !isUUID(teamVaultDevicesMatch[2])) {
+        return sendError(response, 404, "team_not_found");
+      }
+      return handleOperation(
+        response,
+        () => service.listTeamKeyDevices(session, teamVaultDevicesMatch[1], teamVaultDevicesMatch[2]),
+      );
+    }
+    const teamVaultWrappersMatch = url.pathname.match(
+      /^\/v1\/teams\/([^/]+)\/vaults\/([^/]+)\/wrappers$/i,
+    );
+    if (method === "POST" && teamVaultWrappersMatch) {
+      if (!isUUID(teamVaultWrappersMatch[1]) || !isUUID(teamVaultWrappersMatch[2])) {
+        return sendError(response, 404, "team_not_found");
+      }
+      return handleOperation(
+        response,
+        async () => service.grantSharedVaultWrapper(
+          session,
+          teamVaultWrappersMatch[1],
+          teamVaultWrappersMatch[2],
+          await readJSON(request, maxTeamBodyBytes),
+          idempotencyKey(request),
+        ),
+        201,
+      );
+    }
+    const teamVaultMatch = url.pathname.match(/^\/v1\/teams\/([^/]+)\/vaults\/([^/]+)$/i);
+    if (teamVaultMatch) {
+      if (!isUUID(teamVaultMatch[1]) || !isUUID(teamVaultMatch[2])) {
+        return sendError(response, 404, "team_not_found");
+      }
+      if (method === "GET") {
+        return handleOperation(
+          response,
+          () => service.getSharedVault(session, teamVaultMatch[1], teamVaultMatch[2]),
+        );
+      }
+      if (method === "PUT") {
+        try {
+          const result = await service.putSharedVault(
+            session,
+            teamVaultMatch[1],
+            teamVaultMatch[2],
+            await readJSON(request),
+            idempotencyKey(request),
+          );
+          return sendJSON(response, result.conflict ? 409 : 200, result);
+        } catch (error) {
+          return handleOperationError(response, error);
+        }
       }
     }
     return sendError(response, 404, "not_found");

--- a/cloud/src/service-error.mjs
+++ b/cloud/src/service-error.mjs
@@ -9,6 +9,10 @@ const operationStatuses = Object.freeze({
   invalid_email: 400,
   invalid_password: 400,
   invalid_device: 400,
+  invalid_device_public_key: 400,
+  device_public_key_mismatch: 409,
+  device_not_found: 404,
+  device_approval_required: 403,
   invalid_content_type: 415,
   invalid_json: 400,
   request_too_large: 413,
@@ -16,6 +20,14 @@ const operationStatuses = Object.freeze({
   invalid_wrapped_key: 400,
   invalid_base_revision: 400,
   invalid_envelope_version: 400,
+  invalid_key_generation: 409,
+  invalid_team_vault_wrapper: 400,
+  invalid_team_vault_wrapper_context: 400,
+  invalid_team_vault_wrappers: 400,
+  incomplete_team_vault_wrappers: 409,
+  unexpected_team_vault_wrappers: 400,
+  team_vault_key_unavailable: 403,
+  team_vault_conflict: 409,
   vault_too_large: 413,
   vault_missing: 404,
   invalid_team: 400,
@@ -28,6 +40,7 @@ const operationStatuses = Object.freeze({
   team_member_exists: 409,
   team_last_owner: 409,
   shared_vault_exists: 409,
+  shared_vault_wrapper_exists: 409,
 });
 
 export function publicOperationError(error) {

--- a/cloud/src/service.mjs
+++ b/cloud/src/service.mjs
@@ -14,7 +14,10 @@ import {
   hashTeamInvitationToken,
   isUUID,
   normalizeEmail,
+  validateDevicePublicKey,
   validatePassword,
+  validateTeamVaultEnvelope,
+  validateTeamVaultWrapper,
   validateVaultEnvelope,
   verifyPassword,
 } from "./security.mjs";
@@ -89,7 +92,7 @@ export class CloudService {
       name,
       platform,
       appVersion: String(device.appVersion ?? "").slice(0, 40),
-      publicKey: device.publicKey ? String(device.publicKey).slice(0, 4096) : null,
+      publicKey: device.publicKey ? validateDevicePublicKey(device.publicKey) : null,
     };
   }
 
@@ -349,6 +352,54 @@ export class CloudService {
     return { vault: publicSharedVault(result.vault) };
   }
 
+  async approveDeviceKey(session, deviceID, input, idempotencyKey) {
+    return this.store.approveDeviceKey({
+      actorUserID: session.user_id,
+      actorDeviceID: session.device_id,
+      deviceID,
+      expectedPublicKey: validateDevicePublicKey(input?.publicKey),
+      idempotencyKey: validateIdempotencyKey(idempotencyKey),
+    });
+  }
+
+  async listTeamKeyDevices(session, teamID, vaultID) {
+    const rows = await this.store.listTeamKeyDevices(teamID, vaultID, session.user_id);
+    return { devices: rows.map(publicTeamKeyDevice) };
+  }
+
+  async getSharedVault(session, teamID, vaultID) {
+    const row = await this.store.getSharedVault(
+      teamID,
+      vaultID,
+      session.user_id,
+      session.device_id,
+    );
+    return publicSharedVaultEnvelope(row);
+  }
+
+  async putSharedVault(session, teamID, vaultID, input, idempotencyKey) {
+    return this.store.putSharedVault({
+      actorUserID: session.user_id,
+      actorDeviceID: session.device_id,
+      teamID,
+      vaultID,
+      envelope: validateTeamVaultEnvelope(input),
+      idempotencyKey: validateIdempotencyKey(idempotencyKey),
+    });
+  }
+
+  async grantSharedVaultWrapper(session, teamID, vaultID, input, idempotencyKey) {
+    return this.store.grantSharedVaultWrapper({
+      actorUserID: session.user_id,
+      actorDeviceID: session.device_id,
+      teamID,
+      vaultID,
+      wrapper: validateTeamVaultWrapper(input?.wrapper),
+      keyGeneration: input?.keyGeneration,
+      idempotencyKey: validateIdempotencyKey(idempotencyKey),
+    });
+  }
+
   async dispatchTeamInvitationOutbox() {
     if (!this.mailer) return false;
     const job = await this.store.claimTeamInvitationOutbox(this.outboxClaimOwner);
@@ -423,6 +474,39 @@ function publicSharedVault(row) {
     keyGeneration: Number(row.key_generation),
     rotationRequired: row.rotation_required === true,
     createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function publicTeamKeyDevice(row) {
+  return {
+    membershipID: row.membership_id,
+    membershipEpoch: Number(row.membership_epoch),
+    deviceID: row.device_id,
+    publicKeyAlgorithm: row.public_key_algorithm,
+    publicKey: JSON.parse(row.public_key),
+  };
+}
+
+function publicSharedVaultEnvelope(row) {
+  return {
+    ...publicSharedVault(row),
+    envelopeVersion: row.envelope_version,
+    ciphertext: row.ciphertext,
+    nonce: row.nonce,
+    authTag: row.auth_tag,
+    contentHash: row.content_hash,
+    wrapper: row.wrapper_ciphertext ? {
+      wrapperVersion: Number(row.wrapper_version),
+      membershipID: row.membership_id,
+      membershipEpoch: Number(row.membership_epoch),
+      deviceID: row.device_id,
+      ephemeralPublicKey: row.ephemeral_public_key,
+      ciphertext: row.wrapper_ciphertext,
+      nonce: row.wrapper_nonce,
+      authTag: row.wrapper_auth_tag,
+      contextHash: row.context_hash,
+    } : null,
     updatedAt: row.updated_at,
   };
 }

--- a/cloud/src/team-policy.mjs
+++ b/cloud/src/team-policy.mjs
@@ -5,6 +5,8 @@ const permissions = Object.freeze({
   read: new Set(teamRoles),
   list_members: new Set(teamRoles),
   create_vault: new Set(["owner", "admin"]),
+  write_vault: new Set(["owner", "admin", "editor"]),
+  manage_vault_keys: new Set(["owner", "admin"]),
   invite_member: new Set(["owner", "admin"]),
   invite_admin: new Set(["owner"]),
   manage_member: new Set(["owner", "admin"]),

--- a/cloud/tests/migrations.test.mjs
+++ b/cloud/tests/migrations.test.mjs
@@ -13,8 +13,22 @@ test("numbered migrations have stable checksums", async () => {
     { version: 3, name: "003_auth_rate_limits.sql" },
     { version: 4, name: "004_password_reset.sql" },
     { version: 5, name: "005_team_foundation.sql" },
+    { version: 6, name: "006_team_vault_crypto.sql" },
   ]);
   for (const migration of migrations) assert.match(migration.checksum, /^[0-9a-f]{64}$/);
+});
+
+test("Team Vault crypto migration persists ciphertext, device wrappers and rotation subjects", async () => {
+  const migrations = await loadMigrations(migrationsDirectory);
+  const crypto = migrations.find(({ version }) => version === 6);
+
+  assert.match(crypto.sql, /CREATE TABLE shared_vault_revisions/);
+  assert.match(crypto.sql, /CREATE TABLE shared_vault_key_wrappers/);
+  assert.match(crypto.sql, /public_key_algorithm = 'p256-ecdh-v1'/);
+  assert.match(crypto.sql, /membership_epoch bigint NOT NULL/);
+  assert.match(crypto.sql, /removed_device_id uuid/);
+  assert.match(crypto.sql, /shared_vault_rotation_subject/);
+  assert.doesNotMatch(crypto.sql, /\bplaintext\b|\bvault_key\s+text\b|\bprivate_key\b/);
 });
 
 test("Team foundation migration keeps authorization and invitation state durable", async () => {

--- a/cloud/tests/security.test.mjs
+++ b/cloud/tests/security.test.mjs
@@ -13,6 +13,9 @@ import {
   hashSessionToken,
   hashTeamInvitationToken,
   normalizeEmail,
+  teamVaultWrapperContextHash,
+  validateDevicePublicKey,
+  validateTeamVaultEnvelope,
   validateVaultEnvelope,
   verifyPassword,
 } from "../src/security.mjs";
@@ -113,4 +116,69 @@ test("vault envelope rejects unversioned and oversized values", () => {
   assert.throws(() => validateVaultEnvelope({ ...valid, ciphertext: "not base64" }), /invalid_vault_envelope/);
   assert.throws(() => validateVaultEnvelope({ ...valid, nonce: "x".repeat(15) }), /invalid_vault_envelope/);
   assert.throws(() => validateVaultEnvelope({ ...valid, envelopeVersion: 2 }), /invalid_envelope_version/);
+});
+
+test("Team device keys are canonical public-only P-256 JWKs", () => {
+  const key = { kty: "EC", crv: "P-256", x: "A".repeat(43), y: "B".repeat(43) };
+  assert.deepEqual(JSON.parse(validateDevicePublicKey(key)), {
+    ...key,
+    ext: true,
+    key_ops: [],
+  });
+  assert.throws(() => validateDevicePublicKey({ ...key, d: "private" }), /invalid_device_public_key/);
+  assert.throws(() => validateDevicePublicKey({ ...key, crv: "P-384" }), /invalid_device_public_key/);
+});
+
+test("Team Vault envelopes bind one unique wrapper to membership epoch and device", () => {
+  const wrapper = {
+    membershipID: "7026d8a4-116a-4f61-9d8e-ff04e3a73360",
+    membershipEpoch: 3,
+    deviceID: "1f386e3d-d7b7-4365-a116-19f68e7f512d",
+    wrapperVersion: 1,
+    ephemeralPublicKey: { kty: "EC", crv: "P-256", x: "E".repeat(43), y: "F".repeat(43) },
+    ciphertext: "G".repeat(43),
+    nonce: "H".repeat(16),
+    authTag: "I".repeat(22),
+    contextHash: "J".repeat(43),
+  };
+  const envelope = {
+    baseRevision: 0,
+    keyGeneration: 1,
+    envelopeVersion: 1,
+    ciphertext: "AA",
+    nonce: "B".repeat(16),
+    authTag: "C".repeat(22),
+    contentHash: "D".repeat(43),
+    wrappers: [wrapper],
+  };
+  const validated = validateTeamVaultEnvelope(envelope);
+  assert.equal(validated.wrappers[0].membershipEpoch, 3);
+  assert.equal(validated.wrappers[0].ephemeralPublicKey.ext, true);
+  assert.throws(
+    () => validateTeamVaultEnvelope({ ...envelope, wrappers: [wrapper, { ...wrapper }] }),
+    /invalid_team_vault_wrappers/,
+  );
+  assert.throws(
+    () => validateTeamVaultEnvelope({ ...envelope, keyGeneration: 0 }),
+    /invalid_key_generation/,
+  );
+});
+
+test("Team wrapper context changes across every authorization boundary", () => {
+  const input = {
+    teamID: "84f6c860-0d26-4ef5-8652-27cb8b991b70",
+    vaultID: "bc01823b-1401-4058-9488-f4f6d1839b3b",
+    keyGeneration: 2,
+    membershipID: "7026d8a4-116a-4f61-9d8e-ff04e3a73360",
+    membershipEpoch: 3,
+    deviceID: "33cc880e-084a-4d9a-b1ea-f99d2ff86032",
+  };
+  const expected = teamVaultWrapperContextHash(input);
+  assert.match(expected, /^[A-Za-z0-9_-]{43}$/);
+  assert.notEqual(expected, teamVaultWrapperContextHash({ ...input, keyGeneration: 3 }));
+  assert.notEqual(expected, teamVaultWrapperContextHash({ ...input, membershipEpoch: 4 }));
+  assert.notEqual(expected, teamVaultWrapperContextHash({
+    ...input,
+    vaultID: "e6087707-d527-4028-a47c-5cd49080b781",
+  }));
 });

--- a/cloud/tests/team-api-surface.test.mjs
+++ b/cloud/tests/team-api-surface.test.mjs
@@ -14,18 +14,24 @@ test("Team routes are authenticated, explicitly scoped and idempotent", () => {
     "teamInvitationMatch",
     "teamMemberMatch",
     "teamVaultsMatch",
+    "teamVaultMatch",
+    "teamVaultDevicesMatch",
+    "teamVaultWrappersMatch",
   ]) assert.match(serverSource, new RegExp(fragment.replaceAll("/", "\\/")));
   assert.match(serverSource, /idempotencyKey\(request\)/);
   assert.match(serverSource, /maxTeamBodyBytes = 16 \* 1024/);
   assert.match(serverSource, /team_invitation_create_user/);
   assert.match(serverSource, /team_invitation_accept_ip/);
-  assert.doesNotMatch(serverSource, /\/v1\/teams\/\$\{[^}]+\}\/vaults\/\$\{[^}]+\}.*PUT/);
+  assert.match(serverSource, /service\.putSharedVault/);
+  assert.match(serverSource, /service\.approveDeviceKey/);
+  assert.match(serverSource, /service\.grantSharedVaultWrapper/);
 });
 
 test("malformed or cross-scope Team identifiers use the same not-found boundary", () => {
   assert.match(serverSource, /!isUUID\(teamMembersMatch\[1\]\).*team_not_found/s);
   assert.match(serverSource, /!isUUID\(teamMemberMatch\[1\]\) \|\| !isUUID\(teamMemberMatch\[2\]\).*team_not_found/s);
   assert.match(serverSource, /!isUUID\(teamVaultsMatch\[1\]\).*team_not_found/s);
+  assert.match(serverSource, /!isUUID\(teamVaultMatch\[1\]\) \|\| !isUUID\(teamVaultMatch\[2\]\).*team_not_found/s);
 });
 
 test("invitation outbox is pumped with one-process overlap protection", () => {

--- a/cloud/tests/team-postgres-integration.test.mjs
+++ b/cloud/tests/team-postgres-integration.test.mjs
@@ -4,9 +4,33 @@ import { fileURLToPath } from "node:url";
 import pg from "pg";
 import { applyMigrations } from "../src/migrations.mjs";
 import { PostgresStore } from "../src/postgres-store.mjs";
+import { teamVaultWrapperContextHash } from "../src/security.mjs";
 
 const databaseURL = process.env.TEST_DATABASE_URL;
 const migrationsDirectory = fileURLToPath(new URL("../migrations/", import.meta.url));
+const ownerDeviceID = "33cc880e-084a-4d9a-b1ea-f99d2ff86032";
+const viewerDeviceID = "aef6452c-1ad8-48bb-b4b5-ea9c207b707b";
+
+function integrationWrapper(membership, deviceID, marker, teamID, vaultID, keyGeneration) {
+  return {
+    membershipID: membership.id,
+    membershipEpoch: Number(membership.epoch),
+    deviceID,
+    wrapperVersion: 1,
+    ephemeralPublicKey: { kty: "EC", crv: "P-256", x: marker.repeat(43), y: "Z".repeat(43) },
+    ciphertext: marker.repeat(43),
+    nonce: marker.repeat(16),
+    authTag: marker.repeat(22),
+    contextHash: teamVaultWrapperContextHash({
+      teamID,
+      vaultID,
+      keyGeneration,
+      membershipID: membership.id,
+      membershipEpoch: Number(membership.epoch),
+      deviceID,
+    }),
+  };
+}
 
 test("real PostgreSQL serializes Team authorization, invitations and revocation", {
   skip: databaseURL ? false : "TEST_DATABASE_URL is not configured",
@@ -30,6 +54,18 @@ test("real PostgreSQL serializes Team authorization, invitations and revocation"
       name: "Operations",
       idempotencyKey: "integration:team-create-01",
     });
+    const publicKey = JSON.stringify({
+      kty: "EC", crv: "P-256", x: "A".repeat(43), y: "B".repeat(43), ext: true, key_ops: [],
+    });
+    await pool.query(
+      `INSERT INTO devices
+        (id, user_id, name, platform, public_key, public_key_algorithm,
+         key_registered_at, key_approved_at)
+       VALUES ($1, $2, 'Owner browser', 'web', $3, 'p256-ecdh-v1', now(), now()),
+              ($4, $5, 'Viewer browser', 'web', $3, 'p256-ecdh-v1', now(), now())`,
+      [ownerDeviceID, byEmail["owner@example.com"], publicKey,
+        viewerDeviceID, byEmail["viewer@example.com"]],
+    );
     const replayed = await store.createTeam({
       actorUserID: byEmail["owner@example.com"],
       name: "Different ignored replay body",
@@ -46,6 +82,26 @@ test("real PostgreSQL serializes Team authorization, invitations and revocation"
     });
     assert.equal(Number(shared.vault.revision), 0);
     assert.equal(Number(shared.vault.key_generation), 1);
+    const initial = await store.putSharedVault({
+      actorUserID: byEmail["owner@example.com"],
+      actorDeviceID: ownerDeviceID,
+      teamID: created.team.id,
+      vaultID: shared.vault.id,
+      envelope: {
+        baseRevision: 0,
+        keyGeneration: 1,
+        envelopeVersion: 1,
+        ciphertext: "AA",
+        nonce: "B".repeat(16),
+        authTag: "C".repeat(22),
+        contentHash: "D".repeat(43),
+        wrappers: [integrationWrapper(
+          created.membership, ownerDeviceID, "E", created.team.id, shared.vault.id, 1,
+        )],
+      },
+      idempotencyKey: "integration:vault-initialize-01",
+    });
+    assert.equal(initial.revision, 1);
 
     const adminTokenHash = "a".repeat(64);
     const adminInvite = await store.createTeamInvitation({
@@ -107,6 +163,41 @@ test("real PostgreSQL serializes Team authorization, invitations and revocation"
       tokenHash: viewerTokenHash,
       idempotencyKey: "integration:accept-viewer-01",
     });
+    const keyDevices = await store.listTeamKeyDevices(
+      created.team.id,
+      shared.vault.id,
+      byEmail["owner@example.com"],
+    );
+    assert.equal(keyDevices.length, 2);
+    await store.grantSharedVaultWrapper({
+      actorUserID: byEmail["owner@example.com"],
+      actorDeviceID: ownerDeviceID,
+      teamID: created.team.id,
+      vaultID: shared.vault.id,
+      wrapper: integrationWrapper(
+        viewer.membership, viewerDeviceID, "F", created.team.id, shared.vault.id, 1,
+      ),
+      keyGeneration: 1,
+      idempotencyKey: "integration:vault-wrapper-viewer-01",
+    });
+    const viewerVault = await store.getSharedVault(
+      created.team.id,
+      shared.vault.id,
+      byEmail["viewer@example.com"],
+      viewerDeviceID,
+    );
+    assert.equal(viewerVault.wrapper_ciphertext, "F".repeat(43));
+    await assert.rejects(store.putSharedVault({
+      actorUserID: byEmail["viewer@example.com"],
+      actorDeviceID: viewerDeviceID,
+      teamID: created.team.id,
+      vaultID: shared.vault.id,
+      envelope: {
+        baseRevision: 1, keyGeneration: 1, envelopeVersion: 1, ciphertext: "XX",
+        nonce: "B".repeat(16), authTag: "C".repeat(22), contentHash: "D".repeat(43), wrappers: null,
+      },
+      idempotencyKey: "integration:viewer-write-01",
+    }), /team_access_denied/);
     await assert.rejects(store.createSharedVault({
       actorUserID: byEmail["viewer@example.com"],
       teamID: created.team.id,
@@ -159,6 +250,71 @@ test("real PostgreSQL serializes Team authorization, invitations and revocation"
       status: "pending",
       removed_membership_id: accepted.membership.id,
     }]);
+    const rotated = await store.putSharedVault({
+      actorUserID: byEmail["owner@example.com"],
+      actorDeviceID: ownerDeviceID,
+      teamID: created.team.id,
+      vaultID: shared.vault.id,
+      envelope: {
+        baseRevision: 1,
+        keyGeneration: 2,
+        envelopeVersion: 1,
+        ciphertext: "RR",
+        nonce: "S".repeat(16),
+        authTag: "T".repeat(22),
+        contentHash: "U".repeat(43),
+        wrappers: [
+          integrationWrapper(
+            created.membership, ownerDeviceID, "V", created.team.id, shared.vault.id, 2,
+          ),
+          integrationWrapper(
+            viewer.membership, viewerDeviceID, "W", created.team.id, shared.vault.id, 2,
+          ),
+        ],
+      },
+      idempotencyKey: "integration:vault-rotate-01",
+    });
+    assert.deepEqual(rotated, {
+      conflict: false,
+      revision: 2,
+      keyGeneration: 2,
+      rotationCompleted: true,
+    });
+    const completed = await pool.query(
+      "SELECT rotation_required, key_generation FROM shared_vaults WHERE id = $1",
+      [shared.vault.id],
+    );
+    assert.deepEqual(completed.rows[0], { rotation_required: false, key_generation: "2" });
+    const stale = await store.putSharedVault({
+      actorUserID: byEmail["owner@example.com"],
+      actorDeviceID: ownerDeviceID,
+      teamID: created.team.id,
+      vaultID: shared.vault.id,
+      envelope: {
+        baseRevision: 1, keyGeneration: 2, envelopeVersion: 1, ciphertext: "SS",
+        nonce: "B".repeat(16), authTag: "C".repeat(22), contentHash: "D".repeat(43), wrappers: null,
+      },
+      idempotencyKey: "integration:vault-stale-01",
+    });
+    assert.deepEqual(stale, { conflict: true, revision: 2, keyGeneration: 2 });
+    assert.equal(await store.revokeDevice(byEmail["viewer@example.com"], viewerDeviceID), true);
+    await assert.rejects(
+      store.getSharedVault(
+        created.team.id,
+        shared.vault.id,
+        byEmail["viewer@example.com"],
+        viewerDeviceID,
+      ),
+      /team_not_found/,
+    );
+    const deviceRotation = await pool.query(
+      `SELECT vault.rotation_required, task.removed_device_id
+       FROM shared_vaults AS vault
+       JOIN shared_vault_rotation_tasks AS task ON task.vault_id = vault.id
+       WHERE vault.id = $1 AND task.removed_device_id = $2 AND task.status = 'pending'`,
+      [shared.vault.id, viewerDeviceID],
+    );
+    assert.deepEqual(deviceRotation.rows, [{ rotation_required: true, removed_device_id: viewerDeviceID }]);
     assert.equal(viewer.membership.role, "viewer");
     assert.equal(adminInvite.invitation.email, "admin@example.com");
   } finally {

--- a/cloud/tests/team-postgres-store.test.mjs
+++ b/cloud/tests/team-postgres-store.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { PostgresStore } from "../src/postgres-store.mjs";
+import { teamVaultWrapperContextHash } from "../src/security.mjs";
 
 function fixture(respond) {
   const queries = [];
@@ -24,6 +25,47 @@ function fixture(respond) {
 const actorUserID = "1f386e3d-d7b7-4365-a116-19f68e7f512d";
 const teamID = "84f6c860-0d26-4ef5-8652-27cb8b991b70";
 const membershipID = "7026d8a4-116a-4f61-9d8e-ff04e3a73360";
+const deviceID = "33cc880e-084a-4d9a-b1ea-f99d2ff86032";
+const vaultID = "bc01823b-1401-4058-9488-f4f6d1839b3b";
+
+function teamEnvelope({ baseRevision = 0, keyGeneration = 1, wrappers = [] } = {}) {
+  return {
+    baseRevision,
+    keyGeneration,
+    envelopeVersion: 1,
+    ciphertext: "AA",
+    nonce: "B".repeat(16),
+    authTag: "C".repeat(22),
+    contentHash: "D".repeat(43),
+    wrappers,
+  };
+}
+
+function teamWrapper(overrides = {}) {
+  const { keyGeneration = 1, ...wrapperOverrides } = overrides;
+  const wrapper = {
+    membershipID,
+    membershipEpoch: 1,
+    deviceID,
+    wrapperVersion: 1,
+    ephemeralPublicKey: { kty: "EC", crv: "P-256", x: "E".repeat(43), y: "F".repeat(43) },
+    ciphertext: "G".repeat(43),
+    nonce: "H".repeat(16),
+    authTag: "I".repeat(22),
+    ...wrapperOverrides,
+  };
+  return {
+    ...wrapper,
+    contextHash: teamVaultWrapperContextHash({
+      teamID,
+      vaultID,
+      keyGeneration,
+      membershipID: wrapper.membershipID,
+      membershipEpoch: wrapper.membershipEpoch,
+      deviceID: wrapper.deviceID,
+    }),
+  };
+}
 
 function mutationReservation(sql) {
   return sql.includes("INSERT INTO team_mutation_receipts") ? { rows: [{ actor_user_id: actorUserID }] } : null;
@@ -235,4 +277,207 @@ test("outbox claim uses multi-replica-safe SKIP LOCKED leasing", async () => {
   assert.match(f.queries[0].sql, /FOR UPDATE SKIP LOCKED/);
   assert.match(f.queries[0].sql, /claimed_at < now\(\) - interval '5 minutes'/);
   assert.deepEqual(f.queries[0].parameters, ["claim-owner"]);
+});
+
+test("initial shared ciphertext and the complete device wrapper set commit atomically", async () => {
+  const f = fixture((sql) => {
+    const reservation = mutationReservation(sql);
+    if (reservation) return reservation;
+    if (sql.includes("FOR UPDATE OF membership, team, vault, device")) {
+      return { rows: [{
+        membership_id: membershipID, role: "owner", epoch: 1, key_approved_at: new Date(),
+        revision: 0, key_generation: 1, rotation_required: false,
+      }] };
+    }
+    if (sql.includes("ORDER BY membership.id, device.id") && sql.includes("FOR UPDATE")) {
+      return { rows: [{ membership_id: membershipID, membership_epoch: 1, device_id: deviceID }] };
+    }
+    return { rows: [], rowCount: 1 };
+  });
+
+  assert.deepEqual(await f.store.putSharedVault({
+    actorUserID,
+    actorDeviceID: deviceID,
+    teamID,
+    vaultID,
+    envelope: teamEnvelope({ wrappers: [teamWrapper()] }),
+    idempotencyKey: "request:team-vault-init-01",
+  }), { conflict: false, revision: 1, keyGeneration: 1, rotationCompleted: false });
+  assert.ok(f.queries.some(({ sql }) => sql.includes("INSERT INTO shared_vault_key_wrappers")));
+  assert.ok(f.queries.some(({ sql }) => sql.includes("INSERT INTO shared_vault_revisions")));
+  assert.equal(f.queries.at(-2).sql, "COMMIT");
+});
+
+test("initial shared Vault write rejects a partial wrapper set before ciphertext is stored", async () => {
+  const secondDeviceID = "aef6452c-1ad8-48bb-b4b5-ea9c207b707b";
+  const f = fixture((sql) => {
+    const reservation = mutationReservation(sql);
+    if (reservation) return reservation;
+    if (sql.includes("FOR UPDATE OF membership, team, vault, device")) {
+      return { rows: [{
+        membership_id: membershipID, role: "owner", epoch: 1, key_approved_at: new Date(),
+        revision: 0, key_generation: 1, rotation_required: false,
+      }] };
+    }
+    if (sql.includes("ORDER BY membership.id, device.id") && sql.includes("FOR UPDATE")) {
+      return { rows: [
+        { membership_id: membershipID, membership_epoch: 1, device_id: deviceID },
+        { membership_id: membershipID, membership_epoch: 1, device_id: secondDeviceID },
+      ] };
+    }
+    return { rows: [], rowCount: 0 };
+  });
+
+  await assert.rejects(f.store.putSharedVault({
+    actorUserID,
+    actorDeviceID: deviceID,
+    teamID,
+    vaultID,
+    envelope: teamEnvelope({ wrappers: [teamWrapper()] }),
+    idempotencyKey: "request:team-vault-init-02",
+  }), /incomplete_team_vault_wrappers/);
+  assert.equal(f.queries.some(({ sql }) => sql.includes("INSERT INTO shared_vault_revisions")), false);
+  assert.equal(f.queries.at(-2).sql, "ROLLBACK");
+});
+
+test("a wrapper replayed under another authorization context is rejected", async () => {
+  const f = fixture((sql) => {
+    const reservation = mutationReservation(sql);
+    if (reservation) return reservation;
+    if (sql.includes("FOR UPDATE OF membership, team, vault, device")) {
+      return { rows: [{
+        membership_id: membershipID, role: "owner", epoch: 1, key_approved_at: new Date(),
+        revision: 0, key_generation: 1, rotation_required: false,
+      }] };
+    }
+    if (sql.includes("ORDER BY membership.id, device.id") && sql.includes("FOR UPDATE")) {
+      return { rows: [{ membership_id: membershipID, membership_epoch: 1, device_id: deviceID }] };
+    }
+    return { rows: [], rowCount: 0 };
+  });
+  await assert.rejects(f.store.putSharedVault({
+    actorUserID,
+    actorDeviceID: deviceID,
+    teamID,
+    vaultID,
+    envelope: teamEnvelope({
+      wrappers: [{ ...teamWrapper(), contextHash: "J".repeat(43) }],
+    }),
+    idempotencyKey: "request:team-vault-context-01",
+  }), /invalid_team_vault_wrapper_context/);
+  assert.equal(f.queries.some(({ sql }) => sql.includes("INSERT INTO shared_vault_key_wrappers")), false);
+});
+
+test("rotation advances the generation and completes pending work in one transaction", async () => {
+  const f = fixture((sql) => {
+    const reservation = mutationReservation(sql);
+    if (reservation) return reservation;
+    if (sql.includes("FOR UPDATE OF membership, team, vault, device")) {
+      return { rows: [{
+        membership_id: membershipID, role: "admin", epoch: 1, key_approved_at: new Date(),
+        revision: 4, key_generation: 2, rotation_required: true,
+      }] };
+    }
+    if (sql.includes("ORDER BY membership.id, device.id") && sql.includes("FOR UPDATE")) {
+      return { rows: [{ membership_id: membershipID, membership_epoch: 1, device_id: deviceID }] };
+    }
+    return { rows: [], rowCount: 1 };
+  });
+
+  assert.deepEqual(await f.store.putSharedVault({
+    actorUserID,
+    actorDeviceID: deviceID,
+    teamID,
+    vaultID,
+    envelope: teamEnvelope({
+      baseRevision: 4,
+      keyGeneration: 3,
+      wrappers: [teamWrapper({ keyGeneration: 3 })],
+    }),
+    idempotencyKey: "request:team-vault-rotate-01",
+  }), { conflict: false, revision: 5, keyGeneration: 3, rotationCompleted: true });
+  assert.ok(f.queries.some(({ sql }) => sql.includes("shared_vault_rotation_tasks SET status = 'completed'")));
+  assert.ok(f.queries.some(({ parameters }) => parameters.includes("team.vault_rotated")));
+});
+
+test("Viewer writes and unapproved-device reads fail before ciphertext access", async () => {
+  const write = fixture((sql) => {
+    const reservation = mutationReservation(sql);
+    if (reservation) return reservation;
+    if (sql.includes("FOR UPDATE OF membership, team, vault, device")) {
+      return { rows: [{
+        membership_id: membershipID, role: "viewer", epoch: 1, key_approved_at: new Date(),
+        revision: 1, key_generation: 1, rotation_required: false,
+      }] };
+    }
+    return { rows: [], rowCount: 0 };
+  });
+  await assert.rejects(write.store.putSharedVault({
+    actorUserID,
+    actorDeviceID: deviceID,
+    teamID,
+    vaultID,
+    envelope: teamEnvelope({ baseRevision: 1, wrappers: null }),
+    idempotencyKey: "request:team-vault-viewer-01",
+  }), /team_access_denied/);
+
+  const read = fixture((sql) => sql.includes("LEFT JOIN shared_vault_key_wrappers")
+    ? { rows: [{ id: vaultID, key_approved_at: null }] }
+    : { rows: [] });
+  await assert.rejects(
+    read.store.getSharedVault(teamID, vaultID, actorUserID, deviceID),
+    /device_approval_required/,
+  );
+});
+
+test("login cannot revive a revoked device or replace an approved device key", async () => {
+  const f = fixture((sql) => sql.includes("INSERT INTO devices") ? { rows: [] } : { rows: [], rowCount: 0 });
+  await assert.rejects(f.store.createSession({
+    userID: actorUserID,
+    device: {
+      id: deviceID,
+      name: "Browser",
+      platform: "web",
+      appVersion: "0.32.0",
+      publicKey: JSON.stringify({ kty: "EC", crv: "P-256", x: "A".repeat(43), y: "B".repeat(43) }),
+    },
+    sessionHash: "session-hash",
+    expiresAt: new Date("2030-01-01T00:00:00.000Z"),
+  }), /invalid_device/);
+  const upsert = f.queries.find(({ sql }) => sql.includes("INSERT INTO devices"));
+  assert.doesNotMatch(upsert.sql, /revoked_at\s*=\s*NULL/);
+  assert.match(upsert.sql, /devices\.public_key = EXCLUDED\.public_key/);
+  assert.equal(f.queries.some(({ sql }) => sql.includes("INSERT INTO sessions")), false);
+  assert.equal(f.queries.at(-2).sql, "ROLLBACK");
+});
+
+test("only an already-approved account device can approve another public key", async () => {
+  const targetDeviceID = "aef6452c-1ad8-48bb-b4b5-ea9c207b707b";
+  const publicKey = JSON.stringify({
+    kty: "EC", crv: "P-256", x: "A".repeat(43), y: "B".repeat(43), ext: true, key_ops: [],
+  });
+  const f = fixture((sql) => {
+    const reservation = mutationReservation(sql);
+    if (reservation) return reservation;
+    if (sql.includes("SELECT id FROM devices")) return { rows: [{ id: deviceID }] };
+    if (sql.includes("SELECT id, public_key FROM devices")) {
+      return { rows: [{ id: targetDeviceID, public_key: publicKey }] };
+    }
+    if (sql.includes("UPDATE devices SET key_approved_at")) {
+      return { rows: [{ id: targetDeviceID, key_approved_at: new Date() }] };
+    }
+    return { rows: [], rowCount: 1 };
+  });
+  assert.deepEqual(await f.store.approveDeviceKey({
+    actorUserID,
+    actorDeviceID: deviceID,
+    deviceID: targetDeviceID,
+    expectedPublicKey: publicKey,
+    idempotencyKey: "request:device-approve-01",
+  }), { approved: true, deviceID: targetDeviceID });
+  const actorLock = f.queries.find(({ sql }) => sql.includes("SELECT id FROM devices"));
+  assert.match(actorLock.sql, /key_approved_at IS NOT NULL/);
+  assert.match(actorLock.sql, /public_key_algorithm = 'p256-ecdh-v1'/);
+  assert.ok(f.queries.some(({ sql }) => sql.includes("SELECT id, public_key FROM devices") && sql.includes("FOR UPDATE")));
+  assert.equal(f.queries.at(-2).sql, "COMMIT");
 });

--- a/cloud/tests/team-service.test.mjs
+++ b/cloud/tests/team-service.test.mjs
@@ -4,9 +4,11 @@ import { CloudService } from "../src/service.mjs";
 
 const teamID = "84f6c860-0d26-4ef5-8652-27cb8b991b70";
 const membershipID = "7026d8a4-116a-4f61-9d8e-ff04e3a73360";
+const deviceID = "33cc880e-084a-4d9a-b1ea-f99d2ff86032";
+const vaultID = "bc01823b-1401-4058-9488-f4f6d1839b3b";
 const session = {
   user_id: "user-1",
-  device_id: "device-1",
+  device_id: deviceID,
   email: "owner@example.com",
 };
 const config = {
@@ -117,6 +119,58 @@ class TeamStore {
       key_generation: 1,
       rotation_required: false,
     } };
+  }
+
+  async approveDeviceKey(input) {
+    this.calls.push(["approveDeviceKey", input]);
+    return { approved: true, deviceID: input.deviceID };
+  }
+
+  async listTeamKeyDevices(team, vault, actor) {
+    this.calls.push(["listTeamKeyDevices", team, vault, actor]);
+    return [{
+      membership_id: membershipID,
+      membership_epoch: 1,
+      device_id: deviceID,
+      public_key_algorithm: "p256-ecdh-v1",
+      public_key: JSON.stringify({ kty: "EC", crv: "P-256", x: "A".repeat(43), y: "B".repeat(43) }),
+    }];
+  }
+
+  async getSharedVault(team, vault, actor, device) {
+    this.calls.push(["getSharedVault", team, vault, actor, device]);
+    return {
+      id: vaultID,
+      team_id: teamID,
+      name: "Production",
+      revision: 1,
+      key_generation: 1,
+      rotation_required: false,
+      envelope_version: 1,
+      ciphertext: "AA",
+      nonce: "B".repeat(16),
+      auth_tag: "C".repeat(22),
+      content_hash: "D".repeat(43),
+      membership_id: membershipID,
+      membership_epoch: 1,
+      device_id: deviceID,
+      wrapper_version: 1,
+      ephemeral_public_key: { kty: "EC", crv: "P-256", x: "E".repeat(43), y: "F".repeat(43) },
+      wrapper_ciphertext: "G".repeat(43),
+      wrapper_nonce: "H".repeat(16),
+      wrapper_auth_tag: "I".repeat(22),
+      context_hash: "J".repeat(43),
+    };
+  }
+
+  async putSharedVault(input) {
+    this.calls.push(["putSharedVault", input]);
+    return { conflict: false, revision: 1, keyGeneration: 1, rotationCompleted: false };
+  }
+
+  async grantSharedVaultWrapper(input) {
+    this.calls.push(["grantSharedVaultWrapper", input]);
+    return { granted: true, keyGeneration: input.keyGeneration, deviceID: input.wrapper.deviceID };
   }
 }
 
@@ -236,4 +290,62 @@ test("member and shared-Vault operations preserve explicit Team scope", async ()
   for (const [, value] of store.calls) {
     if (value && typeof value === "object" && "actorUserID" in value) assert.equal(value.actorUserID, "user-1");
   }
+});
+
+test("Team ciphertext service binds session device, generation and wrapper context", async () => {
+  const store = new TeamStore();
+  const service = new CloudService(store, config);
+  const wrapper = {
+    membershipID,
+    membershipEpoch: 1,
+    deviceID,
+    wrapperVersion: 1,
+    ephemeralPublicKey: { kty: "EC", crv: "P-256", x: "E".repeat(43), y: "F".repeat(43) },
+    ciphertext: "G".repeat(43),
+    nonce: "H".repeat(16),
+    authTag: "I".repeat(22),
+    contextHash: "J".repeat(43),
+  };
+  const envelope = {
+    baseRevision: 0,
+    keyGeneration: 1,
+    envelopeVersion: 1,
+    ciphertext: "AA",
+    nonce: "B".repeat(16),
+    authTag: "C".repeat(22),
+    contentHash: "D".repeat(43),
+    wrappers: [wrapper],
+  };
+
+  const devicePublicKey = { kty: "EC", crv: "P-256", x: "A".repeat(43), y: "B".repeat(43) };
+  await service.approveDeviceKey(
+    session,
+    deviceID,
+    { publicKey: devicePublicKey },
+    "request:device-approve-01",
+  );
+  const devices = await service.listTeamKeyDevices(session, teamID, vaultID);
+  const vault = await service.getSharedVault(session, teamID, vaultID);
+  await service.putSharedVault(session, teamID, vaultID, envelope, "request:team-vault-put-01");
+  await service.grantSharedVaultWrapper(
+    session,
+    teamID,
+    vaultID,
+    { keyGeneration: 1, wrapper },
+    "request:team-wrapper-grant-01",
+  );
+
+  assert.equal(devices.devices[0].publicKey.crv, "P-256");
+  assert.equal(vault.wrapper.membershipEpoch, 1);
+  for (const call of store.calls.filter(([name]) => [
+    "approveDeviceKey", "putSharedVault", "grantSharedVaultWrapper",
+  ].includes(name))) {
+    assert.equal(call[1].actorUserID, "user-1");
+    assert.equal(call[1].actorDeviceID, deviceID);
+  }
+  assert.deepEqual(JSON.parse(store.calls.find(([name]) => name === "approveDeviceKey")[1].expectedPublicKey), {
+    ...devicePublicKey,
+    ext: true,
+    key_ops: [],
+  });
 });

--- a/docs/cloud-v0.32-architecture.md
+++ b/docs/cloud-v0.32-architecture.md
@@ -8,9 +8,10 @@ fully usable without an account. The current cumulative implementation includes
 account/device APIs, opaque personal-Vault storage, browser-local encryption and
 manual authenticated personal-Vault synchronization. The Team backend now has
 durable Team, membership, invitation, role, audit, idempotency and shared-Vault
-metadata structures plus explicitly scoped authenticated routes. Shared
-ciphertext, device-bound wrappers, key rotation completion and browser/macOS
-Team clients remain required later milestones within the final 0.32 scope.
+metadata structures, shared ciphertext revisions, approved P-256 devices,
+device-bound wrappers and fail-closed rotation completion plus explicitly
+scoped authenticated routes. Browser/macOS Team cryptography and clients remain
+required later milestones within the final 0.32 scope.
 FIDO2 remains outside the initial 0.32 release scope.
 
 The first production deployment targets:
@@ -158,13 +159,13 @@ conditional upload succeeds.
 The Cloud payload is separate from `.srbackup`. Backup archives remain manual,
 portable rollback artifacts; Cloud revisions are small synchronization units.
 
-Shared Vaults use independent random Vault keys. The final design must wrap a
-shared key separately for authorized members/devices, enforce roles in both
-the API and clients, and rotate the key (or use an equivalently reviewed
-revocation design) when access is removed. Team lifecycle, invitation,
-membership and shared-Vault metadata endpoints now implement the non-plaintext
-authorization foundation. Ciphertext and wrapper writes remain absent until
-the key-rotation contract can be enforced as one complete protocol.
+Shared Vaults use independent random Vault keys. Authorized clients wrap each
+key separately for approved member devices and rotate it when access is
+removed; the backend receives only ciphertext and context-bound wrappers,
+never the key. Team lifecycle, invitation, membership and shared-Vault metadata
+endpoints implement the non-plaintext authorization foundation. The API enforces
+optimistic revision/generation writes, approved-device wrappers and atomic
+complete-set rotation; the clients do not consume it yet.
 The browser sync client accepts an explicit Vault scope and currently permits
 only `{type: "personal", id: "self"}`. Team scopes fail before any network
 request until the browser Team client and shared-key protocol are implemented.
@@ -188,6 +189,7 @@ than overloading the personal route.
 | `POST` | `/v1/auth/logout` | Revoke the current session |
 | `GET` | `/v1/me` | Current account and device |
 | `GET` | `/v1/devices` | List account devices |
+| `POST` | `/v1/devices/{id}` | Approve a device key from an approved device |
 | `DELETE` | `/v1/devices/{id}` | Revoke a device and its sessions |
 | `GET` | `/v1/vault` | Download latest encrypted revision |
 | `PUT` | `/v1/vault` | Conditionally upload a revision |
@@ -201,6 +203,10 @@ than overloading the personal route.
 | `DELETE` | `/v1/teams/{teamID}/members/{membershipID}` | Revoke membership and require rotation |
 | `GET` | `/v1/teams/{teamID}/vaults` | List shared-Vault metadata |
 | `POST` | `/v1/teams/{teamID}/vaults` | Create shared-Vault metadata |
+| `GET` | `/v1/teams/{teamID}/vaults/{vaultID}/key-devices` | List active approved wrapping targets |
+| `GET` | `/v1/teams/{teamID}/vaults/{vaultID}` | Download ciphertext and current-device wrapper |
+| `PUT` | `/v1/teams/{teamID}/vaults/{vaultID}` | Conditionally write/rotate shared ciphertext |
+| `POST` | `/v1/teams/{teamID}/vaults/{vaultID}/wrappers` | Grant one current-generation device wrapper |
 
 Every Team mutation requires an `Idempotency-Key`. Role and membership state
 is locked and checked in the same PostgreSQL transaction as the mutation.

--- a/docs/cloud-v0.32-team-threat-model.md
+++ b/docs/cloud-v0.32-team-threat-model.md
@@ -1,10 +1,11 @@
 # Cloud 0.32 Team and shared Vault threat model
 
-Status: design contract with the backend Team-access foundation implemented.
+Status: design contract with the backend Team-access and ciphertext protocol implemented.
 Durable Teams, memberships, four-role checks, membership epochs, hash-only
 invitations, encrypted outbox delivery, audit events, idempotency receipts and
-shared-Vault metadata are present. Shared ciphertext, device approval/wrappers,
-rotation completion and browser/macOS Team clients are not yet implemented.
+shared-Vault metadata, shared ciphertext revisions, approved P-256 devices,
+per-device wrappers and atomic rotation completion are present. Browser/macOS
+Team cryptography and UI are not yet implemented.
 
 ## Security outcome
 
@@ -100,8 +101,10 @@ fixtures must lock the exact encoding and algorithms:
 - P-256 ECDH;
 - HKDF-SHA-256;
 - AES-256-GCM key wrapping;
-- canonical context containing protocol version, Team ID, Vault ID, key
-  generation, member ID and device ID.
+- canonical UTF-8 context joined with NUL separators: protocol label
+  `selective-remote/team-vault-wrapper/v1`, Team ID, Vault ID, decimal key
+  generation, membership ID, decimal membership epoch and device ID. The API
+  verifies its base64url SHA-256 hash before storing a wrapper.
 
 For every shared Vault generation, an authorized client creates one random
 256-bit Vault key, encrypts the normalized Vault document locally, and creates
@@ -189,6 +192,7 @@ or wrappers.
 - Server/database inspection proving no personal or shared plaintext/key is
   present.
 
-Team/shared Vault release status remains `planned_required`: the access
-foundation is only the first implementation slice, and the full contract plus
-browser/macOS acceptance suite must pass before Cloud 0.32 is complete.
+Team/shared Vault release status remains `planned_required`: the server-side
+access and ciphertext protocol is implemented, but interoperable browser/macOS
+cryptography, Team UI and the complete acceptance suite must pass before Cloud
+0.32 is complete.


### PR DESCRIPTION
## Summary

- persist opaque shared-Vault revisions and per-device P-256 wrapper envelopes
- require approval from an already-approved device before a new login device can receive Team keys
- enforce Owner/Admin key management, Editor writes and Viewer read-only access transactionally
- freeze writes on member or approved-device revocation, then atomically require the next generation and a complete active-device wrapper set
- verify a canonical Team/Vault/generation/membership-epoch/device context hash to reject cross-scope wrapper replay
- extend the real PostgreSQL 16 integration path through initialize, grant, revoke, rotate, stale-write and device-revocation cases

## Local verification

- Cloud tests: 190 passed, 1 PostgreSQL-only test skipped locally
- focused Team/security tests: passed
- `npm audit --omit=dev`: 0 vulnerabilities
- Node syntax and `git diff --check`: passed
- exact local/remote tree: `0d493e9516c3c8c6ccb9a032b9dd301e164fa149`

## Boundaries

- server remains plaintext-blind; no Vault key or decrypted record is uploaded
- browser/macOS Team cryptography and UI are not part of this PR
- closed staging and registration are unchanged
- public `main` is unchanged pending separate exact-head approval