### PR TITLE
Cloud: add browser Team Vault UI and causal sync

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -10,9 +10,11 @@ single-use 48-hour invitations, encrypted durable invitation delivery and
 explicit Team/shared-Vault metadata endpoints. Shared ciphertext revisions,
 P-256 device registration/approval, per-device key wrappers and fail-closed
 rotation completion are implemented in the backend. The browser now has the
-interoperable cryptographic/client foundation: non-exportable P-256 identities,
-ECDH/HKDF/AES-GCM wrappers, scope-bound shared payload envelopes and strict Team
-API calls. Team UI and causal shared-record orchestration remain later layers.
+interoperable cryptographic/client layer: non-exportable P-256 identities,
+ECDH/HKDF/AES-GCM wrappers, scope-bound shared payload envelopes, strict Team
+API calls, Team/member/shared-Vault UI and causal shared-record synchronization.
+The remaining client milestones include explicit new-device approval and
+rotation-completion UI plus the macOS implementation.
 
 The browser portal can create and unlock a client-encrypted personal Vault,
 perform local CRUD, sign in with an existing verified account and manually
@@ -90,6 +92,14 @@ Shared payload AES-GCM AAD binds protocol, Team, Vault and key generation.
 Private device keys are non-exportable and stored as structured-cloned
 `CryptoKey` values in IndexedDB; simultaneous tabs converge through a
 create-if-absent transaction.
+
+The Team portal keeps its bearer session and decrypted shared-Vault keys only
+in page memory. It persists one strict ciphertext-only IndexedDB snapshot per
+Team/Vault scope, supports the four versioned record types and performs manual
+optimistic synchronization. Concurrent record or tombstone edits block upload
+until the user chooses every winner explicitly. Membership or device revocation
+freezes writes at `rotation_required`; the current browser UI fails closed and
+does not attempt an incomplete key rotation.
 
 ## Local verification
 

--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -1,5 +1,14 @@
 import { createIndexedDBVaultRepository, createLocalVaultController } from "./vault-local.js";
 import { createAuthenticatedVaultClient, synchronizeVault } from "./vault-sync.js";
+import {
+  createIndexedDBTeamDeviceRepository,
+  ensureTeamDeviceIdentity,
+} from "./team-vault-crypto.js";
+import {
+  createIndexedDBTeamVaultRepository,
+  createTeamVaultController,
+  synchronizeTeamVault,
+} from "./team-vault-sync.js";
 
 const verificationPrefix = "#verify-email?";
 const passwordResetPrefix = "#reset-password?";
@@ -306,6 +315,489 @@ export async function initializeLocalVault({
   };
 }
 
