### PR TITLE
Cloud: add browser device approval and safe Vault rotation

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -13,8 +13,11 @@ rotation completion are implemented in the backend. The browser now has the
 interoperable cryptographic/client layer: non-exportable P-256 identities,
 ECDH/HKDF/AES-GCM wrappers, scope-bound shared payload envelopes, strict Team
 API calls, Team/member/shared-Vault UI and causal shared-record synchronization.
-The remaining client milestones include explicit new-device approval and
-rotation-completion UI plus the macOS implementation.
+The portal also lists account devices, shows canonical SHA-256 public-key
+fingerprints, approves a matching new key only from an approved device, revokes
+other devices, lets Owner/Admin grant missing current-generation wrappers from
+an unlocked Vault and completes required rotations. The remaining client
+milestone is the macOS implementation and cross-client acceptance.
 
 The browser portal can create and unlock a client-encrypted personal Vault,
 perform local CRUD, sign in with an existing verified account and manually
@@ -98,8 +101,12 @@ in page memory. It persists one strict ciphertext-only IndexedDB snapshot per
 Team/Vault scope, supports the four versioned record types and performs manual
 optimistic synchronization. Concurrent record or tombstone edits block upload
 until the user chooses every winner explicitly. Membership or device revocation
-freezes writes at `rotation_required`; the current browser UI fails closed and
-does not attempt an incomplete key rotation.
+freezes writes at `rotation_required`. Owner/Admin rotation decrypts and merges
+only in memory, generates a new key, wraps it for the exact current approved
+device set and conditionally uploads the full ciphertext plus wrappers. Local
+state changes only after the atomic server acknowledgement. A competing writer
+leaves the losing snapshot untouched; an unknown network result is reconciled
+against the exact revision, generation and content hash before local commit.
 
 ## Local verification
 

--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -3,10 +3,12 @@ import { createAuthenticatedVaultClient, synchronizeVault } from "./vault-sync.j
 import {
   createIndexedDBTeamDeviceRepository,
   ensureTeamDeviceIdentity,
+  teamDevicePublicKeyFingerprint,
 } from "./team-vault-crypto.js";
 import {
   createIndexedDBTeamVaultRepository,
   createTeamVaultController,
+  rotateTeamVault,
   synchronizeTeamVault,
 } from "./team-vault-sync.js";
 
@@ -323,6 +325,8 @@ export function initializeTeamWorkspace({
   const section = documentValue.querySelector("#team-vault");
   if (!section || !client) return null;
   const message = documentValue.querySelector("#team-vault-message");
+  const devices = documentValue.querySelector("#team-devices");
+  const devicesRefresh = documentValue.querySelector("#team-devices-refresh");
   const createTeamForm = documentValue.querySelector("#team-create-form");
   const acceptInvitationForm = documentValue.querySelector("#team-invitation-accept-form");
   const teamSelect = documentValue.querySelector("#team-select");
@@ -338,6 +342,8 @@ export function initializeTeamWorkspace({
   const workspaceTitle = documentValue.querySelector("#team-vault-workspace-title");
   const workspaceStatus = documentValue.querySelector("#team-vault-workspace-status");
   const syncButton = documentValue.querySelector("#team-vault-sync");
+  const rotateButton = documentValue.querySelector("#team-vault-rotate");
+  const grantWrappersButton = documentValue.querySelector("#team-vault-grant-wrappers");
   const lockButton = documentValue.querySelector("#team-vault-lock");
   const recordForm = documentValue.querySelector("#team-vault-record-form");
   const recordType = documentValue.querySelector("#team-record-type");
@@ -464,6 +470,65 @@ export function initializeTeamWorkspace({
     conflictPanel.hidden = false;
   }
 
+  async function loadDevices() {
+    const values = await client.listDevices();
+    devices.replaceChildren();
+    for (const device of values) {
+      const card = documentValue.createElement("article");
+      const name = documentValue.createElement("strong");
+      const detail = documentValue.createElement("small");
+      const fingerprint = documentValue.createElement("p");
+      const approve = documentValue.createElement("button");
+      const revoke = documentValue.createElement("button");
+      const current = device.id === client.deviceID();
+      const approved = device.keyApprovedAt !== null;
+      name.textContent = `${device.name || "Без названия"}${current ? " · текущее" : ""}`;
+      detail.textContent = `${device.platform || "unknown"} ${device.appVersion || ""} · ${device.revokedAt ? "отозвано" : approved ? "ключ одобрен" : device.keyRegistered ? "ожидает одобрения" : "без Team-ключа"}`;
+      fingerprint.className = "team-device-fingerprint";
+      fingerprint.textContent = device.publicKey
+        ? `SHA-256: ${await teamDevicePublicKeyFingerprint(device.publicKey)}`
+        : "SHA-256: ключ не зарегистрирован";
+      approve.type = "button";
+      approve.textContent = "Одобрить ключ";
+      approve.disabled = current || Boolean(device.revokedAt) || approved || !device.publicKey;
+      approve.addEventListener("click", async () => {
+        if (!confirmValue(`Сравните отпечаток на новом устройстве:\n${fingerprint.textContent}\n\nОдобрить этот ключ?`)) return;
+        approve.disabled = true;
+        try {
+          await client.approveDeviceKey({
+            deviceID: device.id,
+            publicKey: device.publicKey,
+            idempotencyKey: `web:device:approve:${globalThis.crypto.randomUUID()}`,
+          });
+          await loadDevices();
+          setText(message, "Ключ устройства одобрен. Owner/Admin может выдать недостающие wrappers из открытого Shared Vault.");
+        } catch {
+          setText(message, "Ключ не одобрен: требуется уже одобренное текущее устройство и совпадающий отпечаток.");
+          approve.disabled = false;
+        }
+      });
+      revoke.type = "button";
+      revoke.className = "danger";
+      revoke.textContent = "Отозвать";
+      revoke.disabled = current || Boolean(device.revokedAt);
+      revoke.addEventListener("click", async () => {
+        if (!confirmValue(`Отозвать устройство «${device.name || device.id}»? Его сессии завершатся, а затронутые Shared Vaults будут заморожены до ротации.`)) return;
+        revoke.disabled = true;
+        try {
+          await client.revokeDevice(device.id);
+          lockCurrentVault();
+          await Promise.all([loadDevices(), loadTeams(selectedTeam?.id)]);
+          setText(message, "Устройство отозвано. Завершите ротацию отмеченных Shared Vaults.");
+        } catch {
+          setText(message, "Устройство не отозвано: операция разрешена только с одобренного текущего устройства.");
+          revoke.disabled = false;
+        }
+      });
+      card.append(name, detail, fingerprint, approve, revoke);
+      devices.append(card);
+    }
+  }
+
   function renderMembers(values) {
     members.replaceChildren();
     for (const member of values) {
@@ -539,6 +604,10 @@ export function initializeTeamWorkspace({
     controller = null;
     selectedVault = null;
     workspace.hidden = true;
+    rotateButton.hidden = true;
+    rotateButton.disabled = true;
+    grantWrappersButton.hidden = true;
+    grantWrappersButton.disabled = true;
     records.replaceChildren();
     clearConflicts();
   }
@@ -555,6 +624,10 @@ export function initializeTeamWorkspace({
       scope,
     });
     workspace.hidden = false;
+    rotateButton.hidden = !vault.rotationRequired || !canManage();
+    rotateButton.disabled = !vault.rotationRequired || !canManage();
+    grantWrappersButton.hidden = vault.rotationRequired || !canManage();
+    grantWrappersButton.disabled = true;
     workspaceTitle.textContent = `${selectedTeam.name} / ${vault.name}`;
     setText(workspaceStatus, "Загружаем зашифрованную Team-ревизию…");
     syncButton.disabled = true;
@@ -563,6 +636,7 @@ export function initializeTeamWorkspace({
       renderRecords();
       setWorkspaceControls(false);
       syncButton.disabled = false;
+      grantWrappersButton.disabled = grantWrappersButton.hidden;
       setText(workspaceStatus, {
         initialized: `Shared Vault создан и зашифрован для всех одобренных устройств · ревизия ${result.revision}.`,
         downloaded: `Team-ревизия ${result.revision} расшифрована локально.`,
@@ -571,6 +645,9 @@ export function initializeTeamWorkspace({
     } catch (error) {
       const code = String(error?.message ?? "");
       setWorkspaceControls(true);
+      grantWrappersButton.disabled = true;
+      rotateButton.hidden = code !== "team_vault_rotation_required" || !canManage();
+      rotateButton.disabled = rotateButton.hidden;
       setText(workspaceStatus, code === "team_vault_rotation_required"
         ? "Запись заморожена: после отзыва участника или устройства требуется полная ротация ключа."
         : code === "team_vault_key_unavailable"
@@ -689,7 +766,69 @@ export function initializeTeamWorkspace({
 
   teamSelect.addEventListener("change", () => loadSelectedTeam().catch(() => setText(message, "Не удалось загрузить Team.")));
   teamRefresh.addEventListener("click", () => loadTeams(selectedTeam?.id).catch(() => setText(message, "Не удалось обновить Teams.")));
+  devicesRefresh.addEventListener("click", () => loadDevices().catch(() => setText(message, "Не удалось обновить устройства.")));
   vaultOpen.addEventListener("click", () => openSelectedVault());
+  rotateButton.addEventListener("click", async () => {
+    if (!controller || !selectedVault || !canManage()) return;
+    if (!confirmValue("Зашифровать полную текущую Team-ревизию новым ключом и выдать wrappers всем актуальным одобренным устройствам?")) return;
+    rotateButton.disabled = true;
+    syncButton.disabled = true;
+    lockButton.disabled = true;
+    grantWrappersButton.disabled = true;
+    setWorkspaceControls(true);
+    try {
+      const result = await rotateTeamVault({ client, controller, role: selectedTeam.role });
+      if (result.status === "conflict") {
+        renderConflicts(result);
+        setText(workspaceStatus, `Перед ротацией разрешите конфликтов: ${result.conflicts.length}. Секреты не отображаются.`);
+      } else if (result.status === "remote_changed") {
+        setText(workspaceStatus, `Другая ротация или запись уже изменила Vault до ревизии ${result.remoteRevision}. Повторно откройте Vault.`);
+      } else {
+        selectedVault = { ...selectedVault, rotationRequired: false, revision: result.revision, keyGeneration: result.keyGeneration };
+        vaults = vaults.map((value) => value.id === selectedVault.id ? selectedVault : value);
+        populateVaults();
+        vaultSelect.value = selectedVault.id;
+        rotateButton.hidden = true;
+        grantWrappersButton.hidden = !canManage();
+        grantWrappersButton.disabled = grantWrappersButton.hidden;
+        clearConflicts();
+        renderRecords();
+        setWorkspaceControls(false);
+        setText(workspaceStatus, `Ротация завершена атомарно · ревизия ${result.revision} · поколение ключа ${result.keyGeneration}.`);
+      }
+    } catch {
+      setText(workspaceStatus, "Ротация не подтверждена. Локальный snapshot не заменён; безопасно повторите операцию.");
+    } finally {
+      lockButton.disabled = false;
+      syncButton.disabled = !controller || !rotateButton.hidden;
+      rotateButton.disabled = rotateButton.hidden || !canManage() || Boolean(activeConflicts);
+      grantWrappersButton.disabled = grantWrappersButton.hidden || Boolean(activeConflicts);
+    }
+  });
+  grantWrappersButton.addEventListener("click", async () => {
+    if (!controller || !selectedVault || !canManage() || selectedVault.rotationRequired) return;
+    grantWrappersButton.disabled = true;
+    try {
+      const keyDevices = await client.listTeamKeyDevices(controller.scope);
+      const missing = keyDevices.devices.filter((device) => !device.hasWrapper);
+      const state = await controller.syncState();
+      for (const recipient of missing) {
+        const wrapper = await controller.prepareWrapper(recipient);
+        await client.grantTeamVaultWrapper(
+          controller.scope,
+          { keyGeneration: state.keyGeneration, wrapper },
+          `web:team:vault:grant:${globalThis.crypto.randomUUID()}`,
+        );
+      }
+      setText(workspaceStatus, missing.length === 0
+        ? "Все актуальные одобренные устройства уже имеют wrapper этой генерации."
+        : `Выдано недостающих wrappers: ${missing.length}. Vault plaintext не покидал браузер.`);
+    } catch {
+      setText(workspaceStatus, "Не все wrappers подтверждены. Обновите состояние и безопасно повторите операцию.");
+    } finally {
+      grantWrappersButton.disabled = !controller || selectedVault?.rotationRequired || !canManage();
+    }
+  });
   recordType.addEventListener("change", updateRecordLabels);
   recordForm.addEventListener("submit", async (event) => {
     event.preventDefault();
@@ -707,6 +846,7 @@ export function initializeTeamWorkspace({
       recordForm.reset();
       updateRecordLabels();
       clearConflicts();
+      rotateButton.disabled = !selectedVault?.rotationRequired || !canManage();
       renderRecords();
       setText(workspaceStatus, "Изменение зашифровано локально. Выполните синхронизацию.");
     } catch {
@@ -769,8 +909,11 @@ export function initializeTeamWorkspace({
         })),
       });
       clearConflicts();
+      rotateButton.disabled = !selectedVault?.rotationRequired || !canManage();
       renderRecords();
-      setText(workspaceStatus, "Конфликты разрешены локально. Синхронизируйте условную запись.");
+      setText(workspaceStatus, selectedVault?.rotationRequired
+        ? "Конфликты разрешены локально. Повторите безопасную ротацию."
+        : "Конфликты разрешены локально. Синхронизируйте условную запись.");
     } catch {
       clearConflicts();
       setText(workspaceStatus, "Набор конфликтов устарел. Запустите синхронизацию ещё раз.");
@@ -782,7 +925,7 @@ export function initializeTeamWorkspace({
     async activate(nextIdentity) {
       identity = nextIdentity;
       section.hidden = false;
-      await loadTeams();
+      await Promise.all([loadDevices(), loadTeams()]);
     },
     deactivate() {
       identity = null;
@@ -791,6 +934,7 @@ export function initializeTeamWorkspace({
       selectedTeam = null;
       lockCurrentVault();
       teamSelect.replaceChildren();
+      devices.replaceChildren();
       members.replaceChildren();
       selectedPanel.hidden = true;
       section.hidden = true;

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -166,6 +166,17 @@
         <p id="team-vault-message" aria-live="polite">Загрузка Teams…</p>
       </div>
 
+      <div class="team-devices-panel">
+        <div class="team-devices-heading">
+          <div>
+            <h3>Устройства Team-доступа</h3>
+            <p>Перед одобрением сравните SHA-256 отпечаток на обоих устройствах. Отозванное устройство немедленно теряет сессии, а Shared Vaults требуют ротации.</p>
+          </div>
+          <button type="button" class="secondary" id="team-devices-refresh">Обновить устройства</button>
+        </div>
+        <div class="team-devices" id="team-devices"></div>
+      </div>
+
       <div class="team-onboarding">
         <form id="team-create-form">
           <h3>Создать Team</h3>
@@ -231,6 +242,8 @@
               <p id="team-vault-workspace-status" aria-live="polite">Vault заблокирован.</p>
             </div>
             <div class="vault-actions">
+              <button type="button" class="danger" id="team-vault-rotate" hidden>Завершить ротацию</button>
+              <button type="button" class="secondary" id="team-vault-grant-wrappers" hidden>Выдать недостающие wrappers</button>
               <button type="button" id="team-vault-sync">Синхронизировать</button>
               <button type="button" class="secondary" id="team-vault-lock">Заблокировать</button>
             </div>

--- a/cloud/public/styles.css
+++ b/cloud/public/styles.css
@@ -44,6 +44,14 @@ body { margin:0; min-height:100vh; background:radial-gradient(circle at 70% 15%,
 .team-picker.compact { grid-template-columns:auto minmax(160px,1fr) auto; }
 .team-summary { display:flex; align-items:end; justify-content:space-between; gap:24px; margin-top:28px; padding-top:24px; border-top:1px solid var(--line); }
 .team-summary h3,.team-summary p { margin:0; }.team-summary p { color:var(--muted); max-width:580px; line-height:1.55; }
+.team-devices-panel { margin-top:26px; padding:20px; border:1px solid var(--line); border-radius:14px; background:#08110e; }
+.team-devices-heading { display:flex; align-items:start; justify-content:space-between; gap:20px; }
+.team-devices-heading h3,.team-devices-heading p { margin:0; }.team-devices-heading p { margin-top:8px; color:var(--muted); line-height:1.5; max-width:720px; }
+.team-devices { display:grid; gap:10px; margin-top:18px; }
+.team-devices article { display:grid; grid-template-columns:minmax(0,1fr) auto auto; gap:8px 12px; align-items:center; padding:14px; border:1px solid var(--line); border-radius:12px; }
+.team-devices strong,.team-devices small,.team-device-fingerprint { grid-column:1; overflow-wrap:anywhere; }
+.team-devices small,.team-device-fingerprint { color:var(--muted); }.team-device-fingerprint { margin:0; font:12px ui-monospace,monospace; }
+.team-devices button { grid-row:1 / span 3; }.team-devices button.danger { grid-column:3; }
 .team-members { display:grid; gap:10px; margin-bottom:20px; }
 .team-members article { display:grid; grid-template-columns:minmax(0,1fr) auto auto; gap:8px 10px; align-items:center; padding:14px; border:1px solid var(--line); border-radius:12px; }
 .team-members strong,.team-members small { grid-column:1; overflow-wrap:anywhere; }.team-members small { color:var(--muted); }
@@ -72,5 +80,5 @@ body { margin:0; min-height:100vh; background:radial-gradient(circle at 70% 15%,
 .vault-conflicts button:disabled { opacity:.6; cursor:not-allowed; }
 .access { display:flex; justify-content:space-between; gap:40px; align-items:end; padding:34px; border:1px solid var(--line); border-radius:18px; background:#0c1714cc; }.access h2 { margin:8px 0 0; }.access>p { max-width:500px; margin:0; }
 @keyframes spin { to { transform:rotate(360deg); } }
-@media (max-width:760px) { .shell{width:min(100% - 24px,1180px);padding-top:18px}.hero{grid-template-columns:1fr;padding:64px 0;gap:30px}.vault-visual{width:230px}.grid,.cloud-account,.team-onboarding,.team-columns{grid-template-columns:1fr}.vault-heading,.vault-toolbar,.access,.team-summary{align-items:start;flex-direction:column}.vault-actions{justify-content:flex-start}.vault-panel form,.record-form{grid-template-columns:1fr}.vault-panel button,.record-form button{grid-column:1}.vault-records{grid-template-columns:1fr}.team-picker,.team-picker.compact{grid-template-columns:1fr}.team-members article{grid-template-columns:1fr}.team-members strong,.team-members small,.team-members select,.team-members button,.team-members button.danger{grid-column:1;grid-row:auto}.status{font-size:0}.status::after{content:"●";font-size:16px} }
+@media (max-width:760px) { .shell{width:min(100% - 24px,1180px);padding-top:18px}.hero{grid-template-columns:1fr;padding:64px 0;gap:30px}.vault-visual{width:230px}.grid,.cloud-account,.team-onboarding,.team-columns{grid-template-columns:1fr}.vault-heading,.vault-toolbar,.access,.team-summary,.team-devices-heading{align-items:start;flex-direction:column}.vault-actions{justify-content:flex-start}.vault-panel form,.record-form{grid-template-columns:1fr}.vault-panel button,.record-form button{grid-column:1}.vault-records{grid-template-columns:1fr}.team-picker,.team-picker.compact{grid-template-columns:1fr}.team-members article,.team-devices article{grid-template-columns:1fr}.team-members strong,.team-members small,.team-members select,.team-members button,.team-members button.danger,.team-devices strong,.team-devices small,.team-device-fingerprint,.team-devices button,.team-devices button.danger{grid-column:1;grid-row:auto}.status{font-size:0}.status::after{content:"●";font-size:16px} }
 @media (prefers-reduced-motion:reduce) { .orbit{animation:none} }

--- a/cloud/public/team-vault-crypto.js
+++ b/cloud/public/team-vault-crypto.js
@@ -122,6 +122,16 @@ export function normalizeTeamDevicePublicKey(value) {
   return { kty: "EC", crv: "P-256", x: value.x, y: value.y, ext: true, key_ops: [] };
 }
 
+export async function teamDevicePublicKeyFingerprint(value, cryptoValue = globalThis.crypto) {
+  const publicKey = normalizeTeamDevicePublicKey(value);
+  const digest = new Uint8Array(await webCrypto(cryptoValue).subtle.digest(
+    "SHA-256",
+    textEncoder.encode(`selective-remote/team-device-key/v1\0${publicKey.x}\0${publicKey.y}`),
+  ));
+  const hex = [...digest].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+  return hex.match(/.{1,4}/gu).join("-");
+}
+
 export function normalizeTeamVaultScope(value) {
   exactKeys(value, ["teamID", "type", "vaultID"], "invalid_team_vault_scope");
   if (value.type !== "team") throw new Error("invalid_team_vault_scope");

--- a/cloud/public/team-vault-sync.js
+++ b/cloud/public/team-vault-sync.js
@@ -170,6 +170,8 @@ export function createTeamVaultController({
   let vaultKey = null;
   let document = null;
   let pendingConflicts = null;
+  let pendingRotation = null;
+  let pendingGeneration = null;
 
   function requireUnlocked() {
     if (!snapshot || !vaultKey || !document) throw new Error("team_vault_locked");
@@ -183,6 +185,8 @@ export function createTeamVaultController({
 
   async function persist(nextDocument) {
     requireUnlocked();
+    if (pendingRotation) throw new Error("team_vault_rotation_in_progress");
+    if (pendingGeneration) throw new Error("team_vault_generation_conflict");
     const normalizedDocument = validateVaultDocument(nextDocument);
     const envelope = await encryptTeamVaultPayload({
       vaultKey,
@@ -228,6 +232,8 @@ export function createTeamVaultController({
       vaultKey = nextKey;
       document = nextDocument;
       pendingConflicts = null;
+      pendingRotation = null;
+      pendingGeneration = null;
       return clone(document);
     },
 
@@ -236,6 +242,8 @@ export function createTeamVaultController({
       vaultKey = null;
       document = null;
       pendingConflicts = null;
+      pendingRotation = null;
+      pendingGeneration = null;
     },
 
     document() {
@@ -382,6 +390,141 @@ export function createTeamVaultController({
       };
     },
 
+    async prepareWrapper(recipient) {
+      requireUnlocked();
+      if (pendingRotation) throw new Error("team_vault_rotation_in_progress");
+      return wrapTeamVaultKeyForDevice({
+        vaultKey,
+        recipient,
+        ...normalizedScope,
+        keyGeneration: snapshot.keyGeneration,
+        cryptoValue,
+      });
+    },
+
+    async prepareRotation(remote, keyDevices) {
+      if (pendingRotation) throw new Error("team_vault_rotation_in_progress");
+      if (!remote?.rotationRequired || !Number.isSafeInteger(remote.revision) || remote.revision < 1
+        || !Number.isSafeInteger(remote.keyGeneration) || remote.keyGeneration < 1) {
+        throw new Error("team_vault_rotation_not_required");
+      }
+      let status = await this.status();
+      if (status === "locked") {
+        await this.unlock();
+        status = "unlocked";
+      }
+      let currentKey = vaultKey;
+      let localDocument = document;
+      const sourceLocalRevision = snapshot?.localRevision ?? 0;
+      if (status === "unlocked") {
+        if (snapshot.keyGeneration !== remote.keyGeneration) throw new Error("team_vault_generation_changed");
+        if (snapshot.serverRevision > remote.revision) throw new Error("remote_revision_regressed");
+      } else if (status === "empty") {
+        if (!remote.wrapper) throw new Error("team_vault_key_unavailable");
+        currentKey = await unwrapTeamVaultKeyForDevice({
+          privateKey: identity.privateKey,
+          wrapper: remote.wrapper,
+          ...normalizedScope,
+          keyGeneration: remote.keyGeneration,
+          deviceID,
+          cryptoValue,
+        });
+      } else {
+        throw new Error("team_vault_locked");
+      }
+      const encryptedRemote = remoteEnvelope(remote);
+      const remoteDocument = validateVaultDocument(await decryptTeamVaultPayload({
+        vaultKey: currentKey,
+        envelope: encryptedRemote,
+        scope: normalizedScope,
+        cryptoValue,
+      }));
+      let nextDocument = remoteDocument;
+      if (localDocument) {
+        const merged = mergeVaultDocuments(localDocument, remoteDocument);
+        if (merged.conflicts.length > 0) {
+          pendingConflicts = { revision: remote.revision, document: merged.document, conflicts: clone(merged.conflicts) };
+          return { conflicts: clone(merged.conflicts), revision: remote.revision };
+        }
+        nextDocument = merged.document;
+      }
+      if (!Array.isArray(keyDevices) || keyDevices.length === 0) throw new Error("team_key_devices_required");
+      const unique = new Set(keyDevices.map((value) => normalizedUUID(value?.deviceID, "invalid_team_key_devices")));
+      if (unique.size !== keyDevices.length || !unique.has(deviceID)) throw new Error("invalid_team_key_devices");
+      const nextGeneration = remote.keyGeneration + 1;
+      const nextKey = await generateVaultKey(cryptoValue);
+      const wrappers = await Promise.all(keyDevices.map((recipient) => wrapTeamVaultKeyForDevice({
+        vaultKey: nextKey,
+        recipient,
+        ...normalizedScope,
+        keyGeneration: nextGeneration,
+        cryptoValue,
+      })));
+      const currentWrapper = wrappers.find((wrapper) => wrapper.deviceID === deviceID);
+      if (!currentWrapper) throw new Error("team_vault_key_unavailable");
+      const envelope = await encryptTeamVaultPayload({
+        vaultKey: nextKey,
+        payload: nextDocument,
+        scope: normalizedScope,
+        baseRevision: remote.revision,
+        keyGeneration: nextGeneration,
+        wrappers,
+        cryptoValue,
+      });
+      const token = randomUUID();
+      pendingRotation = {
+        token,
+        baseRevision: remote.revision,
+        sourceLocalRevision,
+        keyGeneration: nextGeneration,
+        vaultKey: nextKey,
+        document: nextDocument,
+        uploadEnvelope: envelope,
+        envelope: { ...envelope, wrappers: undefined },
+        wrapper: currentWrapper,
+      };
+      delete pendingRotation.envelope.wrappers;
+      return { token, baseRevision: remote.revision, envelope, keyGeneration: nextGeneration, conflicts: [] };
+    },
+
+    rotationPreparation() {
+      if (!pendingRotation) return null;
+      return {
+        token: pendingRotation.token,
+        baseRevision: pendingRotation.baseRevision,
+        keyGeneration: pendingRotation.keyGeneration,
+        envelope: clone(pendingRotation.uploadEnvelope),
+      };
+    },
+
+    async commitRotation({ token, serverRevision, keyGeneration }) {
+      const prepared = pendingRotation;
+      if (!prepared || prepared.token !== token || prepared.keyGeneration !== keyGeneration
+        || serverRevision !== prepared.baseRevision + 1) {
+        throw new Error("invalid_team_vault_rotation");
+      }
+      const nextLocalRevision = Math.max(1, prepared.sourceLocalRevision + 1);
+      await save({
+        scope: normalizedScope,
+        deviceID,
+        keyGeneration,
+        localRevision: nextLocalRevision,
+        serverRevision,
+        syncedLocalRevision: nextLocalRevision,
+        envelope: prepared.envelope,
+        wrapper: prepared.wrapper,
+      });
+      vaultKey = prepared.vaultKey;
+      document = prepared.document;
+      pendingConflicts = null;
+      pendingRotation = null;
+      return { revision: serverRevision, keyGeneration };
+    },
+
+    cancelRotation(token) {
+      if (pendingRotation?.token === token) pendingRotation = null;
+    },
+
     async markSynced({ serverRevision, localRevision }) {
       requireUnlocked();
       if (!Number.isSafeInteger(serverRevision) || serverRevision < 1
@@ -432,6 +575,63 @@ export function createTeamVaultController({
       return { conflicts: [], matchesRemote, localChanged };
     },
 
+    async mergeRemoteGeneration(remote) {
+      requireUnlocked();
+      if (remote.rotationRequired) throw new Error("team_vault_rotation_required");
+      if (remote.keyGeneration <= snapshot.keyGeneration || remote.revision <= snapshot.serverRevision) {
+        throw new Error("team_vault_generation_changed");
+      }
+      if (!remote.wrapper) throw new Error("team_vault_key_unavailable");
+      const nextKey = await unwrapTeamVaultKeyForDevice({
+        privateKey: identity.privateKey,
+        wrapper: remote.wrapper,
+        ...normalizedScope,
+        keyGeneration: remote.keyGeneration,
+        deviceID,
+        cryptoValue,
+      });
+      const envelope = remoteEnvelope(remote);
+      const remoteDocument = validateVaultDocument(await decryptTeamVaultPayload({
+        vaultKey: nextKey,
+        envelope,
+        scope: normalizedScope,
+        cryptoValue,
+      }));
+      const merged = mergeVaultDocuments(document, remoteDocument);
+      if (merged.conflicts.length > 0) {
+        pendingGeneration = { remote, vaultKey: nextKey, envelope, wrapper: remote.wrapper };
+        pendingConflicts = { revision: remote.revision, document: merged.document, conflicts: clone(merged.conflicts) };
+        return { conflicts: clone(merged.conflicts) };
+      }
+      const matchesRemote = JSON.stringify(merged.document) === JSON.stringify(remoteDocument);
+      const nextLocalRevision = snapshot.localRevision + 1;
+      let nextEnvelope = envelope;
+      if (!matchesRemote) {
+        nextEnvelope = await encryptTeamVaultPayload({
+          vaultKey: nextKey,
+          payload: merged.document,
+          scope: normalizedScope,
+          baseRevision: remote.revision,
+          keyGeneration: remote.keyGeneration,
+          cryptoValue,
+        });
+      }
+      await save({
+        ...snapshot,
+        keyGeneration: remote.keyGeneration,
+        localRevision: nextLocalRevision,
+        serverRevision: remote.revision,
+        syncedLocalRevision: matchesRemote ? nextLocalRevision : snapshot.syncedLocalRevision,
+        envelope: nextEnvelope,
+        wrapper: remote.wrapper,
+      });
+      vaultKey = nextKey;
+      document = merged.document;
+      pendingConflicts = null;
+      pendingGeneration = null;
+      return { conflicts: [], matchesRemote };
+    },
+
     pendingConflicts() {
       requireUnlocked();
       return pendingConflicts ? { revision: pendingConflicts.revision, conflicts: clone(pendingConflicts.conflicts) } : null;
@@ -463,8 +663,32 @@ export function createTeamVaultController({
           resolvedAt: now(),
         });
       }
-      await persist(resolved);
-      await save({ ...snapshot, serverRevision: revision });
+      if (pendingGeneration) {
+        const generation = pendingGeneration;
+        const nextLocalRevision = snapshot.localRevision + 1;
+        const envelope = await encryptTeamVaultPayload({
+          vaultKey: generation.vaultKey,
+          payload: resolved,
+          scope: normalizedScope,
+          baseRevision: revision,
+          keyGeneration: generation.remote.keyGeneration,
+          cryptoValue,
+        });
+        await save({
+          ...snapshot,
+          keyGeneration: generation.remote.keyGeneration,
+          localRevision: nextLocalRevision,
+          serverRevision: revision,
+          envelope,
+          wrapper: generation.wrapper,
+        });
+        vaultKey = generation.vaultKey;
+        document = resolved;
+        pendingGeneration = null;
+      } else {
+        await persist(resolved);
+        await save({ ...snapshot, serverRevision: revision });
+      }
       const count = pendingConflicts?.conflicts.length ?? resolutions.length;
       pendingConflicts = null;
       return { revision, localRevision: snapshot.localRevision, conflictsResolved: count };
@@ -554,8 +778,16 @@ export async function synchronizeTeamVault({ client, controller, role } = {}) {
     await controller.markSynced({ serverRevision: result.revision, localRevision: prepared.localRevision });
     return { status: "initialized", revision: result.revision };
   }
-  if (remote.keyGeneration !== state.keyGeneration) throw new Error("team_vault_generation_changed");
   if (remote.revision < state.serverRevision) throw new Error("remote_revision_regressed");
+  if (remote.keyGeneration < state.keyGeneration) throw new Error("team_vault_generation_changed");
+  if (remote.keyGeneration > state.keyGeneration) {
+    const merged = await controller.mergeRemoteGeneration(remote);
+    if (merged.conflicts.length > 0) {
+      return { status: "conflict", revision: remote.revision, conflicts: merged.conflicts };
+    }
+    if (merged.matchesRemote) return { status: "downloaded", revision: remote.revision };
+    return uploadCurrent({ client, controller, scope, baseRevision: remote.revision });
+  }
   if (remote.revision === state.serverRevision) {
     return state.dirty
       ? uploadCurrent({ client, controller, scope, baseRevision: remote.revision })
@@ -567,4 +799,66 @@ export async function synchronizeTeamVault({ client, controller, role } = {}) {
   }
   if (merged.matchesRemote) return { status: "downloaded", revision: remote.revision };
   return uploadCurrent({ client, controller, scope, baseRevision: remote.revision });
+}
+
+export async function rotateTeamVault({ client, controller, role } = {}) {
+  if (!client?.session()) throw new Error("authentication_required");
+  if (!controller || typeof controller.prepareRotation !== "function") {
+    throw new Error("invalid_team_vault_controller");
+  }
+  if (!["owner", "admin"].includes(role)) throw new Error("team_vault_rotation_forbidden");
+  const scope = controller.scope;
+  const remote = await client.getTeamVault(scope);
+  let prepared = controller.rotationPreparation();
+  if (prepared && !remote.rotationRequired) {
+    if (remote.revision === prepared.baseRevision + 1
+      && remote.keyGeneration === prepared.keyGeneration
+      && remote.contentHash === prepared.envelope.contentHash) {
+      await controller.commitRotation({
+        token: prepared.token,
+        serverRevision: remote.revision,
+        keyGeneration: remote.keyGeneration,
+      });
+      return { status: "rotated", revision: remote.revision, keyGeneration: remote.keyGeneration };
+    }
+    controller.cancelRotation(prepared.token);
+    throw new Error("team_vault_rotation_not_required");
+  }
+  if (!remote.rotationRequired) throw new Error("team_vault_rotation_not_required");
+  if (prepared && (prepared.baseRevision !== remote.revision
+    || prepared.keyGeneration !== remote.keyGeneration + 1)) {
+    controller.cancelRotation(prepared.token);
+    prepared = null;
+  }
+  if (!prepared) {
+    const devices = await client.listTeamKeyDevices(scope);
+    prepared = await controller.prepareRotation(remote, devices.devices);
+    if (prepared.conflicts.length > 0) {
+      return { status: "conflict", revision: prepared.revision, conflicts: prepared.conflicts };
+    }
+  }
+  const result = await client.putTeamVault(
+    scope,
+    prepared.envelope,
+    `web:team:vault:rotate:${prepared.token}`,
+  );
+  if (result.conflict) {
+    controller.cancelRotation(prepared.token);
+    return {
+      status: "remote_changed",
+      remoteRevision: result.revision,
+      keyGeneration: result.keyGeneration,
+    };
+  }
+  if (!result.rotationCompleted || result.revision !== prepared.baseRevision + 1
+    || result.keyGeneration !== prepared.keyGeneration) {
+    controller.cancelRotation(prepared.token);
+    throw new Error("invalid_team_vault_rotation");
+  }
+  await controller.commitRotation({
+    token: prepared.token,
+    serverRevision: result.revision,
+    keyGeneration: result.keyGeneration,
+  });
+  return { status: "rotated", revision: result.revision, keyGeneration: result.keyGeneration };
 }

--- a/cloud/public/vault-sync.js
+++ b/cloud/public/vault-sync.js
@@ -100,9 +100,10 @@ function normalizedTeamKeyDevices(value, scope) {
   exactKeys(value, ["devices"], "invalid_team_key_devices");
   if (!Array.isArray(value.devices) || value.devices.length > 1024) throw new Error("invalid_team_key_devices");
   const devices = value.devices.map((device) => {
-    exactKeys(device, ["deviceID", "membershipEpoch", "membershipID", "publicKey", "publicKeyAlgorithm"], "invalid_team_key_devices");
+    exactKeys(device, ["deviceID", "hasWrapper", "membershipEpoch", "membershipID", "publicKey", "publicKeyAlgorithm"], "invalid_team_key_devices");
     if (device.publicKeyAlgorithm !== teamDevicePublicKeyAlgorithm
-      || !Number.isSafeInteger(device.membershipEpoch) || device.membershipEpoch < 1) {
+      || !Number.isSafeInteger(device.membershipEpoch) || device.membershipEpoch < 1
+      || typeof device.hasWrapper !== "boolean") {
       throw new Error("invalid_team_key_devices");
     }
     return {
@@ -111,6 +112,7 @@ function normalizedTeamKeyDevices(value, scope) {
       deviceID: normalizedUUID(device.deviceID, "invalid_team_key_devices"),
       publicKeyAlgorithm: teamDevicePublicKeyAlgorithm,
       publicKey: normalizeTeamDevicePublicKey(device.publicKey),
+      hasWrapper: device.hasWrapper,
     };
   });
   if (new Set(devices.map((device) => device.deviceID)).size !== devices.length) {
@@ -164,6 +166,42 @@ function normalizedRemoteTeamVault(value, scope) {
     wrapper: value.wrapper === null ? null : normalizedTeamWrapper(value.wrapper),
     createdAt: value.createdAt,
     updatedAt: value.updatedAt,
+  };
+}
+
+function normalizedAccountDevice(value) {
+  exactKeys(value, [
+    "app_version", "created_at", "id", "key_approved_at", "key_registered", "last_seen_at",
+    "name", "platform", "public_key", "public_key_algorithm", "revoked_at",
+  ], "invalid_devices");
+  if (typeof value.key_registered !== "boolean"
+    || (value.key_registered && value.public_key_algorithm !== teamDevicePublicKeyAlgorithm)
+    || (!value.key_registered && (value.public_key !== null || value.public_key_algorithm !== null))
+    || (value.key_approved_at !== null && !value.key_registered)) {
+    throw new Error("invalid_devices");
+  }
+  let publicKey = null;
+  if (value.key_registered) {
+    try {
+      publicKey = normalizeTeamDevicePublicKey(
+        typeof value.public_key === "string" ? JSON.parse(value.public_key) : value.public_key,
+      );
+    } catch {
+      throw new Error("invalid_devices");
+    }
+  }
+  return {
+    id: normalizedUUID(value.id, "invalid_devices"),
+    name: String(value.name ?? ""),
+    platform: String(value.platform ?? ""),
+    appVersion: String(value.app_version ?? ""),
+    createdAt: value.created_at,
+    lastSeenAt: value.last_seen_at,
+    revokedAt: value.revoked_at,
+    keyRegistered: value.key_registered,
+    keyApprovedAt: value.key_approved_at,
+    publicKeyAlgorithm: value.public_key_algorithm,
+    publicKey,
   };
 }
 
@@ -364,6 +402,10 @@ export function createAuthenticatedVaultClient({ fetchValue = globalThis.fetch }
       return user ? structuredClone(user) : null;
     },
 
+    deviceID() {
+      return currentDeviceID;
+    },
+
     async logout() {
       if (!token) return;
       try {
@@ -373,6 +415,22 @@ export function createAuthenticatedVaultClient({ fetchValue = globalThis.fetch }
         user = null;
         currentDeviceID = null;
       }
+    },
+
+    async listDevices() {
+      const response = await authorizedRequest("/v1/devices");
+      const result = await responseJSON(response, "devices_download_failed");
+      if (!response.ok || !Array.isArray(result.devices) || result.devices.length > 1_000) {
+        throw new Error("devices_download_failed");
+      }
+      return result.devices.map(normalizedAccountDevice);
+    },
+
+    async revokeDevice(deviceID) {
+      const normalizedDeviceID = normalizedUUID(deviceID, "invalid_device");
+      const response = await authorizedRequest(`/v1/devices/${normalizedDeviceID}`, { method: "DELETE" });
+      if (response.status !== 204) throw new Error("device_revoke_failed");
+      return { revoked: true, deviceID: normalizedDeviceID };
     },
 
     async listTeams() {

--- a/cloud/src/postgres-store.mjs
+++ b/cloud/src/postgres-store.mjs
@@ -336,7 +336,9 @@ export class PostgresStore {
   async listDevices(userID) {
     const result = await this.pool.query(
       `SELECT id, name, platform, app_version, created_at, last_seen_at, revoked_at,
-         public_key IS NOT NULL AS key_registered, public_key_algorithm, public_key,
+         public_key_algorithm = 'p256-ecdh-v1' AND public_key IS NOT NULL AS key_registered,
+         public_key_algorithm,
+         CASE WHEN public_key_algorithm = 'p256-ecdh-v1' THEN public_key ELSE NULL END AS public_key,
          key_approved_at
        FROM devices WHERE user_id = $1 ORDER BY last_seen_at DESC`,
       [userID],
@@ -344,10 +346,21 @@ export class PostgresStore {
     return result.rows;
   }
 
-  async revokeDevice(userID, deviceID) {
+  async revokeDevice(userID, deviceID, actorDeviceID = null) {
     const client = await this.pool.connect();
     try {
       await client.query("BEGIN");
+      if (actorDeviceID !== null) {
+        const actor = await client.query(
+          `SELECT id FROM devices
+           WHERE id = $1 AND user_id = $2 AND revoked_at IS NULL
+             AND public_key IS NOT NULL AND public_key_algorithm = 'p256-ecdh-v1'
+             AND key_approved_at IS NOT NULL
+           FOR UPDATE`,
+          [actorDeviceID, userID],
+        );
+        if (!actor.rows[0]) throw new Error("device_approval_required");
+      }
       const result = await client.query(
         `UPDATE devices SET revoked_at = now()
          WHERE user_id = $1 AND id = $2 AND revoked_at IS NULL
@@ -831,9 +844,16 @@ export class PostgresStore {
     requireTeamPermission(access.rows[0].role, "manage_vault_keys");
     const result = await this.pool.query(
       `SELECT membership.id AS membership_id, membership.epoch AS membership_epoch,
-         device.id AS device_id, device.public_key_algorithm, device.public_key
+         device.id AS device_id, device.public_key_algorithm, device.public_key,
+         wrapper.device_id IS NOT NULL AS has_wrapper
        FROM team_memberships AS membership
        JOIN devices AS device ON device.user_id = membership.user_id
+       JOIN shared_vaults AS vault ON vault.id = $2 AND vault.team_id = membership.team_id
+         AND vault.archived_at IS NULL
+       LEFT JOIN shared_vault_key_wrappers AS wrapper
+         ON wrapper.vault_id = vault.id AND wrapper.key_generation = vault.key_generation
+         AND wrapper.membership_id = membership.id AND wrapper.membership_epoch = membership.epoch
+         AND wrapper.device_id = device.id
        WHERE membership.team_id = $1 AND membership.revoked_at IS NULL
          AND device.revoked_at IS NULL AND device.key_approved_at IS NOT NULL
          AND device.public_key IS NOT NULL

--- a/cloud/src/postgres-store.mjs
+++ b/cloud/src/postgres-store.mjs
@@ -858,7 +858,7 @@ export class PostgresStore {
          AND device.revoked_at IS NULL AND device.key_approved_at IS NOT NULL
          AND device.public_key IS NOT NULL
        ORDER BY membership.id, device.id`,
-      [teamID],
+      [teamID, vaultID],
     );
     return result.rows;
   }

--- a/cloud/src/server.mjs
+++ b/cloud/src/server.mjs
@@ -129,8 +129,12 @@ async function route(request, response) {
     }
     if (method === "DELETE" && deviceMatch) {
       if (!isUUID(deviceMatch[1])) return sendError(response, 400, "invalid_device");
-      const revoked = await store.revokeDevice(session.user_id, deviceMatch[1]);
-      return revoked ? empty(response, 204) : sendError(response, 404, "device_not_found");
+      try {
+        const revoked = await store.revokeDevice(session.user_id, deviceMatch[1], session.device_id);
+        return revoked ? empty(response, 204) : sendError(response, 404, "device_not_found");
+      } catch (error) {
+        return handleOperationError(response, error);
+      }
     }
     if (method === "GET" && url.pathname === "/v1/vault") {
       return sendJSON(response, 200, await service.getVault(session));

--- a/cloud/src/service.mjs
+++ b/cloud/src/service.mjs
@@ -503,6 +503,7 @@ function publicTeamKeyDevice(row) {
     deviceID: row.device_id,
     publicKeyAlgorithm: row.public_key_algorithm,
     publicKey: JSON.parse(row.public_key),
+    hasWrapper: row.has_wrapper === true,
   };
 }
 

--- a/cloud/tests/public-team-vault-client.test.mjs
+++ b/cloud/tests/public-team-vault-client.test.mjs
@@ -62,6 +62,7 @@ test("authenticated browser client registers its public key and keeps Team reque
         deviceID,
         publicKeyAlgorithm: "p256-ecdh-v1",
         publicKey: identity.publicKey,
+        hasWrapper: true,
       }] });
     }
     if (path === `/v1/teams/${teamID}/vaults/${vaultID}` && !options.method) {
@@ -98,6 +99,7 @@ test("authenticated browser client registers its public key and keeps Team reque
 
   const devices = await client.listTeamKeyDevices(scope);
   assert.equal(devices.devices[0].deviceID, deviceID);
+  assert.equal(devices.devices[0].hasWrapper, true);
   const remote = await client.getTeamVault(scope);
   assert.equal(remote.scope.teamID, teamID);
   assert.equal(remote.wrapper.deviceID, deviceID);
@@ -106,6 +108,49 @@ test("authenticated browser client registers its public key and keeps Team reque
     assert.equal(call.path.includes(teamID), true);
     assert.equal(call.path.includes(vaultID), true);
   }
+});
+
+test("account device transport normalizes approval metadata and revokes without parsing a 204 body", async () => {
+  const { identity } = await fixture();
+  const calls = [];
+  const timestamp = "2026-09-06T00:00:00.000Z";
+  const client = createAuthenticatedVaultClient({
+    fetchValue: async (path, options = {}) => {
+      calls.push({ path, options });
+      if (path === "/v1/auth/login") return jsonResponse(200, {
+        token: "t".repeat(43), user: { id: userID, email: "user@example.invalid", displayName: "User" }, deviceID,
+      });
+      if (path === "/v1/devices") return jsonResponse(200, { devices: [{
+        id: otherDeviceID,
+        name: "New browser",
+        platform: "web",
+        app_version: "0.32",
+        created_at: timestamp,
+        last_seen_at: timestamp,
+        revoked_at: null,
+        key_registered: true,
+        public_key_algorithm: "p256-ecdh-v1",
+        public_key: JSON.stringify(identity.publicKey),
+        key_approved_at: null,
+      }] });
+      if (path === `/v1/devices/${otherDeviceID}` && options.method === "DELETE") {
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`unexpected_request:${path}`);
+    },
+  });
+  await client.login({ email: "user@example.invalid", password: "synthetic-password", deviceID, publicKey: identity.publicKey });
+
+  const devices = await client.listDevices();
+  assert.equal(client.deviceID(), deviceID);
+  assert.equal(devices[0].id, otherDeviceID);
+  assert.deepEqual(devices[0].publicKey, identity.publicKey);
+  assert.equal(devices[0].keyApprovedAt, null);
+  assert.deepEqual(await client.revokeDevice(otherDeviceID), { revoked: true, deviceID: otherDeviceID });
+  const revoke = calls.at(-1);
+  assert.equal(revoke.options.method, "DELETE");
+  assert.match(revoke.options.headers.Authorization, /^Bearer /u);
+  assert.equal(revoke.options.credentials, "omit");
 });
 
 test("Team writes carry idempotency and distinguish conflict from committed rotation", async () => {

--- a/cloud/tests/public-team-vault-crypto.test.mjs
+++ b/cloud/tests/public-team-vault-crypto.test.mjs
@@ -6,6 +6,7 @@ import {
   encryptTeamVaultPayload,
   ensureTeamDeviceIdentity,
   generateTeamDeviceIdentity,
+  teamDevicePublicKeyFingerprint,
   normalizeTeamVaultScope,
   teamVaultWrapperContext,
   teamVaultWrapperContextHash,
@@ -280,6 +281,21 @@ test("client-side rotation moves ciphertext to a new key and excludes the remove
     }),
     /team_vault_wrapper_context_mismatch/,
   );
+});
+
+test("device approval fingerprints are stable, bounded and key-specific", async () => {
+  const identityA = await generateTeamDeviceIdentity(webcrypto);
+  const identityB = await generateTeamDeviceIdentity(webcrypto);
+  const fingerprintA = await teamDevicePublicKeyFingerprint(identityA.publicKey, webcrypto);
+
+  assert.match(fingerprintA, /^(?:[0-9a-f]{4}-){15}[0-9a-f]{4}$/u);
+  assert.equal(await teamDevicePublicKeyFingerprint({
+    y: identityA.publicKey.y,
+    x: identityA.publicKey.x,
+    crv: "P-256",
+    kty: "EC",
+  }, webcrypto), fingerprintA);
+  assert.notEqual(await teamDevicePublicKeyFingerprint(identityB.publicKey, webcrypto), fingerprintA);
 });
 
 test("device identity is generated once and repository persistence never needs an exportable private key", async () => {

--- a/cloud/tests/public-team-vault-sync.test.mjs
+++ b/cloud/tests/public-team-vault-sync.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import { generateTeamDeviceIdentity } from "../public/team-vault-crypto.js";
 import {
   createTeamVaultController,
+  rotateTeamVault,
   synchronizeTeamVault,
 } from "../public/team-vault-sync.js";
 
@@ -42,12 +43,15 @@ async function device(deviceID, membershipID) {
 
 function sharedServer(keyDevices) {
   let revision = 0;
+  let keyGeneration = 1;
+  let rotationRequired = false;
+  let currentKeyDevices = keyDevices;
   let envelope = null;
   let wrappers = new Map();
   function clientFor(deviceID) {
     return {
       session() { return { id: "99999999-9999-4999-8999-999999999999" }; },
-      async listTeamKeyDevices() { return { scope, devices: keyDevices }; },
+      async listTeamKeyDevices() { return { scope, devices: currentKeyDevices }; },
       async getTeamVault() {
         return {
           scope,
@@ -55,8 +59,8 @@ function sharedServer(keyDevices) {
           teamID,
           name: "Operations",
           revision,
-          keyGeneration: 1,
-          rotationRequired: false,
+          keyGeneration,
+          rotationRequired,
           envelopeVersion: envelope?.envelopeVersion ?? null,
           ciphertext: envelope?.ciphertext ?? null,
           nonce: envelope?.nonce ?? null,
@@ -68,16 +72,29 @@ function sharedServer(keyDevices) {
         };
       },
       async putTeamVault(_scope, next) {
-        if (next.baseRevision !== revision) return { conflict: true, revision, keyGeneration: 1 };
+        if (next.baseRevision !== revision) return { conflict: true, revision, keyGeneration };
+        const rotating = rotationRequired;
+        if (rotating && next.keyGeneration !== keyGeneration + 1) throw new Error("invalid_key_generation");
+        if (!rotating && next.keyGeneration !== keyGeneration) throw new Error("invalid_key_generation");
         if (next.wrappers) wrappers = new Map(next.wrappers.map((wrapper) => [wrapper.deviceID, wrapper]));
         envelope = { ...next };
         delete envelope.wrappers;
         revision += 1;
-        return { conflict: false, revision, keyGeneration: 1, rotationCompleted: false };
+        keyGeneration = next.keyGeneration;
+        rotationRequired = false;
+        return { conflict: false, revision, keyGeneration, rotationCompleted: rotating };
       },
     };
   }
-  return { clientFor, revision: () => revision };
+  return {
+    clientFor,
+    revision: () => revision,
+    inspect: () => ({ revision, keyGeneration, rotationRequired, envelope, wrappers: new Map(wrappers) }),
+    requireRotation(nextKeyDevices) {
+      currentKeyDevices = nextKeyDevices;
+      rotationRequired = true;
+    },
+  };
 }
 
 test("a Team Vault initializes for every approved device and persists ciphertext only", async () => {
@@ -269,4 +286,162 @@ test("rotation and unapproved-device states fail closed without replacing local 
     /team_vault_rotation_required/,
   );
   assert.equal(repository.inspect(), null);
+});
+
+test("an Owner rotates atomically for the complete active device set and excludes a revoked device", async () => {
+  const a = await device(deviceA, membershipA);
+  const b = await device(deviceB, membershipB);
+  const server = sharedServer([a.keyDevice, b.keyDevice]);
+  const repositoryA = memoryRepository();
+  const repositoryB = memoryRepository();
+  const controllerA = createTeamVaultController({ repository: repositoryA, identity: a.identity, scope, cryptoValue: webcrypto });
+  const controllerB = createTeamVaultController({ repository: repositoryB, identity: b.identity, scope, cryptoValue: webcrypto });
+
+  await synchronizeTeamVault({ client: server.clientFor(deviceA), controller: controllerA, role: "owner" });
+  await synchronizeTeamVault({ client: server.clientFor(deviceB), controller: controllerB, role: "editor" });
+  await controllerA.upsert({ id: recordID, type: "host", data: { title: "Production", address: "prod.invalid" } });
+  await synchronizeTeamVault({ client: server.clientFor(deviceA), controller: controllerA, role: "owner" });
+  server.requireRotation([a.keyDevice]);
+
+  assert.deepEqual(
+    await rotateTeamVault({ client: server.clientFor(deviceA), controller: controllerA, role: "owner" }),
+    { status: "rotated", revision: 3, keyGeneration: 2 },
+  );
+  assert.equal(repositoryA.inspect().keyGeneration, 2);
+  assert.equal(controllerA.document().records[0].data.title, "Production");
+  assert.doesNotMatch(JSON.stringify(repositoryA.inspect()), /Production|prod\.invalid/u);
+  assert.deepEqual([...server.inspect().wrappers.keys()], [deviceA]);
+  await assert.rejects(
+    synchronizeTeamVault({ client: server.clientFor(deviceB), controller: controllerB, role: "editor" }),
+    /team_vault_key_unavailable/u,
+  );
+  assert.equal(repositoryB.inspect().keyGeneration, 1);
+});
+
+test("competing rotations commit once and never replace the losing local snapshot", async () => {
+  const a = await device(deviceA, membershipA);
+  const b = await device(deviceB, membershipB);
+  const server = sharedServer([a.keyDevice, b.keyDevice]);
+  const repositoryA = memoryRepository();
+  const repositoryB = memoryRepository();
+  const controllerA = createTeamVaultController({ repository: repositoryA, identity: a.identity, scope, cryptoValue: webcrypto });
+  const controllerB = createTeamVaultController({ repository: repositoryB, identity: b.identity, scope, cryptoValue: webcrypto });
+  const stableA = server.clientFor(deviceA);
+  const stableB = server.clientFor(deviceB);
+  await synchronizeTeamVault({ client: stableA, controller: controllerA, role: "owner" });
+  await synchronizeTeamVault({ client: stableB, controller: controllerB, role: "admin" });
+  server.requireRotation([a.keyDevice, b.keyDevice]);
+  let arrivals = 0;
+  let release;
+  const barrier = new Promise((resolve) => { release = resolve; });
+  function racing(client) {
+    return {
+      ...client,
+      async putTeamVault(...args) {
+        arrivals += 1;
+        if (arrivals === 2) release();
+        await barrier;
+        return client.putTeamVault(...args);
+      },
+    };
+  }
+
+  const results = await Promise.all([
+    rotateTeamVault({ client: racing(stableA), controller: controllerA, role: "owner" }),
+    rotateTeamVault({ client: racing(stableB), controller: controllerB, role: "admin" }),
+  ]);
+  assert.deepEqual(results.map((value) => value.status).sort(), ["remote_changed", "rotated"]);
+  const generations = [repositoryA.inspect().keyGeneration, repositoryB.inspect().keyGeneration].sort();
+  assert.deepEqual(generations, [1, 2]);
+  assert.equal(server.inspect().keyGeneration, 2);
+});
+
+test("rotation stops for an explicit causal conflict and resumes only after every choice", async () => {
+  const a = await device(deviceA, membershipA);
+  const b = await device(deviceB, membershipB);
+  const server = sharedServer([a.keyDevice, b.keyDevice]);
+  const controllerA = createTeamVaultController({
+    repository: memoryRepository(), identity: a.identity, scope, cryptoValue: webcrypto,
+    now: () => "2026-09-06T01:00:00.000Z",
+  });
+  const controllerB = createTeamVaultController({
+    repository: memoryRepository(), identity: b.identity, scope, cryptoValue: webcrypto,
+    now: () => "2026-09-06T02:00:00.000Z",
+  });
+  const clientA = server.clientFor(deviceA);
+  const clientB = server.clientFor(deviceB);
+  await synchronizeTeamVault({ client: clientA, controller: controllerA, role: "owner" });
+  await synchronizeTeamVault({ client: clientB, controller: controllerB, role: "admin" });
+  await controllerA.upsert({ id: recordID, type: "host", data: { title: "A", address: "a.invalid" } });
+  await controllerB.upsert({ id: recordID, type: "host", data: { title: "B", address: "b.invalid" } });
+  await synchronizeTeamVault({ client: clientA, controller: controllerA, role: "owner" });
+  server.requireRotation([a.keyDevice, b.keyDevice]);
+
+  const conflict = await rotateTeamVault({ client: clientB, controller: controllerB, role: "admin" });
+  assert.equal(conflict.status, "conflict");
+  assert.equal(conflict.conflicts.length, 1);
+  assert.equal(server.inspect().rotationRequired, true);
+  await controllerB.resolveConflicts({
+    revision: conflict.revision,
+    resolutions: [{ id: recordID, choice: "local" }],
+  });
+  assert.deepEqual(
+    await rotateTeamVault({ client: clientB, controller: controllerB, role: "admin" }),
+    { status: "rotated", revision: 3, keyGeneration: 2 },
+  );
+  assert.equal(controllerB.document().records[0].data.title, "B");
+});
+
+test("a retained device adopts the rotated generation and uploads its causal local changes", async () => {
+  const a = await device(deviceA, membershipA);
+  const b = await device(deviceB, membershipB);
+  const server = sharedServer([a.keyDevice, b.keyDevice]);
+  const controllerA = createTeamVaultController({ repository: memoryRepository(), identity: a.identity, scope, cryptoValue: webcrypto });
+  const repositoryB = memoryRepository();
+  const controllerB = createTeamVaultController({ repository: repositoryB, identity: b.identity, scope, cryptoValue: webcrypto });
+  const clientA = server.clientFor(deviceA);
+  const clientB = server.clientFor(deviceB);
+  await synchronizeTeamVault({ client: clientA, controller: controllerA, role: "owner" });
+  await synchronizeTeamVault({ client: clientB, controller: controllerB, role: "editor" });
+  await controllerB.upsert({ id: recordID, type: "host", data: { title: "Offline", address: "offline.invalid" } });
+  server.requireRotation([a.keyDevice, b.keyDevice]);
+  await rotateTeamVault({ client: clientA, controller: controllerA, role: "owner" });
+
+  assert.deepEqual(
+    await synchronizeTeamVault({ client: clientB, controller: controllerB, role: "editor" }),
+    { status: "uploaded", revision: 3 },
+  );
+  assert.equal(repositoryB.inspect().keyGeneration, 2);
+  assert.equal(controllerB.document().records[0].data.title, "Offline");
+});
+
+test("an unknown network result recovers the exact committed rotation without a second mutation", async () => {
+  const a = await device(deviceA, membershipA);
+  const server = sharedServer([a.keyDevice]);
+  const repository = memoryRepository();
+  const controller = createTeamVaultController({ repository, identity: a.identity, scope, cryptoValue: webcrypto });
+  const stable = server.clientFor(deviceA);
+  await synchronizeTeamVault({ client: stable, controller, role: "owner" });
+  server.requireRotation([a.keyDevice]);
+  let putCalls = 0;
+  const interrupted = {
+    ...stable,
+    async putTeamVault(...args) {
+      putCalls += 1;
+      const result = await stable.putTeamVault(...args);
+      throw Object.assign(new Error("network_interrupted"), { committedResult: result });
+    },
+  };
+
+  await assert.rejects(
+    rotateTeamVault({ client: interrupted, controller, role: "owner" }),
+    /network_interrupted/u,
+  );
+  assert.equal(repository.inspect().keyGeneration, 1);
+  assert.deepEqual(
+    await rotateTeamVault({ client: interrupted, controller, role: "owner" }),
+    { status: "rotated", revision: 2, keyGeneration: 2 },
+  );
+  assert.equal(putCalls, 1);
+  assert.equal(repository.inspect().keyGeneration, 2);
 });

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -98,12 +98,18 @@ test("portal exposes memory-only login and explicit manual synchronization contr
   assert.match(html, /id="team-create-form"/u);
   assert.match(html, /id="team-invitation-accept-form"/u);
   assert.match(html, /id="team-select"/u);
+  assert.match(html, /id="team-devices"/u);
+  assert.match(html, /id="team-vault-rotate"[^>]*hidden/u);
   assert.match(html, /id="team-vault-record-form"/u);
   assert.match(html, /id="team-vault-conflicts-form"/u);
   assert.match(application, /createAuthenticatedVaultClient/u);
   assert.match(application, /synchronizeVault/u);
   assert.match(application, /ensureTeamDeviceIdentity/u);
   assert.match(application, /synchronizeTeamVault/u);
+  assert.match(application, /rotateTeamVault/u);
+  assert.match(application, /teamDevicePublicKeyFingerprint/u);
+  assert.match(application, /client\.approveDeviceKey/u);
+  assert.match(application, /client\.revokeDevice/u);
   assert.match(application, /resolveConflicts/u);
   assert.match(application, /recoveryPassphrase/u);
   assert.doesNotMatch(`${application}\n${synchronization}\n${teamSynchronization}`, /localStorage|sessionStorage/u);

--- a/cloud/tests/team-api-surface.test.mjs
+++ b/cloud/tests/team-api-surface.test.mjs
@@ -26,6 +26,7 @@ test("Team routes are authenticated, explicitly scoped and idempotent", () => {
   assert.match(serverSource, /service\.approveDeviceKey/);
   assert.match(serverSource, /service\.bootstrapDeviceKey/);
   assert.match(serverSource, /service\.grantSharedVaultWrapper/);
+  assert.match(serverSource, /store\.revokeDevice\(session\.user_id, deviceMatch\[1\], session\.device_id\)/);
   assert.ok(serverSource.indexOf('url.pathname === "/v1/devices/bootstrap-key"')
     < serverSource.indexOf("const deviceMatch"));
   assert.match(serverSource, /device_key_bootstrap_user/);

--- a/cloud/tests/team-postgres-store.test.mjs
+++ b/cloud/tests/team-postgres-store.test.mjs
@@ -279,6 +279,23 @@ test("outbox claim uses multi-replica-safe SKIP LOCKED leasing", async () => {
   assert.deepEqual(f.queries[0].parameters, ["claim-owner"]);
 });
 
+test("Team key-device listing binds both the Team and Vault scope", async () => {
+  const f = fixture((sql) => {
+    if (sql.includes("SELECT membership.role")) return { rows: [{ role: "owner" }] };
+    if (sql.includes("wrapper.device_id IS NOT NULL AS has_wrapper")) {
+      return { rows: [{ membership_id: membershipID, device_id: deviceID, has_wrapper: true }] };
+    }
+    return { rows: [] };
+  });
+
+  assert.deepEqual(
+    await f.store.listTeamKeyDevices(teamID, vaultID, actorUserID),
+    [{ membership_id: membershipID, device_id: deviceID, has_wrapper: true }],
+  );
+  assert.deepEqual(f.queries[0].parameters, [teamID, vaultID, actorUserID]);
+  assert.deepEqual(f.queries[1].parameters, [teamID, vaultID]);
+});
+
 test("initial shared ciphertext and the complete device wrapper set commit atomically", async () => {
   const f = fixture((sql) => {
     const reservation = mutationReservation(sql);

--- a/cloud/tests/team-postgres-store.test.mjs
+++ b/cloud/tests/team-postgres-store.test.mjs
@@ -482,6 +482,24 @@ test("only an already-approved account device can approve another public key", a
   assert.equal(f.queries.at(-2).sql, "COMMIT");
 });
 
+test("an unapproved session device cannot revoke another account device", async () => {
+  const targetDeviceID = "aef6452c-1ad8-48bb-b4b5-ea9c207b707b";
+  const f = fixture((sql) => {
+    if (sql.includes("SELECT id FROM devices") && sql.includes("key_approved_at IS NOT NULL")) {
+      return { rows: [] };
+    }
+    return { rows: [], rowCount: 0 };
+  });
+
+  await assert.rejects(
+    f.store.revokeDevice(actorUserID, targetDeviceID, deviceID),
+    /device_approval_required/u,
+  );
+  assert.equal(f.queries.some(({ sql }) => sql.includes("UPDATE devices SET revoked_at")), false);
+  assert.equal(f.queries.at(-2).sql, "ROLLBACK");
+  assert.equal(f.queries.at(-1).sql, "RELEASE");
+});
+
 test("legacy accounts can atomically bootstrap only their first approved Team device", async () => {
   const publicKey = JSON.stringify({
     kty: "EC", crv: "P-256", x: "A".repeat(43), y: "B".repeat(43), ext: true, key_ops: [],

--- a/cloud/tests/team-service.test.mjs
+++ b/cloud/tests/team-service.test.mjs
@@ -144,6 +144,7 @@ class TeamStore {
       device_id: deviceID,
       public_key_algorithm: "p256-ecdh-v1",
       public_key: JSON.stringify({ kty: "EC", crv: "P-256", x: "A".repeat(43), y: "B".repeat(43) }),
+      has_wrapper: true,
     }];
   }
 
@@ -346,6 +347,7 @@ test("Team ciphertext service binds session device, generation and wrapper conte
   );
 
   assert.equal(devices.devices[0].publicKey.crv, "P-256");
+  assert.equal(devices.devices[0].hasWrapper, true);
   assert.equal(vault.wrapper.membershipEpoch, 1);
   for (const call of store.calls.filter(([name]) => [
     "approveDeviceKey", "putSharedVault", "grantSharedVaultWrapper",

--- a/docs/cloud-v0.32-architecture.md
+++ b/docs/cloud-v0.32-architecture.md
@@ -12,8 +12,9 @@ metadata structures, shared ciphertext revisions, approved P-256 devices,
 device-bound wrappers and fail-closed rotation completion plus explicitly
 scoped authenticated routes. The browser has the interoperable Team
 cryptographic/client layer, Team/member/shared-Vault UI and causal shared-record
-orchestration. Explicit new-device approval, rotation-completion UI and the
-macOS implementation remain required milestones within the final 0.32 scope.
+orchestration, fingerprint-confirmed new-device approval/revocation and safe
+rotation completion. The macOS implementation remains a required milestone
+within the final 0.32 scope.
 FIDO2 remains outside the initial 0.32 release scope.
 
 The first production deployment targets:
@@ -171,8 +172,13 @@ complete-set rotation. The browser Team client consumes explicit Team/Vault
 scopes, generates one wrapper per currently approved device, stores only local
 ciphertext and performs the same version-vector/tombstone merge used by the
 personal Vault. Concurrent entities require explicit choices and revocation
-states freeze writes. Rotation completion remains a separate required client
-milestone; the current UI never weakens the server's fail-closed gate.
+states freeze writes. Owner/Admin rotation prepares the next-generation key,
+complete wrapper set and full ciphertext in memory, then changes the local
+snapshot only after the conditional server commit. Competing rotation conflicts
+and unknown network outcomes preserve the previous local snapshot; the latter
+is accepted locally only after the exact committed content hash, generation and
+revision are observed. Retained devices can merge offline causal changes after
+adopting their new-generation wrapper.
 
 The mandatory role matrix, invitation lifecycle, device-bound key
 distribution, membership epochs and fail-closed rotation protocol are defined

--- a/docs/cloud-v0.32-team-threat-model.md
+++ b/docs/cloud-v0.32-team-threat-model.md
@@ -5,8 +5,9 @@ Durable Teams, memberships, four-role checks, membership epochs, hash-only
 invitations, encrypted outbox delivery, audit events, idempotency receipts and
 shared-Vault metadata, shared ciphertext revisions, approved P-256 devices,
 per-device wrappers and atomic rotation completion are present. The browser has
-Team/member/shared-Vault UI, non-exportable device keys and causal shared-record
-synchronization. Browser approval/rotation UI and the macOS client remain.
+Team/member/shared-Vault UI, non-exportable device keys, fingerprint-confirmed
+device approval/revocation, causal shared-record synchronization and atomic
+rotation completion. The macOS client and cross-client acceptance remain.
 
 ## Security outcome
 
@@ -206,6 +207,6 @@ or wrappers.
   present.
 
 Team/shared Vault release status remains `planned_required`: the server-side
-protocol and browser Team UI/cryptography/causal sync are implemented, but
-browser approval/rotation completion, macOS interoperability and the complete
+protocol and browser Team UI/cryptography/causal sync/device approval/rotation
+completion are implemented, but macOS interoperability and the complete
 acceptance suite must pass before Cloud 0.32 is complete.


### PR DESCRIPTION
## Summary

- add canonical SHA-256 P-256 device fingerprints and the browser account-device approval/revocation flow
- let Owner/Admin grant missing current-generation wrappers locally without sending plaintext
- add fail-closed client-side Team Vault rotation with exact active-device wrapper coverage
- preserve the losing local snapshot on competing writes and reconcile unknown network outcomes by exact revision, generation, and content hash
- let retained devices adopt a committed generation and merge offline causal changes safely
- document the browser security boundary and remaining macOS interoperability milestone

## Security invariants

- password login alone cannot approve a Team device key
- revocation is authorized by the active approved P-256 session device
- Vault plaintext and raw keys remain client-side/in memory
- rotation uploads are atomic and conditional; partial or stale rotations fail closed
- revoked devices receive no new-generation wrapper
- concurrent record/tombstone conflicts require an explicit local choice

## Verification

- `npm test`: 220 tests, 219 passed, 1 skipped locally (PostgreSQL integration requires `TEST_DATABASE_URL` and runs in CI)
- `npm audit --omit=dev`: 0 vulnerabilities
- `node --check` on touched JavaScript/ESM files
- `git diff --check`
- repository secret scan: only the synthetic test password matched

## Scope boundary

This completes the browser-side device approval/revocation, wrapper grant, and safe Team Vault rotation milestone. macOS parity and cross-client acceptance remain separate work. Closed staging is unchanged; registration remains disabled.