+export function initializeTeamWorkspace({
+  documentValue = document,
+  client,
+  confirmValue = (message) => globalThis.confirm(message),
+} = {}) {
+  const section = documentValue.querySelector("#team-vault");
+  if (!section || !client) return null;
+  const message = documentValue.querySelector("#team-vault-message");
+  const createTeamForm = documentValue.querySelector("#team-create-form");
+  const acceptInvitationForm = documentValue.querySelector("#team-invitation-accept-form");
+  const teamSelect = documentValue.querySelector("#team-select");
+  const teamRefresh = documentValue.querySelector("#team-refresh");
+  const selectedPanel = documentValue.querySelector("#team-selected");
+  const teamRole = documentValue.querySelector("#team-role");
+  const members = documentValue.querySelector("#team-members");
+  const inviteForm = documentValue.querySelector("#team-invite-form");
+  const createVaultForm = documentValue.querySelector("#team-vault-create-form");
+  const vaultSelect = documentValue.querySelector("#team-vault-select");
+  const vaultOpen = documentValue.querySelector("#team-vault-open");
+  const workspace = documentValue.querySelector("#team-vault-workspace");
+  const workspaceTitle = documentValue.querySelector("#team-vault-workspace-title");
+  const workspaceStatus = documentValue.querySelector("#team-vault-workspace-status");
+  const syncButton = documentValue.querySelector("#team-vault-sync");
+  const lockButton = documentValue.querySelector("#team-vault-lock");
+  const recordForm = documentValue.querySelector("#team-vault-record-form");
+  const recordType = documentValue.querySelector("#team-record-type");
+  const recordTitle = documentValue.querySelector("#team-record-title");
+  const recordTarget = documentValue.querySelector("#team-record-target");
+  const recordSecret = documentValue.querySelector("#team-record-secret");
+  const recordTargetLabel = documentValue.querySelector("#team-record-target-label");
+  const recordSecretLabel = documentValue.querySelector("#team-record-secret-label");
+  const records = documentValue.querySelector("#team-vault-records");
+  const conflictPanel = documentValue.querySelector("#team-vault-conflicts");
+  const conflictForm = documentValue.querySelector("#team-vault-conflicts-form");
+  const conflictList = documentValue.querySelector("#team-vault-conflicts-list");
+  const conflictApply = documentValue.querySelector("#team-vault-conflicts-apply");
+  let identity = null;
+  let teams = [];
+  let vaults = [];
+  let selectedTeam = null;
+  let selectedVault = null;
+  let controller = null;
+  let activeConflicts = null;
+
+  function canManage() {
+    return ["owner", "admin"].includes(selectedTeam?.role);
+  }
+
+  function canEdit() {
+    return ["owner", "admin", "editor"].includes(selectedTeam?.role);
+  }
+
+  function setWorkspaceControls(disabled) {
+    for (const control of recordForm.querySelectorAll("input, select, textarea, button")) {
+      control.disabled = disabled || !canEdit();
+    }
+    for (const button of records.querySelectorAll("button")) button.disabled = disabled || !canEdit();
+  }
+
+  function clearConflicts() {
+    activeConflicts = null;
+    conflictPanel.hidden = true;
+    conflictForm.reset();
+    conflictList.replaceChildren();
+    conflictApply.disabled = true;
+    setWorkspaceControls(false);
+  }
+
+  function updateRecordLabels() {
+    const labels = {
+      host: ["Адрес", "Дополнительные данные не требуются"],
+      credential: ["Имя пользователя", "Секрет"],
+      snippet: ["Не используется", "Текст Snippet"],
+      forwarding: ["Назначение", "Параметры"],
+    };
+    const [targetText, secretText] = labels[recordType.value] ?? labels.host;
+    setText(recordTargetLabel, targetText);
+    setText(recordSecretLabel, secretText);
+    recordTarget.required = recordType.value !== "snippet";
+    recordSecret.required = ["credential", "snippet"].includes(recordType.value);
+  }
+
+  function renderRecords() {
+    records.replaceChildren();
+    if (!controller) return;
+    const current = controller.document();
+    if (current.records.length === 0) {
+      const empty = documentValue.createElement("p");
+      empty.className = "vault-empty";
+      empty.textContent = "Shared Vault пока пуст.";
+      records.append(empty);
+      return;
+    }
+    for (const record of current.records) {
+      const card = documentValue.createElement("article");
+      const heading = documentValue.createElement("h4");
+      const summary = documentValue.createElement("p");
+      const metadata = documentValue.createElement("small");
+      const remove = documentValue.createElement("button");
+      heading.textContent = String(record.data.title ?? "Без названия");
+      summary.textContent = localVaultRecordSummary(record);
+      metadata.textContent = `${record.type} · ${record.modifiedAt}`;
+      remove.type = "button";
+      remove.className = "danger";
+      remove.textContent = "Удалить";
+      remove.disabled = !canEdit();
+      remove.addEventListener("click", async () => {
+        remove.disabled = true;
+        try {
+          await controller.delete(record.id);
+          clearConflicts();
+          renderRecords();
+          setText(workspaceStatus, "Удаление зашифровано локально. Выполните синхронизацию.");
+        } catch {
+          setText(workspaceStatus, "Не удалось сохранить удаление.");
+          remove.disabled = !canEdit();
+        }
+      });
+      card.append(heading, summary, metadata, remove);
+      records.append(card);
+    }
+  }
+
+  function renderConflicts(result) {
+    activeConflicts = { revision: result.revision, ids: result.conflicts.map((conflict) => conflict.id) };
+    conflictForm.reset();
+    conflictList.replaceChildren();
+    result.conflicts.forEach((conflict, index) => {
+      const fieldset = documentValue.createElement("fieldset");
+      const legend = documentValue.createElement("legend");
+      legend.textContent = `Конфликт ${index + 1}`;
+      fieldset.append(legend);
+      for (const [choice, prefix] of [["local", "Оставить локальную"], ["remote", "Принять Team-версию"]]) {
+        const label = documentValue.createElement("label");
+        const input = documentValue.createElement("input");
+        input.type = "radio";
+        input.name = `team-conflict-${index}`;
+        input.value = choice;
+        input.required = true;
+        label.append(input, ` ${prefix}: ${localVaultConflictSideSummary(conflict[choice])}`);
+        fieldset.append(label);
+      }
+      conflictList.append(fieldset);
+    });
+    conflictApply.disabled = true;
+    setWorkspaceControls(true);
+    conflictPanel.hidden = false;
+  }
+
+  function renderMembers(values) {
+    members.replaceChildren();
+    for (const member of values) {
+      const card = documentValue.createElement("article");
+      const name = documentValue.createElement("strong");
+      const detail = documentValue.createElement("small");
+      const role = documentValue.createElement("select");
+      const save = documentValue.createElement("button");
+      const revoke = documentValue.createElement("button");
+      name.textContent = member.displayName || member.email;
+      detail.textContent = `${member.email} · epoch ${member.epoch}`;
+      const editableByActor = selectedTeam.role === "owner"
+        || (selectedTeam.role === "admin" && ["editor", "viewer"].includes(member.role));
+      const self = member.id === selectedTeam.membershipID;
+      for (const value of ["owner", "admin", "editor", "viewer"]) {
+        const option = documentValue.createElement("option");
+        option.value = value;
+        option.textContent = value;
+        option.selected = member.role === value;
+        option.disabled = selectedTeam.role !== "owner" && !["editor", "viewer"].includes(value);
+        role.append(option);
+      }
+      role.disabled = !editableByActor || self;
+      save.type = "button";
+      save.textContent = "Изменить роль";
+      save.disabled = !editableByActor || self;
+      save.addEventListener("click", async () => {
+        save.disabled = true;
+        try {
+          await client.updateTeamMemberRole({ teamID: selectedTeam.id, membershipID: member.id, role: role.value });
+          await loadSelectedTeam();
+          setText(message, "Роль участника обновлена.");
+        } catch {
+          setText(message, "Роль не изменена: проверьте полномочия и правило последнего Owner.");
+          save.disabled = !editableByActor || self;
+        }
+      });
+      revoke.type = "button";
+      revoke.className = "danger";
+      revoke.textContent = "Отозвать доступ";
+      revoke.disabled = !editableByActor || self;
+      revoke.addEventListener("click", async () => {
+        if (!confirmValue(`Отозвать доступ для ${member.email}? Все Shared Vaults будут заморожены до ротации ключей.`)) return;
+        revoke.disabled = true;
+        try {
+          const result = await client.revokeTeamMember({ teamID: selectedTeam.id, membershipID: member.id });
+          await loadSelectedTeam();
+          lockCurrentVault();
+          setText(message, `Доступ отозван. Vaults для обязательной ротации: ${result.rotationRequiredVaults}.`);
+        } catch {
+          setText(message, "Доступ не отозван: проверьте полномочия и правило последнего Owner.");
+          revoke.disabled = !editableByActor || self;
+        }
+      });
+      card.append(name, detail, role, save, revoke);
+      members.append(card);
+    }
+  }
+
+  function populateVaults() {
+    vaultSelect.replaceChildren();
+    for (const vault of vaults) {
+      const option = documentValue.createElement("option");
+      option.value = vault.id;
+      option.textContent = `${vault.name}${vault.rotationRequired ? " · требуется ротация" : ""}`;
+      vaultSelect.append(option);
+    }
+    vaultOpen.disabled = vaults.length === 0;
+  }
+
+  function lockCurrentVault() {
+    controller?.lock();
+    controller = null;
+    selectedVault = null;
+    workspace.hidden = true;
+    records.replaceChildren();
+    clearConflicts();
+  }
+
+  async function openSelectedVault() {
+    const vault = vaults.find((value) => value.id === vaultSelect.value);
+    if (!vault || !identity) return;
+    lockCurrentVault();
+    selectedVault = vault;
+    const scope = { type: "team", teamID: selectedTeam.id, vaultID: vault.id };
+    controller = createTeamVaultController({
+      repository: createIndexedDBTeamVaultRepository(scope),
+      identity,
+      scope,
+    });
+    workspace.hidden = false;
+    workspaceTitle.textContent = `${selectedTeam.name} / ${vault.name}`;
+    setText(workspaceStatus, "Загружаем зашифрованную Team-ревизию…");
+    syncButton.disabled = true;
+    try {
+      const result = await synchronizeTeamVault({ client, controller, role: selectedTeam.role });
+      renderRecords();
+      setWorkspaceControls(false);
+      syncButton.disabled = false;
+      setText(workspaceStatus, {
+        initialized: `Shared Vault создан и зашифрован для всех одобренных устройств · ревизия ${result.revision}.`,
+        downloaded: `Team-ревизия ${result.revision} расшифрована локально.`,
+        up_to_date: `Shared Vault синхронизирован · ревизия ${result.revision}.`,
+      }[result.status] ?? "Shared Vault открыт.");
+    } catch (error) {
+      const code = String(error?.message ?? "");
+      setWorkspaceControls(true);
+      setText(workspaceStatus, code === "team_vault_rotation_required"
+        ? "Запись заморожена: после отзыва участника или устройства требуется полная ротация ключа."
+        : code === "team_vault_key_unavailable"
+          ? "Для этого устройства нет wrapper ключа. Требуется одобрение существующим устройством."
+          : "Shared Vault не открыт; локальные данные не изменены.");
+    }
+  }
+
+  async function loadSelectedTeam() {
+    selectedTeam = teams.find((team) => team.id === teamSelect.value) ?? null;
+    lockCurrentVault();
+    if (!selectedTeam) {
+      selectedPanel.hidden = true;
+      return;
+    }
+    selectedPanel.hidden = false;
+    teamRole.textContent = `${selectedTeam.name} · ${selectedTeam.role}`;
+    inviteForm.hidden = !canManage();
+    createVaultForm.hidden = !canManage();
+    const [teamMembers, sharedVaults] = await Promise.all([
+      client.listTeamMembers(selectedTeam.id),
+      client.listSharedVaults(selectedTeam.id),
+    ]);
+    renderMembers(teamMembers);
+    vaults = sharedVaults;
+    populateVaults();
+  }
+
+  async function loadTeams(preferredID = null) {
+    teams = await client.listTeams();
+    teamSelect.replaceChildren();
+    for (const team of teams) {
+      const option = documentValue.createElement("option");
+      option.value = team.id;
+      option.textContent = `${team.name} · ${team.role}`;
+      teamSelect.append(option);
+    }
+    if (preferredID && teams.some((team) => team.id === preferredID)) teamSelect.value = preferredID;
+    if (teams.length > 0) await loadSelectedTeam();
+    else {
+      selectedTeam = null;
+      selectedPanel.hidden = true;
+      setText(message, "Команд пока нет. Создайте Team или примите приглашение.");
+    }
+  }
+
+  createTeamForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const button = createTeamForm.querySelector("button");
+    button.disabled = true;
+    try {
+      const team = await client.createTeam({ name: createTeamForm.elements.name.value });
+      createTeamForm.reset();
+      await loadTeams(team.id);
+      setText(message, "Team создан. Вы назначены Owner.");
+    } catch {
+      setText(message, "Team не создан. Проверьте название и повторите попытку.");
+    } finally {
+      button.disabled = false;
+    }
+  });
+
+  acceptInvitationForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const button = acceptInvitationForm.querySelector("button");
+    button.disabled = true;
+    try {
+      await client.acceptTeamInvitation({ token: acceptInvitationForm.elements.token.value });
+      acceptInvitationForm.reset();
+      await loadTeams();
+      setText(message, "Приглашение принято.");
+    } catch {
+      acceptInvitationForm.elements.token.value = "";
+      setText(message, "Приглашение недействительно, истекло или предназначено другому email.");
+    } finally {
+      button.disabled = false;
+    }
+  });
+
+  inviteForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const button = inviteForm.querySelector("button");
+    button.disabled = true;
+    try {
+      await client.inviteTeamMember({
+        teamID: selectedTeam.id,
+        email: inviteForm.elements.email.value,
+        role: inviteForm.elements.role.value,
+      });
+      inviteForm.reset();
+      setText(message, "Приглашение поставлено в защищённую очередь доставки на 48 часов.");
+    } catch {
+      setText(message, "Приглашение не создано. Проверьте SMTP, роль и полномочия.");
+    } finally {
+      button.disabled = false;
+    }
+  });
+
+  createVaultForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const button = createVaultForm.querySelector("button");
+    button.disabled = true;
+    try {
+      const vault = await client.createSharedVault({ teamID: selectedTeam.id, name: createVaultForm.elements.name.value });
+      createVaultForm.reset();
+      await loadSelectedTeam();
+      vaultSelect.value = vault.id;
+      await openSelectedVault();
+      setText(message, "Shared Vault создан. Состояние криптографической инициализации показано ниже.");
+    } catch {
+      setText(message, "Shared Vault не создан или не инициализирован. Проверьте роль и одобрение устройства.");
+    } finally {
+      button.disabled = false;
+    }
+  });
+
+  teamSelect.addEventListener("change", () => loadSelectedTeam().catch(() => setText(message, "Не удалось загрузить Team.")));
+  teamRefresh.addEventListener("click", () => loadTeams(selectedTeam?.id).catch(() => setText(message, "Не удалось обновить Teams.")));
+  vaultOpen.addEventListener("click", () => openSelectedVault());
+  recordType.addEventListener("change", updateRecordLabels);
+  recordForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const button = recordForm.querySelector("button");
+    button.disabled = true;
+    try {
+      await controller.upsert({
+        type: recordType.value,
+        data: localVaultRecordData(recordType.value, {
+          title: recordTitle.value,
+          target: recordTarget.value,
+          secret: recordSecret.value,
+        }),
+      });
+      recordForm.reset();
+      updateRecordLabels();
+      clearConflicts();
+      renderRecords();
+      setText(workspaceStatus, "Изменение зашифровано локально. Выполните синхронизацию.");
+    } catch {
+      setText(workspaceStatus, "Запись не сохранена. Проверьте поля и роль.");
+    } finally {
+      button.disabled = !canEdit();
+    }
+  });
+
+  syncButton.addEventListener("click", async () => {
+    syncButton.disabled = true;
+    try {
+      const result = await synchronizeTeamVault({ client, controller, role: selectedTeam.role });
+      if (result.status === "conflict") renderConflicts(result);
+      else {
+        clearConflicts();
+        renderRecords();
+      }
+      const messages = {
+        initialized: `Shared Vault инициализирован · ревизия ${result.revision}.`,
+        uploaded: `Зашифрованная Team-ревизия ${result.revision} загружена.`,
+        uploaded_with_new_local_changes: `Ревизия ${result.revision} загружена; остались новые локальные изменения.`,
+        downloaded: `Team-ревизия ${result.revision} загружена и объединена локально.`,
+        up_to_date: `Shared Vault синхронизирован · ревизия ${result.revision}.`,
+        remote_changed: `Team Vault изменился до ревизии ${result.remoteRevision}. Повторите синхронизацию.`,
+        conflict: `Обнаружено конфликтов: ${result.conflicts.length}. Выберите версии явно.`,
+      };
+      setText(workspaceStatus, messages[result.status] ?? "Синхронизация завершена.");
+    } catch (error) {
+      setText(workspaceStatus, String(error?.message ?? "") === "team_vault_rotation_required"
+        ? "Синхронизация заморожена до безопасной ротации ключа."
+        : "Синхронизация не выполнена; локальная зашифрованная копия сохранена.");
+    } finally {
+      syncButton.disabled = !controller;
+    }
+  });
+
+  lockButton.addEventListener("click", () => {
+    controller?.lock();
+    records.replaceChildren();
+    clearConflicts();
+    setWorkspaceControls(true);
+    setText(workspaceStatus, "Ключ Shared Vault удалён из памяти. Нажмите синхронизацию для повторного локального unlock.");
+  });
+
+  conflictForm.addEventListener("change", () => {
+    conflictApply.disabled = !activeConflicts || activeConflicts.ids.some((_id, index) => (
+      !conflictForm.querySelector(`input[name="team-conflict-${index}"]:checked`)
+    ));
+  });
+  conflictForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    if (!activeConflicts) return;
+    try {
+      await controller.resolveConflicts({
+        revision: activeConflicts.revision,
+        resolutions: activeConflicts.ids.map((id, index) => ({
+          id,
+          choice: conflictForm.querySelector(`input[name="team-conflict-${index}"]:checked`)?.value,
+        })),
+      });
+      clearConflicts();
+      renderRecords();
+      setText(workspaceStatus, "Конфликты разрешены локально. Синхронизируйте условную запись.");
+    } catch {
+      clearConflicts();
+      setText(workspaceStatus, "Набор конфликтов устарел. Запустите синхронизацию ещё раз.");
+    }
+  });
+
+  updateRecordLabels();
+  return {
+    async activate(nextIdentity) {
+      identity = nextIdentity;
+      section.hidden = false;
+      await loadTeams();
+    },
+    deactivate() {
+      identity = null;
+      teams = [];
+      vaults = [];
+      selectedTeam = null;
+      lockCurrentVault();
+      teamSelect.replaceChildren();
+      members.replaceChildren();
+      selectedPanel.hidden = true;
+      section.hidden = true;
+    },
+  };
+}
+
 export async function initializeCloudAccount({
   documentValue = document,
   vaultUI,
@@ -328,6 +820,8 @@ export async function initializeCloudAccount({
   const conflictList = documentValue.querySelector("#local-vault-conflicts-list");
   const conflictApply = documentValue.querySelector("#local-vault-conflicts-apply");
   const client = createAuthenticatedVaultClient({ fetchValue });
+  const teamWorkspace = initializeTeamWorkspace({ documentValue, client });
+  const teamDeviceRepository = createIndexedDBTeamDeviceRepository();
   let activeConflicts = null;
   vaultUI.setConflictResetListener(() => {
     activeConflicts = null;
@@ -388,14 +882,43 @@ export async function initializeCloudAccount({
     const button = form.querySelector("button");
     button.disabled = true;
     try {
+      const password = form.elements.password.value;
+      const deviceID = await vault.deviceID();
+      let identity = null;
+      try {
+        identity = await ensureTeamDeviceIdentity({ repository: teamDeviceRepository, deviceID });
+      } catch {
+        // Team keys are optional for personal-Vault login and fail independently.
+      }
       const user = await client.login({
         email: form.elements.email.value,
-        password: form.elements.password.value,
-        deviceID: await vault.deviceID(),
+        password,
+        deviceID,
+        publicKey: identity?.publicKey ?? null,
       });
+      if (identity) {
+        try {
+          await client.bootstrapDeviceKey({
+            password,
+            publicKey: identity.publicKey,
+            idempotencyKey: `web:device:bootstrap:${globalThis.crypto.randomUUID()}`,
+          });
+        } catch {
+          // Existing accounts with an approved device must use device-to-device approval.
+        }
+      }
       form.elements.password.value = "";
       showSession(user);
-      setText(message, "Вход выполнен. Сессионный токен хранится только в памяти этой вкладки.");
+      if (!identity) {
+        setText(message, "Вход выполнен. Team-ключ недоступен в этом браузере; личный Vault продолжает работать.");
+      } else {
+        try {
+          await teamWorkspace?.activate(identity);
+          setText(message, "Вход выполнен. Сессионный токен хранится только в памяти этой вкладки.");
+        } catch {
+          setText(message, "Вход выполнен. Team-раздел временно недоступен; личный Vault и сессия продолжают работать.");
+        }
+      }
     } catch {
       setText(message, "Не удалось войти. Проверьте email, пароль и подтверждение аккаунта.");
     } finally {
@@ -409,6 +932,7 @@ export async function initializeCloudAccount({
       await client.logout();
     } finally {
       showSession(null);
+      teamWorkspace?.deactivate();
       hideConflicts();
       await vaultUI.hideRecoveryAndRestoreMode();
       logoutButton.disabled = false;

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -157,6 +157,113 @@
       </div>
     </section>
 
+    <section class="team-vault" id="team-vault" aria-labelledby="team-vault-title" hidden>
+      <div class="vault-heading">
+        <div>
+          <p class="eyebrow">TEAM VAULTS · CLIENT-SIDE E2EE</p>
+          <h2 id="team-vault-title">Командные хранилища</h2>
+        </div>
+        <p id="team-vault-message" aria-live="polite">Загрузка Teams…</p>
+      </div>
+
+      <div class="team-onboarding">
+        <form id="team-create-form">
+          <h3>Создать Team</h3>
+          <label for="team-create-name">Название</label>
+          <input id="team-create-name" name="name" maxlength="120" required>
+          <button type="submit">Создать</button>
+        </form>
+        <form id="team-invitation-accept-form">
+          <h3>Принять приглашение</h3>
+          <label for="team-invitation-token">Токен приглашения</label>
+          <input id="team-invitation-token" name="token" type="password" minlength="32" maxlength="512" autocomplete="off" required>
+          <button type="submit">Принять</button>
+        </form>
+      </div>
+
+      <div class="team-picker">
+        <label for="team-select">Team</label>
+        <select id="team-select"></select>
+        <button type="button" class="secondary" id="team-refresh">Обновить</button>
+      </div>
+
+      <div id="team-selected" hidden>
+        <div class="team-summary">
+          <h3 id="team-role"></h3>
+          <p>Роли и ключи проверяются сервером независимо от зашифрованного содержимого.</p>
+        </div>
+        <div class="team-columns">
+          <div>
+            <h3>Участники</h3>
+            <div class="team-members" id="team-members"></div>
+            <form id="team-invite-form">
+              <h4>Пригласить на 48 часов</h4>
+              <label for="team-invite-email">Email</label>
+              <input id="team-invite-email" name="email" type="email" maxlength="254" required>
+              <label for="team-invite-role">Роль</label>
+              <select id="team-invite-role" name="role">
+                <option value="viewer">Viewer</option>
+                <option value="editor">Editor</option>
+                <option value="admin">Admin</option>
+              </select>
+              <button type="submit">Отправить приглашение</button>
+            </form>
+          </div>
+          <div>
+            <h3>Shared Vaults</h3>
+            <form id="team-vault-create-form">
+              <label for="team-vault-create-name">Название Vault</label>
+              <input id="team-vault-create-name" name="name" maxlength="120" required>
+              <button type="submit">Создать Vault</button>
+            </form>
+            <div class="team-picker compact">
+              <label for="team-vault-select">Vault</label>
+              <select id="team-vault-select"></select>
+              <button type="button" id="team-vault-open" disabled>Открыть</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="vault-workspace" id="team-vault-workspace" hidden>
+          <div class="vault-toolbar">
+            <div>
+              <h3 id="team-vault-workspace-title">Shared Vault</h3>
+              <p id="team-vault-workspace-status" aria-live="polite">Vault заблокирован.</p>
+            </div>
+            <div class="vault-actions">
+              <button type="button" id="team-vault-sync">Синхронизировать</button>
+              <button type="button" class="secondary" id="team-vault-lock">Заблокировать</button>
+            </div>
+          </div>
+          <form class="record-form" id="team-vault-record-form">
+            <label for="team-record-type">Тип записи</label>
+            <select id="team-record-type" name="type">
+              <option value="host">Host</option>
+              <option value="credential">Credential</option>
+              <option value="snippet">Snippet</option>
+              <option value="forwarding">Forwarding</option>
+            </select>
+            <label for="team-record-title">Название</label>
+            <input id="team-record-title" name="title" maxlength="120" required>
+            <label for="team-record-target" id="team-record-target-label">Адрес</label>
+            <input id="team-record-target" name="target" maxlength="2048">
+            <label for="team-record-secret" id="team-record-secret-label">Дополнительные данные не требуются</label>
+            <textarea id="team-record-secret" name="secret" maxlength="32768" rows="3"></textarea>
+            <button type="submit">Зашифровать локально</button>
+          </form>
+          <div class="vault-records" id="team-vault-records"></div>
+          <section class="vault-conflicts" id="team-vault-conflicts" aria-labelledby="team-vault-conflicts-title" hidden>
+            <h3 id="team-vault-conflicts-title">Конфликт Team-ревизий</h3>
+            <p>Выберите одну версию каждой записи. Секреты и содержимое здесь не отображаются.</p>
+            <form id="team-vault-conflicts-form">
+              <div id="team-vault-conflicts-list"></div>
+              <button type="submit" id="team-vault-conflicts-apply" disabled>Сохранить выбранные версии</button>
+            </form>
+          </section>
+        </div>
+      </div>
+    </section>
+
     <section class="access">
       <div><p class="eyebrow">V0.32 FOUNDATION</p><h2>Портал готовится к первому входу</h2></div>
       <p>Регистрация будет открыта после завершения сброса пароля, ограничения запросов, защиты от злоупотреблений и ручной проверки безопасности.</p>

--- a/cloud/public/styles.css
+++ b/cloud/public/styles.css
@@ -29,6 +29,26 @@ body { margin:0; min-height:100vh; background:radial-gradient(circle at 70% 15%,
 .cloud-account button { justify-self:start; border:0; border-radius:10px; padding:12px 18px; background:var(--accent); color:#082016; font:inherit; font-weight:750; cursor:pointer; }
 .cloud-account button.secondary { background:transparent; border:1px solid var(--line); color:var(--ink); }.cloud-account button:disabled { opacity:.6; cursor:wait; }
 .local-vault { margin:50px 0; padding:34px; border:1px solid var(--line); border-radius:22px; background:#0c1714e8; }
+.team-vault { margin:50px 0; padding:34px; border:1px solid #75e0b45c; border-radius:22px; background:linear-gradient(145deg,#0c1714f2,#102019e8); }
+.team-onboarding,.team-columns { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:18px; margin-top:26px; }
+.team-onboarding form,.team-columns>div { padding:20px; border:1px solid var(--line); border-radius:14px; background:#08110e; }
+.team-onboarding form,.team-columns form { display:grid; gap:10px; }
+.team-onboarding h3,.team-columns h3,.team-columns h4 { margin:0 0 8px; }
+.team-vault label { color:var(--muted); font-size:13px; }
+.team-vault input,.team-vault select,.team-picker select { width:100%; border:1px solid var(--line); border-radius:10px; padding:12px 14px; background:#07100d; color:var(--ink); font:inherit; }
+.team-vault button,.team-picker button { border:0; border-radius:10px; padding:12px 18px; background:var(--accent); color:#082016; font:inherit; font-weight:750; cursor:pointer; }
+.team-vault button.secondary,.team-picker button.secondary { background:transparent; border:1px solid var(--line); color:var(--ink); }
+.team-vault button.danger { background:transparent; border:1px solid #ff8f7a66; color:#ffb4a6; }
+.team-vault button:disabled { opacity:.55; cursor:not-allowed; }
+.team-picker { display:grid; grid-template-columns:auto minmax(220px,1fr) auto; align-items:center; gap:12px; margin-top:24px; }
+.team-picker.compact { grid-template-columns:auto minmax(160px,1fr) auto; }
+.team-summary { display:flex; align-items:end; justify-content:space-between; gap:24px; margin-top:28px; padding-top:24px; border-top:1px solid var(--line); }
+.team-summary h3,.team-summary p { margin:0; }.team-summary p { color:var(--muted); max-width:580px; line-height:1.55; }
+.team-members { display:grid; gap:10px; margin-bottom:20px; }
+.team-members article { display:grid; grid-template-columns:minmax(0,1fr) auto auto; gap:8px 10px; align-items:center; padding:14px; border:1px solid var(--line); border-radius:12px; }
+.team-members strong,.team-members small { grid-column:1; overflow-wrap:anywhere; }.team-members small { color:var(--muted); }
+.team-members select { grid-column:2; grid-row:1 / span 2; min-width:110px; }
+.team-members button { padding:9px 11px; }.team-members button.danger { grid-column:3; }
 .vault-heading,.vault-toolbar { display:flex; align-items:flex-start; justify-content:space-between; gap:32px; }
 .vault-heading h2,.vault-toolbar h3 { margin:8px 0 0; }.vault-heading>p,.vault-toolbar p,.vault-panel>p { max-width:520px; color:var(--muted); line-height:1.55; margin:0; }
 .vault-panel,.vault-workspace { margin-top:28px; padding-top:28px; border-top:1px solid var(--line); }.vault-panel h3 { margin-top:0; }
@@ -52,5 +72,5 @@ body { margin:0; min-height:100vh; background:radial-gradient(circle at 70% 15%,
 .vault-conflicts button:disabled { opacity:.6; cursor:not-allowed; }
 .access { display:flex; justify-content:space-between; gap:40px; align-items:end; padding:34px; border:1px solid var(--line); border-radius:18px; background:#0c1714cc; }.access h2 { margin:8px 0 0; }.access>p { max-width:500px; margin:0; }
 @keyframes spin { to { transform:rotate(360deg); } }
-@media (max-width:760px) { .shell{width:min(100% - 24px,1180px);padding-top:18px}.hero{grid-template-columns:1fr;padding:64px 0;gap:30px}.vault-visual{width:230px}.grid,.cloud-account{grid-template-columns:1fr}.vault-heading,.vault-toolbar,.access{align-items:start;flex-direction:column}.vault-actions{justify-content:flex-start}.vault-panel form,.record-form{grid-template-columns:1fr}.vault-panel button,.record-form button{grid-column:1}.vault-records{grid-template-columns:1fr}.status{font-size:0}.status::after{content:"●";font-size:16px} }
+@media (max-width:760px) { .shell{width:min(100% - 24px,1180px);padding-top:18px}.hero{grid-template-columns:1fr;padding:64px 0;gap:30px}.vault-visual{width:230px}.grid,.cloud-account,.team-onboarding,.team-columns{grid-template-columns:1fr}.vault-heading,.vault-toolbar,.access,.team-summary{align-items:start;flex-direction:column}.vault-actions{justify-content:flex-start}.vault-panel form,.record-form{grid-template-columns:1fr}.vault-panel button,.record-form button{grid-column:1}.vault-records{grid-template-columns:1fr}.team-picker,.team-picker.compact{grid-template-columns:1fr}.team-members article{grid-template-columns:1fr}.team-members strong,.team-members small,.team-members select,.team-members button,.team-members button.danger{grid-column:1;grid-row:auto}.status{font-size:0}.status::after{content:"●";font-size:16px} }
 @media (prefers-reduced-motion:reduce) { .orbit{animation:none} }

--- a/cloud/public/team-vault-sync.js
+++ b/cloud/public/team-vault-sync.js
@@ -1,0 +1,570 @@
+import { generateVaultKey } from "./vault-crypto.js";
+import {
+  createEmptyVaultDocument,
+  deleteVaultRecord,
+  mergeVaultDocuments,
+  resolveVaultConflict,
+  upsertVaultRecord,
+  validateVaultDocument,
+} from "./vault-model.js";
+import {
+  decryptTeamVaultPayload,
+  encryptTeamVaultPayload,
+  normalizeTeamVaultScope,
+  unwrapTeamVaultKeyForDevice,
+  wrapTeamVaultKeyForDevice,
+} from "./team-vault-crypto.js";
+
+const databaseName = "selective-remote-cloud";
+const storeName = "local-vault";
+const recordTypes = new Set(["host", "credential", "snippet", "forwarding"]);
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const snapshotKeys = [
+  "deviceID", "envelope", "keyGeneration", "localRevision", "scope",
+  "serverRevision", "syncedLocalRevision", "wrapper",
+];
+const envelopeKeys = [
+  "authTag", "baseRevision", "ciphertext", "contentHash", "envelopeVersion", "keyGeneration", "nonce",
+];
+
+function clone(value) {
+  return globalThis.structuredClone ? globalThis.structuredClone(value) : JSON.parse(JSON.stringify(value));
+}
+
+function exactKeys(value, expected, code) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(code);
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (actual.length !== wanted.length || actual.some((key, index) => key !== wanted[index])) throw new Error(code);
+}
+
+function normalizedUUID(value, code) {
+  const normalized = String(value ?? "").toLowerCase();
+  if (!uuidPattern.test(normalized)) throw new Error(code);
+  return normalized;
+}
+
+function normalizedEnvelope(value) {
+  exactKeys(value, envelopeKeys, "invalid_local_team_vault");
+  if (!Number.isSafeInteger(value.baseRevision) || value.baseRevision < 0
+    || !Number.isSafeInteger(value.keyGeneration) || value.keyGeneration < 1
+    || value.envelopeVersion !== 1) {
+    throw new Error("invalid_local_team_vault");
+  }
+  for (const key of ["ciphertext", "nonce", "authTag", "contentHash"]) {
+    if (typeof value[key] !== "string" || !/^[A-Za-z0-9_-]+$/u.test(value[key])) {
+      throw new Error("invalid_local_team_vault");
+    }
+  }
+  return clone(value);
+}
+
+function normalizedSnapshot(value, expectedScope = null) {
+  exactKeys(value, snapshotKeys, "invalid_local_team_vault");
+  const scope = normalizeTeamVaultScope(value.scope);
+  if (expectedScope && (scope.teamID !== expectedScope.teamID || scope.vaultID !== expectedScope.vaultID)) {
+    throw new Error("invalid_local_team_vault");
+  }
+  const envelope = normalizedEnvelope(value.envelope);
+  if (envelope.keyGeneration !== value.keyGeneration
+    || !Number.isSafeInteger(value.localRevision) || value.localRevision < 1
+    || !Number.isSafeInteger(value.serverRevision) || value.serverRevision < 0
+    || !Number.isSafeInteger(value.syncedLocalRevision) || value.syncedLocalRevision < 0
+    || value.syncedLocalRevision > value.localRevision
+    || !value.wrapper || typeof value.wrapper !== "object" || Array.isArray(value.wrapper)) {
+    throw new Error("invalid_local_team_vault");
+  }
+  return {
+    scope,
+    deviceID: normalizedUUID(value.deviceID, "invalid_local_team_vault"),
+    keyGeneration: value.keyGeneration,
+    localRevision: value.localRevision,
+    serverRevision: value.serverRevision,
+    syncedLocalRevision: value.syncedLocalRevision,
+    envelope,
+    wrapper: clone(value.wrapper),
+  };
+}
+
+function snapshotKey(scope) {
+  const normalized = normalizeTeamVaultScope(scope);
+  return `team-vault:${normalized.teamID}:${normalized.vaultID}`;
+}
+
+function openDatabase(indexedDBValue) {
+  if (!indexedDBValue?.open) return Promise.reject(new Error("team_vault_storage_unavailable"));
+  return new Promise((resolve, reject) => {
+    const request = indexedDBValue.open(databaseName, 1);
+    request.onupgradeneeded = () => {
+      if (!request.result.objectStoreNames.contains(storeName)) request.result.createObjectStore(storeName);
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(new Error("team_vault_storage_unavailable"));
+    request.onblocked = () => reject(new Error("team_vault_storage_unavailable"));
+  });
+}
+
+async function transaction(indexedDBValue, mode, operation) {
+  const database = await openDatabase(indexedDBValue);
+  try {
+    return await new Promise((resolve, reject) => {
+      const tx = database.transaction(storeName, mode);
+      const request = operation(tx.objectStore(storeName));
+      let result = null;
+      request.onsuccess = () => { result = request.result ?? null; };
+      request.onerror = () => reject(new Error("team_vault_storage_failed"));
+      tx.onabort = () => reject(new Error("team_vault_storage_failed"));
+      tx.onerror = () => reject(new Error("team_vault_storage_failed"));
+      tx.oncomplete = () => resolve(result);
+    });
+  } finally {
+    database.close();
+  }
+}
+
+export function createIndexedDBTeamVaultRepository(scope, indexedDBValue = globalThis.indexedDB) {
+  const normalizedScope = normalizeTeamVaultScope(scope);
+  const key = snapshotKey(normalizedScope);
+  return {
+    async load() {
+      const value = await transaction(indexedDBValue, "readonly", (store) => store.get(key));
+      return value === null || value === undefined ? null : normalizedSnapshot(value, normalizedScope);
+    },
+    async save(value) {
+      const snapshot = normalizedSnapshot(value, normalizedScope);
+      await transaction(indexedDBValue, "readwrite", (store) => store.put(clone(snapshot), key));
+    },
+    async remove() {
+      await transaction(indexedDBValue, "readwrite", (store) => store.delete(key));
+    },
+  };
+}
+
+function remoteEnvelope(remote) {
+  return normalizedEnvelope({
+    baseRevision: Math.max(0, remote.revision - 1),
+    keyGeneration: remote.keyGeneration,
+    envelopeVersion: remote.envelopeVersion,
+    ciphertext: remote.ciphertext,
+    nonce: remote.nonce,
+    authTag: remote.authTag,
+    contentHash: remote.contentHash,
+  });
+}
+
+export function createTeamVaultController({
+  repository,
+  identity,
+  scope,
+  cryptoValue = globalThis.crypto,
+  now = () => new Date().toISOString(),
+  randomUUID = () => cryptoValue.randomUUID(),
+} = {}) {
+  if (!repository || typeof repository.load !== "function" || typeof repository.save !== "function") {
+    throw new Error("invalid_team_vault_repository");
+  }
+  const normalizedScope = normalizeTeamVaultScope(scope);
+  const deviceID = normalizedUUID(identity?.deviceID, "invalid_team_device_identity");
+  if (!identity?.privateKey) throw new Error("invalid_team_device_identity");
+  let snapshot = null;
+  let vaultKey = null;
+  let document = null;
+  let pendingConflicts = null;
+
+  function requireUnlocked() {
+    if (!snapshot || !vaultKey || !document) throw new Error("team_vault_locked");
+  }
+
+  async function save(nextSnapshot) {
+    const normalized = normalizedSnapshot(nextSnapshot, normalizedScope);
+    await repository.save(normalized);
+    snapshot = normalized;
+  }
+
+  async function persist(nextDocument) {
+    requireUnlocked();
+    const normalizedDocument = validateVaultDocument(nextDocument);
+    const envelope = await encryptTeamVaultPayload({
+      vaultKey,
+      payload: normalizedDocument,
+      scope: normalizedScope,
+      baseRevision: snapshot.serverRevision,
+      keyGeneration: snapshot.keyGeneration,
+      cryptoValue,
+    });
+    await save({ ...snapshot, localRevision: snapshot.localRevision + 1, envelope });
+    document = normalizedDocument;
+    pendingConflicts = null;
+    return clone(document);
+  }
+
+  return {
+    scope: normalizedScope,
+
+    async status() {
+      if (snapshot && vaultKey && document) return "unlocked";
+      return (await repository.load()) ? "locked" : "empty";
+    },
+
+    async unlock() {
+      const stored = await repository.load();
+      if (!stored) throw new Error("local_team_vault_missing");
+      const nextSnapshot = normalizedSnapshot(stored, normalizedScope);
+      const nextKey = await unwrapTeamVaultKeyForDevice({
+        privateKey: identity.privateKey,
+        wrapper: nextSnapshot.wrapper,
+        ...normalizedScope,
+        keyGeneration: nextSnapshot.keyGeneration,
+        deviceID,
+        cryptoValue,
+      });
+      const nextDocument = validateVaultDocument(await decryptTeamVaultPayload({
+        vaultKey: nextKey,
+        envelope: nextSnapshot.envelope,
+        scope: normalizedScope,
+        cryptoValue,
+      }));
+      snapshot = nextSnapshot;
+      vaultKey = nextKey;
+      document = nextDocument;
+      pendingConflicts = null;
+      return clone(document);
+    },
+
+    lock() {
+      snapshot = null;
+      vaultKey = null;
+      document = null;
+      pendingConflicts = null;
+    },
+
+    document() {
+      requireUnlocked();
+      return clone(document);
+    },
+
+    async initialize(keyDevices) {
+      if (await repository.load()) throw new Error("local_team_vault_exists");
+      if (!Array.isArray(keyDevices) || keyDevices.length === 0) throw new Error("team_key_devices_required");
+      const unique = new Set(keyDevices.map((device) => normalizedUUID(device?.deviceID, "invalid_team_key_devices")));
+      if (unique.size !== keyDevices.length || !unique.has(deviceID)) throw new Error("invalid_team_key_devices");
+      const nextKey = await generateVaultKey(cryptoValue);
+      const wrappers = await Promise.all(keyDevices.map((recipient) => wrapTeamVaultKeyForDevice({
+        vaultKey: nextKey,
+        recipient,
+        ...normalizedScope,
+        keyGeneration: 1,
+        cryptoValue,
+      })));
+      const envelope = await encryptTeamVaultPayload({
+        vaultKey: nextKey,
+        payload: createEmptyVaultDocument(),
+        scope: normalizedScope,
+        baseRevision: 0,
+        keyGeneration: 1,
+        wrappers,
+        cryptoValue,
+      });
+      const currentWrapper = wrappers.find((wrapper) => wrapper.deviceID === deviceID);
+      const storedEnvelope = { ...envelope };
+      delete storedEnvelope.wrappers;
+      const nextSnapshot = {
+        scope: normalizedScope,
+        deviceID,
+        keyGeneration: 1,
+        localRevision: 1,
+        serverRevision: 0,
+        syncedLocalRevision: 0,
+        envelope: storedEnvelope,
+        wrapper: currentWrapper,
+      };
+      await save(nextSnapshot);
+      vaultKey = nextKey;
+      document = createEmptyVaultDocument();
+      return { localRevision: 1, envelope };
+    },
+
+    async prepareInitialization(keyDevices) {
+      requireUnlocked();
+      if (snapshot.serverRevision !== 0 || !Array.isArray(keyDevices) || keyDevices.length === 0) {
+        throw new Error("invalid_team_vault_initialization");
+      }
+      const unique = new Set(keyDevices.map((device) => normalizedUUID(device?.deviceID, "invalid_team_key_devices")));
+      if (unique.size !== keyDevices.length || !unique.has(deviceID)) throw new Error("invalid_team_key_devices");
+      const wrappers = await Promise.all(keyDevices.map((recipient) => wrapTeamVaultKeyForDevice({
+        vaultKey,
+        recipient,
+        ...normalizedScope,
+        keyGeneration: snapshot.keyGeneration,
+        cryptoValue,
+      })));
+      return {
+        localRevision: snapshot.localRevision,
+        envelope: await encryptTeamVaultPayload({
+          vaultKey,
+          payload: document,
+          scope: normalizedScope,
+          baseRevision: 0,
+          keyGeneration: snapshot.keyGeneration,
+          wrappers,
+          cryptoValue,
+        }),
+      };
+    },
+
+    async discardUncommittedInitialization() {
+      if (snapshot?.serverRevision !== 0 || snapshot?.syncedLocalRevision !== 0 || snapshot?.localRevision !== 1) {
+        throw new Error("team_vault_initialization_committed");
+      }
+      if (typeof repository.remove !== "function") throw new Error("team_vault_storage_unavailable");
+      await repository.remove();
+      this.lock();
+    },
+
+    async importRemote(remote) {
+      if (await repository.load()) throw new Error("local_team_vault_exists");
+      if (remote.rotationRequired) throw new Error("team_vault_rotation_required");
+      if (remote.revision < 1 || !remote.wrapper) throw new Error("team_vault_key_unavailable");
+      const envelope = remoteEnvelope(remote);
+      const nextKey = await unwrapTeamVaultKeyForDevice({
+        privateKey: identity.privateKey,
+        wrapper: remote.wrapper,
+        ...normalizedScope,
+        keyGeneration: remote.keyGeneration,
+        deviceID,
+        cryptoValue,
+      });
+      const nextDocument = validateVaultDocument(await decryptTeamVaultPayload({
+        vaultKey: nextKey,
+        envelope,
+        scope: normalizedScope,
+        cryptoValue,
+      }));
+      const nextSnapshot = {
+        scope: normalizedScope,
+        deviceID,
+        keyGeneration: remote.keyGeneration,
+        localRevision: 1,
+        serverRevision: remote.revision,
+        syncedLocalRevision: 1,
+        envelope,
+        wrapper: remote.wrapper,
+      };
+      await save(nextSnapshot);
+      vaultKey = nextKey;
+      document = nextDocument;
+      pendingConflicts = null;
+      return clone(document);
+    },
+
+    async syncState() {
+      requireUnlocked();
+      return {
+        localRevision: snapshot.localRevision,
+        serverRevision: snapshot.serverRevision,
+        keyGeneration: snapshot.keyGeneration,
+        dirty: snapshot.syncedLocalRevision !== snapshot.localRevision,
+      };
+    },
+
+    async prepareUpload(baseRevision) {
+      requireUnlocked();
+      return {
+        localRevision: snapshot.localRevision,
+        envelope: await encryptTeamVaultPayload({
+          vaultKey,
+          payload: document,
+          scope: normalizedScope,
+          baseRevision,
+          keyGeneration: snapshot.keyGeneration,
+          cryptoValue,
+        }),
+      };
+    },
+
+    async markSynced({ serverRevision, localRevision }) {
+      requireUnlocked();
+      if (!Number.isSafeInteger(serverRevision) || serverRevision < 1
+        || !Number.isSafeInteger(localRevision) || localRevision < 1 || localRevision > snapshot.localRevision) {
+        throw new Error("invalid_team_vault_sync");
+      }
+      await save({
+        ...snapshot,
+        serverRevision,
+        syncedLocalRevision: localRevision,
+      });
+      return { dirty: snapshot.syncedLocalRevision !== snapshot.localRevision, ...await this.syncState() };
+    },
+
+    async mergeRemote(remote) {
+      requireUnlocked();
+      if (remote.rotationRequired) throw new Error("team_vault_rotation_required");
+      if (remote.keyGeneration !== snapshot.keyGeneration) throw new Error("team_vault_generation_changed");
+      const envelope = remoteEnvelope(remote);
+      const remoteDocument = validateVaultDocument(await decryptTeamVaultPayload({
+        vaultKey,
+        envelope,
+        scope: normalizedScope,
+        cryptoValue,
+      }));
+      const merged = mergeVaultDocuments(document, remoteDocument);
+      if (merged.conflicts.length > 0) {
+        pendingConflicts = { revision: remote.revision, document: merged.document, conflicts: clone(merged.conflicts) };
+        return { conflicts: clone(merged.conflicts) };
+      }
+      const matchesRemote = JSON.stringify(merged.document) === JSON.stringify(remoteDocument);
+      const localChanged = JSON.stringify(merged.document) !== JSON.stringify(document);
+      if (matchesRemote) {
+        const nextLocalRevision = snapshot.localRevision + 1;
+        await save({
+          ...snapshot,
+          localRevision: nextLocalRevision,
+          serverRevision: remote.revision,
+          syncedLocalRevision: nextLocalRevision,
+          envelope,
+          wrapper: remote.wrapper ?? snapshot.wrapper,
+        });
+        document = remoteDocument;
+      } else if (localChanged) {
+        await persist(merged.document);
+        await save({ ...snapshot, serverRevision: remote.revision, wrapper: remote.wrapper ?? snapshot.wrapper });
+      }
+      return { conflicts: [], matchesRemote, localChanged };
+    },
+
+    pendingConflicts() {
+      requireUnlocked();
+      return pendingConflicts ? { revision: pendingConflicts.revision, conflicts: clone(pendingConflicts.conflicts) } : null;
+    },
+
+    async resolveConflicts({ revision, resolutions }) {
+      requireUnlocked();
+      if (!pendingConflicts || revision !== pendingConflicts.revision || !Array.isArray(resolutions)
+        || resolutions.length !== pendingConflicts.conflicts.length) {
+        throw new Error("invalid_pending_conflicts");
+      }
+      const choices = new Map();
+      for (const resolution of resolutions) {
+        exactKeys(resolution, ["choice", "id"], "invalid_conflict_resolution");
+        const id = normalizedUUID(resolution.id, "invalid_conflict_resolution");
+        if (!['local', 'remote'].includes(resolution.choice) || choices.has(id)) {
+          throw new Error("invalid_conflict_resolution");
+        }
+        choices.set(id, resolution.choice);
+      }
+      if (pendingConflicts.conflicts.some((conflict) => !choices.has(conflict.id))) {
+        throw new Error("incomplete_conflict_resolution");
+      }
+      let resolved = pendingConflicts.document;
+      for (const conflict of pendingConflicts.conflicts) {
+        resolved = resolveVaultConflict(resolved, conflict, {
+          choice: choices.get(conflict.id),
+          deviceID,
+          resolvedAt: now(),
+        });
+      }
+      await persist(resolved);
+      await save({ ...snapshot, serverRevision: revision });
+      const count = pendingConflicts?.conflicts.length ?? resolutions.length;
+      pendingConflicts = null;
+      return { revision, localRevision: snapshot.localRevision, conflictsResolved: count };
+    },
+
+    async upsert({ id = randomUUID(), type, data }) {
+      requireUnlocked();
+      if (!recordTypes.has(type)) throw new Error("invalid_record_type");
+      await persist(upsertVaultRecord(document, {
+        id,
+        type,
+        data,
+        deviceID,
+        modifiedAt: now(),
+      }));
+      return id;
+    },
+
+    async delete(id) {
+      requireUnlocked();
+      return persist(deleteVaultRecord(document, { id, deviceID, deletedAt: now() }));
+    },
+  };
+}
+
+async function uploadCurrent({ client, controller, scope, baseRevision }) {
+  const prepared = await controller.prepareUpload(baseRevision);
+  const result = await client.putTeamVault(
+    scope,
+    prepared.envelope,
+    `web:team:vault:put:${globalThis.crypto.randomUUID()}`,
+  );
+  if (result.conflict) return { status: "remote_changed", remoteRevision: result.revision };
+  if (result.revision !== baseRevision + 1) throw new Error("invalid_remote_revision");
+  const state = await controller.markSynced({ serverRevision: result.revision, localRevision: prepared.localRevision });
+  return { status: state.dirty ? "uploaded_with_new_local_changes" : "uploaded", revision: result.revision };
+}
+
+export async function synchronizeTeamVault({ client, controller, role } = {}) {
+  if (!client?.session()) throw new Error("authentication_required");
+  if (!controller || typeof controller.status !== "function") throw new Error("invalid_team_vault_controller");
+  const scope = controller.scope;
+  const remote = await client.getTeamVault(scope);
+  if (remote.rotationRequired) throw new Error("team_vault_rotation_required");
+  let status = await controller.status();
+  if (status === "locked") {
+    await controller.unlock();
+    status = "unlocked";
+  }
+  if (status === "empty") {
+    if (remote.revision > 0) {
+      await controller.importRemote(remote);
+      return { status: "downloaded", revision: remote.revision };
+    }
+    if (!["owner", "admin"].includes(role)) throw new Error("team_vault_initialization_forbidden");
+    const devices = await client.listTeamKeyDevices(scope);
+    const prepared = await controller.initialize(devices.devices);
+    const result = await client.putTeamVault(
+      scope,
+      prepared.envelope,
+      `web:team:vault:initialize:${globalThis.crypto.randomUUID()}`,
+    );
+    if (result.conflict) {
+      await controller.discardUncommittedInitialization();
+      return { status: "remote_changed", remoteRevision: result.revision };
+    }
+    await controller.markSynced({ serverRevision: result.revision, localRevision: prepared.localRevision });
+    return { status: "initialized", revision: result.revision };
+  }
+  if (status !== "unlocked") throw new Error("team_vault_locked");
+  const state = await controller.syncState();
+  if (remote.revision > 0 && state.serverRevision === 0) {
+    await controller.discardUncommittedInitialization();
+    await controller.importRemote(remote);
+    return { status: "downloaded", revision: remote.revision };
+  }
+  if (remote.revision === 0 && state.serverRevision === 0) {
+    if (!["owner", "admin"].includes(role)) throw new Error("team_vault_initialization_forbidden");
+    const devices = await client.listTeamKeyDevices(scope);
+    const prepared = await controller.prepareInitialization(devices.devices);
+    const result = await client.putTeamVault(
+      scope,
+      prepared.envelope,
+      `web:team:vault:initialize:${globalThis.crypto.randomUUID()}`,
+    );
+    if (result.conflict) return { status: "remote_changed", remoteRevision: result.revision };
+    await controller.markSynced({ serverRevision: result.revision, localRevision: prepared.localRevision });
+    return { status: "initialized", revision: result.revision };
+  }
+  if (remote.keyGeneration !== state.keyGeneration) throw new Error("team_vault_generation_changed");
+  if (remote.revision < state.serverRevision) throw new Error("remote_revision_regressed");
+  if (remote.revision === state.serverRevision) {
+    return state.dirty
+      ? uploadCurrent({ client, controller, scope, baseRevision: remote.revision })
+      : { status: "up_to_date", revision: remote.revision };
+  }
+  const merged = await controller.mergeRemote(remote);
+  if (merged.conflicts.length > 0) {
+    return { status: "conflict", revision: remote.revision, conflicts: merged.conflicts };
+  }
+  if (merged.matchesRemote) return { status: "downloaded", revision: remote.revision };
+  return uploadCurrent({ client, controller, scope, baseRevision: remote.revision });
+}

--- a/cloud/public/vault-sync.js
+++ b/cloud/public/vault-sync.js
@@ -167,6 +167,74 @@ function normalizedRemoteTeamVault(value, scope) {
   };
 }
 
+function normalizedTeam(value) {
+  exactKeys(value, ["createdAt", "id", "membershipEpoch", "membershipID", "name", "role", "updatedAt"], "invalid_team");
+  if (!["owner", "admin", "editor", "viewer"].includes(value.role)
+    || !Number.isSafeInteger(value.membershipEpoch) || value.membershipEpoch < 1) {
+    throw new Error("invalid_team");
+  }
+  return {
+    id: normalizedUUID(value.id, "invalid_team"),
+    name: String(value.name ?? ""),
+    membershipID: normalizedUUID(value.membershipID, "invalid_team"),
+    role: value.role,
+    membershipEpoch: value.membershipEpoch,
+    createdAt: value.createdAt,
+    updatedAt: value.updatedAt,
+  };
+}
+
+function normalizedTeamMember(value) {
+  exactKeys(value, ["displayName", "email", "epoch", "id", "joinedAt", "role", "userID"], "invalid_team_member");
+  if (!["owner", "admin", "editor", "viewer"].includes(value.role)
+    || !Number.isSafeInteger(value.epoch) || value.epoch < 1) {
+    throw new Error("invalid_team_member");
+  }
+  return {
+    id: normalizedUUID(value.id, "invalid_team_member"),
+    userID: normalizedUUID(value.userID, "invalid_team_member"),
+    email: String(value.email ?? ""),
+    displayName: String(value.displayName ?? ""),
+    role: value.role,
+    epoch: value.epoch,
+    joinedAt: value.joinedAt,
+  };
+}
+
+function normalizedSharedVault(value, teamID) {
+  exactKeys(value, [
+    "createdAt", "id", "keyGeneration", "name", "revision", "rotationRequired", "teamID", "updatedAt",
+  ], "invalid_shared_vault");
+  if (normalizedUUID(value.teamID, "invalid_shared_vault") !== teamID
+    || !Number.isSafeInteger(value.revision) || value.revision < 0
+    || !Number.isSafeInteger(value.keyGeneration) || value.keyGeneration < 1
+    || typeof value.rotationRequired !== "boolean") {
+    throw new Error("invalid_shared_vault");
+  }
+  return {
+    id: normalizedUUID(value.id, "invalid_shared_vault"),
+    teamID,
+    name: String(value.name ?? ""),
+    revision: value.revision,
+    keyGeneration: value.keyGeneration,
+    rotationRequired: value.rotationRequired,
+    createdAt: value.createdAt,
+    updatedAt: value.updatedAt,
+  };
+}
+
+function normalizedTeamName(value, code = "invalid_team") {
+  const name = String(value ?? "").trim();
+  if (!name || name.length > 120) throw new Error(code);
+  return name;
+}
+
+function generatedIdempotencyKey(prefix) {
+  const id = globalThis.crypto?.randomUUID?.();
+  if (!id) throw new Error("idempotency_unavailable");
+  return `${prefix}:${id}`;
+}
+
 function normalizedEnvelope(value, expectedBaseRevision = null) {
   exactKeys(value, envelopeKeys, "invalid_remote_vault");
   if (!Number.isSafeInteger(value.baseRevision) || value.baseRevision < 0) throw new Error("invalid_remote_vault");
@@ -305,6 +373,116 @@ export function createAuthenticatedVaultClient({ fetchValue = globalThis.fetch }
         user = null;
         currentDeviceID = null;
       }
+    },
+
+    async listTeams() {
+      const response = await authorizedRequest("/v1/teams");
+      const result = await responseJSON(response, "teams_download_failed");
+      if (!response.ok || !Array.isArray(result.teams) || result.teams.length > 1_000) {
+        throw new Error("teams_download_failed");
+      }
+      return result.teams.map(normalizedTeam);
+    },
+
+    async createTeam({ name, idempotencyKey = generatedIdempotencyKey("web:team:create") }) {
+      const response = await authorizedRequest("/v1/teams", {
+        method: "POST",
+        headers: { "Idempotency-Key": normalizedIdempotencyKey(idempotencyKey) },
+        body: JSON.stringify({ name: normalizedTeamName(name) }),
+      });
+      const result = await responseJSON(response, "team_create_failed");
+      if (!response.ok || !result.team) throw new Error("team_create_failed");
+      return normalizedTeam(result.team);
+    },
+
+    async listTeamMembers(teamID) {
+      const normalizedTeamID = normalizedUUID(teamID, "invalid_team");
+      const response = await authorizedRequest(`/v1/teams/${normalizedTeamID}/members`);
+      const result = await responseJSON(response, "team_members_download_failed");
+      if (!response.ok || !Array.isArray(result.members) || result.members.length > 10_000) {
+        throw new Error("team_members_download_failed");
+      }
+      return result.members.map(normalizedTeamMember);
+    },
+
+    async inviteTeamMember({ teamID, email, role, idempotencyKey = generatedIdempotencyKey("web:team:invite") }) {
+      const normalizedTeamID = normalizedUUID(teamID, "invalid_team");
+      const normalizedRole = String(role ?? "");
+      if (!["admin", "editor", "viewer"].includes(normalizedRole)) throw new Error("invalid_team_role");
+      const normalizedEmail = String(email ?? "").trim().toLowerCase();
+      if (!normalizedEmail || normalizedEmail.length > 254) throw new Error("invalid_email");
+      const response = await authorizedRequest(`/v1/teams/${normalizedTeamID}/invitations`, {
+        method: "POST",
+        headers: { "Idempotency-Key": normalizedIdempotencyKey(idempotencyKey) },
+        body: JSON.stringify({ email: normalizedEmail, role: normalizedRole }),
+      });
+      const result = await responseJSON(response, "team_invitation_failed");
+      if (!response.ok || !result.invitation || "token" in result.invitation) throw new Error("team_invitation_failed");
+      return structuredClone(result.invitation);
+    },
+
+    async acceptTeamInvitation({ token: invitationToken, idempotencyKey = generatedIdempotencyKey("web:team:accept") }) {
+      const value = String(invitationToken ?? "").trim();
+      if (value.length < 32 || value.length > 512) throw new Error("invalid_team_invitation");
+      const response = await authorizedRequest("/v1/team-invitations/accept", {
+        method: "POST",
+        headers: { "Idempotency-Key": normalizedIdempotencyKey(idempotencyKey) },
+        body: JSON.stringify({ token: value }),
+      });
+      const result = await responseJSON(response, "team_invitation_accept_failed");
+      if (!response.ok || !result.membership) throw new Error("team_invitation_accept_failed");
+      return normalizedTeamMember(result.membership);
+    },
+
+    async updateTeamMemberRole({ teamID, membershipID, role, idempotencyKey = generatedIdempotencyKey("web:team:role") }) {
+      const normalizedTeamID = normalizedUUID(teamID, "invalid_team");
+      const normalizedMembershipID = normalizedUUID(membershipID, "invalid_team_member");
+      const normalizedRole = String(role ?? "");
+      if (!["owner", "admin", "editor", "viewer"].includes(normalizedRole)) throw new Error("invalid_team_role");
+      const response = await authorizedRequest(`/v1/teams/${normalizedTeamID}/members/${normalizedMembershipID}`, {
+        method: "PATCH",
+        headers: { "Idempotency-Key": normalizedIdempotencyKey(idempotencyKey) },
+        body: JSON.stringify({ role: normalizedRole }),
+      });
+      const result = await responseJSON(response, "team_member_role_failed");
+      if (!response.ok || !result.membership) throw new Error("team_member_role_failed");
+      return normalizedTeamMember(result.membership);
+    },
+
+    async revokeTeamMember({ teamID, membershipID, idempotencyKey = generatedIdempotencyKey("web:team:revoke") }) {
+      const normalizedTeamID = normalizedUUID(teamID, "invalid_team");
+      const normalizedMembershipID = normalizedUUID(membershipID, "invalid_team_member");
+      const response = await authorizedRequest(`/v1/teams/${normalizedTeamID}/members/${normalizedMembershipID}`, {
+        method: "DELETE",
+        headers: { "Idempotency-Key": normalizedIdempotencyKey(idempotencyKey) },
+      });
+      const result = await responseJSON(response, "team_member_revoke_failed");
+      if (!response.ok || result.revoked !== true || !Number.isSafeInteger(result.rotationRequiredVaults)) {
+        throw new Error("team_member_revoke_failed");
+      }
+      return { revoked: true, rotationRequiredVaults: result.rotationRequiredVaults };
+    },
+
+    async listSharedVaults(teamID) {
+      const normalizedTeamID = normalizedUUID(teamID, "invalid_team");
+      const response = await authorizedRequest(`/v1/teams/${normalizedTeamID}/vaults`);
+      const result = await responseJSON(response, "shared_vaults_download_failed");
+      if (!response.ok || !Array.isArray(result.vaults) || result.vaults.length > 10_000) {
+        throw new Error("shared_vaults_download_failed");
+      }
+      return result.vaults.map((vault) => normalizedSharedVault(vault, normalizedTeamID));
+    },
+
+    async createSharedVault({ teamID, name, idempotencyKey = generatedIdempotencyKey("web:team:vault:create") }) {
+      const normalizedTeamID = normalizedUUID(teamID, "invalid_team");
+      const response = await authorizedRequest(`/v1/teams/${normalizedTeamID}/vaults`, {
+        method: "POST",
+        headers: { "Idempotency-Key": normalizedIdempotencyKey(idempotencyKey) },
+        body: JSON.stringify({ name: normalizedTeamName(name, "invalid_shared_vault") }),
+      });
+      const result = await responseJSON(response, "shared_vault_create_failed");
+      if (!response.ok || !result.vault) throw new Error("shared_vault_create_failed");
+      return normalizedSharedVault(result.vault, normalizedTeamID);
     },
 
     async getVault(scope = personalVaultScope) {

--- a/cloud/tests/public-team-vault-client.test.mjs
+++ b/cloud/tests/public-team-vault-client.test.mjs
@@ -205,3 +205,89 @@ test("invalid Team scope, key sets and idempotency fail before a network request
   );
   assert.equal(calls.length, 0);
 });
+
+test("browser Team management covers lifecycle, members, invitations and shared Vault metadata", async () => {
+  const { identity } = await fixture();
+  const calls = [];
+  const timestamps = { createdAt: "2026-09-05T00:00:00.000Z", updatedAt: "2026-09-05T00:00:00.000Z" };
+  const team = {
+    id: teamID,
+    name: "Operations",
+    membershipID,
+    role: "owner",
+    membershipEpoch: 1,
+    ...timestamps,
+  };
+  const member = {
+    id: membershipID,
+    userID,
+    email: "user@example.invalid",
+    displayName: "User",
+    role: "owner",
+    epoch: 1,
+    joinedAt: timestamps.createdAt,
+  };
+  const vault = {
+    id: vaultID,
+    teamID,
+    name: "Operations",
+    revision: 0,
+    keyGeneration: 1,
+    rotationRequired: false,
+    ...timestamps,
+  };
+  const client = createAuthenticatedVaultClient({
+    fetchValue: async (path, options = {}) => {
+      calls.push({ path, options });
+      if (path === "/v1/auth/login") return jsonResponse(200, {
+        token: "t".repeat(43), user: { id: userID, email: "user@example.invalid", displayName: "User" }, deviceID,
+      });
+      if (path === "/v1/teams" && !options.method) return jsonResponse(200, { teams: [team] });
+      if (path === "/v1/teams" && options.method === "POST") return jsonResponse(201, { team });
+      if (path.endsWith("/members") && !options.method) return jsonResponse(200, { members: [member] });
+      if (path.endsWith("/invitations")) return jsonResponse(201, { invitation: {
+        id: "66666666-6666-4666-8666-666666666666",
+        teamID,
+        email: "member@example.invalid",
+        role: "viewer",
+        status: "pending",
+        createdAt: timestamps.createdAt,
+        expiresAt: "2026-09-07T00:00:00.000Z",
+      } });
+      if (path === "/v1/team-invitations/accept") return jsonResponse(200, { membership: member });
+      if (path.endsWith(`/${membershipID}`) && options.method === "PATCH") {
+        return jsonResponse(200, { membership: { ...member, role: "editor" } });
+      }
+      if (path.endsWith(`/${membershipID}`) && options.method === "DELETE") {
+        return jsonResponse(200, { revoked: true, rotationRequiredVaults: 1 });
+      }
+      if (path.endsWith("/vaults") && !options.method) return jsonResponse(200, { vaults: [vault] });
+      if (path.endsWith("/vaults") && options.method === "POST") return jsonResponse(201, { vault });
+      throw new Error(`unexpected_request:${path}`);
+    },
+  });
+  await client.login({
+    email: "user@example.invalid", password: "synthetic-password", deviceID, publicKey: identity.publicKey,
+  });
+
+  assert.deepEqual(await client.listTeams(), [team]);
+  assert.deepEqual(await client.createTeam({ name: " Operations " }), team);
+  assert.deepEqual(await client.listTeamMembers(teamID), [member]);
+  const invitation = await client.inviteTeamMember({ teamID, email: "MEMBER@example.invalid", role: "viewer" });
+  assert.equal(invitation.email, "member@example.invalid");
+  assert.equal("token" in invitation, false);
+  assert.deepEqual(await client.acceptTeamInvitation({ token: "x".repeat(48) }), member);
+  assert.equal((await client.updateTeamMemberRole({ teamID, membershipID, role: "editor" })).role, "editor");
+  assert.deepEqual(await client.revokeTeamMember({ teamID, membershipID }), {
+    revoked: true, rotationRequiredVaults: 1,
+  });
+  assert.deepEqual(await client.listSharedVaults(teamID), [vault]);
+  assert.deepEqual(await client.createSharedVault({ teamID, name: " Operations " }), vault);
+
+  for (const call of calls.filter(({ options }) => options.method && options.method !== "POST" || options.body)) {
+    if (call.path === "/v1/auth/login") continue;
+    assert.match(call.options.headers.Authorization, /^Bearer /u);
+    if (call.options.method !== undefined) assert.match(call.options.headers["Idempotency-Key"], /^web:/u);
+  }
+  assert.doesNotMatch(JSON.stringify(calls), /localStorage|sessionStorage/u);
+});

--- a/cloud/tests/public-team-vault-sync.test.mjs
+++ b/cloud/tests/public-team-vault-sync.test.mjs
@@ -1,0 +1,272 @@
+import assert from "node:assert/strict";
+import { webcrypto } from "node:crypto";
+import test from "node:test";
+import { generateTeamDeviceIdentity } from "../public/team-vault-crypto.js";
+import {
+  createTeamVaultController,
+  synchronizeTeamVault,
+} from "../public/team-vault-sync.js";
+
+const teamID = "11111111-1111-4111-8111-111111111111";
+const vaultID = "22222222-2222-4222-8222-222222222222";
+const deviceA = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const deviceB = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const membershipA = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const membershipB = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+const recordID = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
+const scope = { type: "team", teamID, vaultID };
+
+function memoryRepository() {
+  let value = null;
+  return {
+    async load() { return value ? structuredClone(value) : null; },
+    async save(next) { value = structuredClone(next); },
+    async remove() { value = null; },
+    inspect() { return value; },
+  };
+}
+
+async function device(deviceID, membershipID) {
+  const identity = { deviceID, ...await generateTeamDeviceIdentity(webcrypto) };
+  return {
+    identity,
+    keyDevice: {
+      deviceID,
+      membershipID,
+      membershipEpoch: 1,
+      publicKeyAlgorithm: "p256-ecdh-v1",
+      publicKey: identity.publicKey,
+    },
+  };
+}
+
+function sharedServer(keyDevices) {
+  let revision = 0;
+  let envelope = null;
+  let wrappers = new Map();
+  function clientFor(deviceID) {
+    return {
+      session() { return { id: "99999999-9999-4999-8999-999999999999" }; },
+      async listTeamKeyDevices() { return { scope, devices: keyDevices }; },
+      async getTeamVault() {
+        return {
+          scope,
+          id: vaultID,
+          teamID,
+          name: "Operations",
+          revision,
+          keyGeneration: 1,
+          rotationRequired: false,
+          envelopeVersion: envelope?.envelopeVersion ?? null,
+          ciphertext: envelope?.ciphertext ?? null,
+          nonce: envelope?.nonce ?? null,
+          authTag: envelope?.authTag ?? null,
+          contentHash: envelope?.contentHash ?? null,
+          wrapper: wrappers.get(deviceID) ?? null,
+          createdAt: "2026-09-05T00:00:00.000Z",
+          updatedAt: "2026-09-05T00:00:00.000Z",
+        };
+      },
+      async putTeamVault(_scope, next) {
+        if (next.baseRevision !== revision) return { conflict: true, revision, keyGeneration: 1 };
+        if (next.wrappers) wrappers = new Map(next.wrappers.map((wrapper) => [wrapper.deviceID, wrapper]));
+        envelope = { ...next };
+        delete envelope.wrappers;
+        revision += 1;
+        return { conflict: false, revision, keyGeneration: 1, rotationCompleted: false };
+      },
+    };
+  }
+  return { clientFor, revision: () => revision };
+}
+
+test("a Team Vault initializes for every approved device and persists ciphertext only", async () => {
+  const a = await device(deviceA, membershipA);
+  const b = await device(deviceB, membershipB);
+  const server = sharedServer([a.keyDevice, b.keyDevice]);
+  const repository = memoryRepository();
+  const controller = createTeamVaultController({
+    repository,
+    identity: a.identity,
+    scope,
+    cryptoValue: webcrypto,
+  });
+
+  assert.deepEqual(
+    await synchronizeTeamVault({ client: server.clientFor(deviceA), controller, role: "owner" }),
+    { status: "initialized", revision: 1 },
+  );
+  assert.equal(server.revision(), 1);
+  assert.equal(await controller.status(), "unlocked");
+  assert.deepEqual(controller.document(), { schemaVersion: 1, records: [], tombstones: [] });
+  const stored = JSON.stringify(repository.inspect());
+  assert.doesNotMatch(stored, /Operations|secret|"records":/u);
+  assert.equal(repository.inspect().syncedLocalRevision, 1);
+});
+
+test("an interrupted first upload retries initialization with wrappers for every current device", async () => {
+  const a = await device(deviceA, membershipA);
+  const b = await device(deviceB, membershipB);
+  const server = sharedServer([a.keyDevice, b.keyDevice]);
+  const repository = memoryRepository();
+  const controller = createTeamVaultController({
+    repository,
+    identity: a.identity,
+    scope,
+    cryptoValue: webcrypto,
+  });
+  let interrupted = true;
+  const stableClient = server.clientFor(deviceA);
+  const client = {
+    ...stableClient,
+    async putTeamVault(...args) {
+      if (interrupted) {
+        interrupted = false;
+        throw new Error("network_interrupted");
+      }
+      return stableClient.putTeamVault(...args);
+    },
+  };
+
+  await assert.rejects(
+    synchronizeTeamVault({ client, controller, role: "owner" }),
+    /network_interrupted/u,
+  );
+  assert.equal(await controller.status(), "unlocked");
+  assert.equal(repository.inspect().serverRevision, 0);
+  assert.deepEqual(
+    await synchronizeTeamVault({ client, controller, role: "owner" }),
+    { status: "initialized", revision: 1 },
+  );
+  assert.equal(repository.inspect().syncedLocalRevision, 1);
+});
+
+test("an empty uncommitted initialization yields to a concurrently initialized remote Vault", async () => {
+  const a = await device(deviceA, membershipA);
+  const b = await device(deviceB, membershipB);
+  const server = sharedServer([a.keyDevice, b.keyDevice]);
+  const repositoryA = memoryRepository();
+  const repositoryB = memoryRepository();
+  const controllerA = createTeamVaultController({ repository: repositoryA, identity: a.identity, scope, cryptoValue: webcrypto });
+  const controllerB = createTeamVaultController({ repository: repositoryB, identity: b.identity, scope, cryptoValue: webcrypto });
+  const stableClientA = server.clientFor(deviceA);
+  const interruptedClientA = {
+    ...stableClientA,
+    async putTeamVault() { throw new Error("network_interrupted"); },
+  };
+
+  await assert.rejects(
+    synchronizeTeamVault({ client: interruptedClientA, controller: controllerA, role: "owner" }),
+    /network_interrupted/u,
+  );
+  assert.deepEqual(
+    await synchronizeTeamVault({ client: server.clientFor(deviceB), controller: controllerB, role: "admin" }),
+    { status: "initialized", revision: 1 },
+  );
+  assert.deepEqual(
+    await synchronizeTeamVault({ client: stableClientA, controller: controllerA, role: "owner" }),
+    { status: "downloaded", revision: 1 },
+  );
+  assert.equal(repositoryA.inspect().serverRevision, 1);
+});
+
+test("a changed uncommitted initialization is never discarded for a concurrent remote Vault", async () => {
+  const a = await device(deviceA, membershipA);
+  const b = await device(deviceB, membershipB);
+  const server = sharedServer([a.keyDevice, b.keyDevice]);
+  const repositoryA = memoryRepository();
+  const controllerA = createTeamVaultController({ repository: repositoryA, identity: a.identity, scope, cryptoValue: webcrypto });
+  const controllerB = createTeamVaultController({ repository: memoryRepository(), identity: b.identity, scope, cryptoValue: webcrypto });
+  const stableClientA = server.clientFor(deviceA);
+  const interruptedClientA = {
+    ...stableClientA,
+    async putTeamVault() { throw new Error("network_interrupted"); },
+  };
+
+  await assert.rejects(
+    synchronizeTeamVault({ client: interruptedClientA, controller: controllerA, role: "owner" }),
+    /network_interrupted/u,
+  );
+  await controllerA.upsert({ type: "host", data: { title: "Local", address: "local.invalid" } });
+  await synchronizeTeamVault({ client: server.clientFor(deviceB), controller: controllerB, role: "admin" });
+  await assert.rejects(
+    synchronizeTeamVault({ client: stableClientA, controller: controllerA, role: "owner" }),
+    /team_vault_initialization_committed/u,
+  );
+  assert.equal(repositoryA.inspect().localRevision, 2);
+  assert.equal(controllerA.document().records[0].data.title, "Local");
+});
+
+test("two Team devices merge causal updates and require explicit choices for concurrent records", async () => {
+  const a = await device(deviceA, membershipA);
+  const b = await device(deviceB, membershipB);
+  const server = sharedServer([a.keyDevice, b.keyDevice]);
+  const repositoryA = memoryRepository();
+  const repositoryB = memoryRepository();
+  const controllerA = createTeamVaultController({
+    repository: repositoryA,
+    identity: a.identity,
+    scope,
+    cryptoValue: webcrypto,
+    now: () => "2026-09-05T01:00:00.000Z",
+  });
+  const controllerB = createTeamVaultController({
+    repository: repositoryB,
+    identity: b.identity,
+    scope,
+    cryptoValue: webcrypto,
+    now: () => "2026-09-05T02:00:00.000Z",
+  });
+  const clientA = server.clientFor(deviceA);
+  const clientB = server.clientFor(deviceB);
+
+  await synchronizeTeamVault({ client: clientA, controller: controllerA, role: "owner" });
+  assert.deepEqual(
+    await synchronizeTeamVault({ client: clientB, controller: controllerB, role: "editor" }),
+    { status: "downloaded", revision: 1 },
+  );
+  await controllerA.upsert({ id: recordID, type: "host", data: { title: "A", address: "a.invalid" } });
+  await controllerB.upsert({ id: recordID, type: "host", data: { title: "B", address: "b.invalid" } });
+  assert.deepEqual(
+    await synchronizeTeamVault({ client: clientA, controller: controllerA, role: "owner" }),
+    { status: "uploaded", revision: 2 },
+  );
+
+  const conflict = await synchronizeTeamVault({ client: clientB, controller: controllerB, role: "editor" });
+  assert.equal(conflict.status, "conflict");
+  assert.equal(conflict.conflicts.length, 1);
+  assert.equal(conflict.conflicts[0].local.value.data.title, "B");
+  assert.equal(conflict.conflicts[0].remote.value.data.title, "A");
+  await controllerB.resolveConflicts({
+    revision: conflict.revision,
+    resolutions: [{ id: recordID, choice: "local" }],
+  });
+  assert.deepEqual(
+    await synchronizeTeamVault({ client: clientB, controller: controllerB, role: "editor" }),
+    { status: "uploaded", revision: 3 },
+  );
+  assert.equal(controllerB.document().records[0].data.title, "B");
+});
+
+test("rotation and unapproved-device states fail closed without replacing local ciphertext", async () => {
+  const a = await device(deviceA, membershipA);
+  const repository = memoryRepository();
+  const controller = createTeamVaultController({ repository, identity: a.identity, scope, cryptoValue: webcrypto });
+  const client = {
+    session() { return { id: "99999999-9999-4999-8999-999999999999" }; },
+    async getTeamVault() {
+      return {
+        scope,
+        revision: 1,
+        keyGeneration: 2,
+        rotationRequired: true,
+        wrapper: null,
+      };
+    },
+  };
+  await assert.rejects(
+    synchronizeTeamVault({ client, controller, role: "viewer" }),
+    /team_vault_rotation_required/,
+  );
+  assert.equal(repository.inspect(), null);
+});

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -81,10 +81,11 @@ test("conflict choices expose only bounded metadata and never record secrets or 
 });
 
 test("portal exposes memory-only login and explicit manual synchronization controls", async () => {
-  const [html, application, synchronization] = await Promise.all([
+  const [html, application, synchronization, teamSynchronization] = await Promise.all([
     readFile(new URL("../public/index.html", import.meta.url), "utf8"),
     readFile(new URL("../public/app.js", import.meta.url), "utf8"),
     readFile(new URL("../public/vault-sync.js", import.meta.url), "utf8"),
+    readFile(new URL("../public/team-vault-sync.js", import.meta.url), "utf8"),
   ]);
 
   assert.match(html, /id="cloud-login-form"/u);
@@ -93,11 +94,21 @@ test("portal exposes memory-only login and explicit manual synchronization contr
   assert.match(html, /id="cloud-vault-recovery-form"/u);
   assert.match(html, /id="local-vault-conflicts-form"/u);
   assert.match(html, /id="local-vault-conflicts-apply"[^>]*disabled/u);
+  assert.match(html, /id="team-vault"[^>]*hidden/u);
+  assert.match(html, /id="team-create-form"/u);
+  assert.match(html, /id="team-invitation-accept-form"/u);
+  assert.match(html, /id="team-select"/u);
+  assert.match(html, /id="team-vault-record-form"/u);
+  assert.match(html, /id="team-vault-conflicts-form"/u);
   assert.match(application, /createAuthenticatedVaultClient/u);
   assert.match(application, /synchronizeVault/u);
+  assert.match(application, /ensureTeamDeviceIdentity/u);
+  assert.match(application, /synchronizeTeamVault/u);
   assert.match(application, /resolveConflicts/u);
   assert.match(application, /recoveryPassphrase/u);
-  assert.doesNotMatch(`${application}\n${synchronization}`, /localStorage|sessionStorage/u);
+  assert.doesNotMatch(`${application}\n${synchronization}\n${teamSynchronization}`, /localStorage|sessionStorage/u);
   assert.match(synchronization, /unsupported_vault_scope/u);
   assert.match(synchronization, /credentials: "omit"/u);
+  assert.match(teamSynchronization, /team_vault_rotation_required/u);
+  assert.match(teamSynchronization, /prepareInitialization/u);
 });

--- a/docs/cloud-v0.32-architecture.md
+++ b/docs/cloud-v0.32-architecture.md
@@ -11,9 +11,9 @@ durable Team, membership, invitation, role, audit, idempotency and shared-Vault
 metadata structures, shared ciphertext revisions, approved P-256 devices,
 device-bound wrappers and fail-closed rotation completion plus explicitly
 scoped authenticated routes. The browser has the interoperable Team
-cryptographic/client foundation; Team UI, causal shared-record orchestration
-and the macOS implementation remain required milestones within the final 0.32
-scope.
+cryptographic/client layer, Team/member/shared-Vault UI and causal shared-record
+orchestration. Explicit new-device approval, rotation-completion UI and the
+macOS implementation remain required milestones within the final 0.32 scope.
 FIDO2 remains outside the initial 0.32 release scope.
 
 The first production deployment targets:
@@ -167,11 +167,12 @@ removed; the backend receives only ciphertext and context-bound wrappers,
 never the key. Team lifecycle, invitation, membership and shared-Vault metadata
 endpoints implement the non-plaintext authorization foundation. The API enforces
 optimistic revision/generation writes, approved-device wrappers and atomic
-complete-set rotation; the clients do not consume it yet.
-The browser sync client accepts an explicit Vault scope and currently permits
-only `{type: "personal", id: "self"}`. Team scopes fail before any network
-request until the browser Team client and shared-key protocol are implemented.
-The backend routes do not weaken that client-side gate.
+complete-set rotation. The browser Team client consumes explicit Team/Vault
+scopes, generates one wrapper per currently approved device, stores only local
+ciphertext and performs the same version-vector/tombstone merge used by the
+personal Vault. Concurrent entities require explicit choices and revocation
+states freeze writes. Rotation completion remains a separate required client
+milestone; the current UI never weakens the server's fail-closed gate.
 
 The mandatory role matrix, invitation lifecycle, device-bound key
 distribution, membership epochs and fail-closed rotation protocol are defined

--- a/docs/cloud-v0.32-team-threat-model.md
+++ b/docs/cloud-v0.32-team-threat-model.md
@@ -1,11 +1,12 @@
 # Cloud 0.32 Team and shared Vault threat model
 
-Status: design contract with the backend Team-access and ciphertext protocol implemented.
+Status: design contract with the backend protocol and browser Team client implemented.
 Durable Teams, memberships, four-role checks, membership epochs, hash-only
 invitations, encrypted outbox delivery, audit events, idempotency receipts and
 shared-Vault metadata, shared ciphertext revisions, approved P-256 devices,
-per-device wrappers and atomic rotation completion are present. Browser/macOS
-Team cryptography and UI are not yet implemented.
+per-device wrappers and atomic rotation completion are present. The browser has
+Team/member/shared-Vault UI, non-exportable device keys and causal shared-record
+synchronization. Browser approval/rotation UI and the macOS client remain.
 
 ## Security outcome
 
@@ -205,6 +206,6 @@ or wrappers.
   present.
 
 Team/shared Vault release status remains `planned_required`: the server-side
-access and ciphertext protocol is implemented, but interoperable browser/macOS
-cryptography, Team UI and the complete acceptance suite must pass before Cloud
-0.32 is complete.
+protocol and browser Team UI/cryptography/causal sync are implemented, but
+browser approval/rotation completion, macOS interoperability and the complete
+acceptance suite must pass before Cloud 0.32 is complete.


### PR DESCRIPTION
## Summary

- add browser Team, membership, invitation and Shared Vault management
- keep Team device private keys non-exportable and shared snapshots ciphertext-only in IndexedDB
- initialize wrappers for every approved device and synchronize shared records with causal vectors/tombstones
- block rotation-required writes and require explicit conflict choices without rendering secrets
- document the completed browser layer and remaining approval/rotation/macOS work

## Verification

- `npm --prefix cloud test` — 211 passed, 1 skipped (`TEST_DATABASE_URL` unavailable), 0 failed
- `npm audit --omit=dev` — 0 vulnerabilities
- `node --check` for changed browser modules
- `git diff --check`

## Boundary

This PR does not enable registration, deploy staging, complete key rotation, or change `main`.