### PR TITLE
Cloud: add macOS session and Team crypto foundation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,8 @@ let package = Package(
         .testTarget(
             name: "SelectiveRemoteTests",
             dependencies: ["SelectiveRemote"],
-            path: "Tests/SelectiveRemoteTests"
+            path: "Tests/SelectiveRemoteTests",
+            resources: [.copy("Fixtures")]
         )
     ]
 )

--- a/Sources/SelectiveRemote/CloudAPIClient.swift
+++ b/Sources/SelectiveRemote/CloudAPIClient.swift
@@ -3,6 +3,8 @@ import Foundation
 enum SelectiveRemoteCloudError: LocalizedError, Equatable {
     case invalidEndpoint
     case insecureEndpoint
+    case invalidRequest
+    case authenticationRequired
     case invalidResponse
     case serviceError(Int, String?)
     case incompatibleAPI(Int)
@@ -18,6 +20,16 @@ enum SelectiveRemoteCloudError: LocalizedError, Equatable {
             UpdateLocalization.text(
                 ru: "Для Cloud требуется HTTPS. HTTP разрешён только для localhost.",
                 en: "Cloud requires HTTPS. HTTP is allowed only for localhost."
+            )
+        case .invalidRequest:
+            UpdateLocalization.text(
+                ru: "Проверьте данные аккаунта и этого Mac.",
+                en: "Check the account and this Mac's details."
+            )
+        case .authenticationRequired:
+            UpdateLocalization.text(
+                ru: "Сессия Cloud завершена. Войдите снова.",
+                en: "The Cloud session ended. Sign in again."
             )
         case .invalidResponse:
             UpdateLocalization.text(
@@ -44,6 +56,53 @@ struct SelectiveRemoteCloudMetadata: Codable, Equatable, Sendable {
     var registrationEnabled: Bool
 }
 
+struct SelectiveRemoteCloudUser: Codable, Equatable, Sendable {
+    var id: UUID
+    var email: String
+    var displayName: String
+}
+
+enum SelectiveRemoteCloudTeamRole: String, Codable, Equatable, Sendable {
+    case owner
+    case admin
+    case editor
+    case viewer
+}
+
+struct SelectiveRemoteCloudTeam: Codable, Equatable, Sendable {
+    var id: UUID
+    var name: String
+    var membershipID: UUID
+    var role: SelectiveRemoteCloudTeamRole
+    var membershipEpoch: Int
+    var createdAt: String
+    var updatedAt: String
+}
+
+struct SelectiveRemoteCloudDeviceRegistration: Codable, Equatable, Sendable {
+    var id: UUID
+    var name: String
+    var platform: String
+    var appVersion: String
+    var publicKey: SelectiveRemoteTeamDevicePublicKey?
+
+    static func thisMac(
+        id: UUID,
+        name: String = Host.current().localizedName ?? "Mac",
+        publicKey: SelectiveRemoteTeamDevicePublicKey? = nil
+    ) -> Self {
+        Self(
+            id: id,
+            name: name,
+            platform: "macos",
+            appVersion: AppBuildInfo.version,
+            publicKey: publicKey
+        )
+    }
+}
+
+typealias SelectiveRemoteCloudDataLoader = @Sendable (URLRequest) async throws -> (Data, URLResponse)
+
 enum SelectiveRemoteCloudEndpoint {
     static let production = "https://cloud.pastfly.ru"
 
@@ -56,6 +115,7 @@ enum SelectiveRemoteCloudEndpoint {
               !host.isEmpty,
               url.user == nil,
               url.password == nil,
+              url.path.isEmpty || url.path == "/",
               url.query == nil,
               url.fragment == nil
         else { throw SelectiveRemoteCloudError.invalidEndpoint }
@@ -68,12 +128,21 @@ enum SelectiveRemoteCloudEndpoint {
     }
 }
 
-final class SelectiveRemoteCloudAPIClient: @unchecked Sendable {
-    private let session: URLSession
+actor SelectiveRemoteCloudAPIClient {
+    private let dataLoader: SelectiveRemoteCloudDataLoader
+    private let tokenStore: any SelectiveRemoteCloudTokenStore
     private let decoder = JSONDecoder()
+    private let encoder = JSONEncoder()
 
-    init(session: URLSession = .shared) {
-        self.session = session
+    init(
+        session: URLSession = .shared,
+        tokenStore: any SelectiveRemoteCloudTokenStore = SelectiveRemoteCloudKeychainTokenStore(),
+        dataLoader: SelectiveRemoteCloudDataLoader? = nil
+    ) {
+        self.tokenStore = tokenStore
+        self.dataLoader = dataLoader ?? { request in
+            try await session.data(for: request)
+        }
     }
 
     func metadata(endpoint: URL) async throws -> SelectiveRemoteCloudMetadata {
@@ -82,9 +151,10 @@ final class SelectiveRemoteCloudAPIClient: @unchecked Sendable {
         request.timeoutInterval = 12
         request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
         request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("no-store", forHTTPHeaderField: "Cache-Control")
         request.setValue("SelectiveRemote/\(AppBuildInfo.version)", forHTTPHeaderField: "User-Agent")
 
-        let (data, response) = try await session.data(for: request)
+        let (data, response) = try await dataLoader(request)
         guard let http = response as? HTTPURLResponse else {
             throw SelectiveRemoteCloudError.invalidResponse
         }
@@ -100,6 +170,171 @@ final class SelectiveRemoteCloudAPIClient: @unchecked Sendable {
         }
         return metadata
     }
+
+    func hasStoredSession(endpoint: URL) -> Bool {
+        (try? storedToken(for: endpoint)) != nil
+    }
+
+    func login(
+        endpoint: URL,
+        email: String,
+        password: String,
+        device: SelectiveRemoteCloudDeviceRegistration
+    ) async throws -> SelectiveRemoteCloudUser {
+        let normalizedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedName = device.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedEmail.isEmpty, normalizedEmail.count <= 254,
+              password.count >= 12, password.count <= 1_024,
+              !normalizedName.isEmpty, normalizedName.count <= 120,
+              !device.platform.isEmpty, device.platform.count <= 80,
+              device.appVersion.count <= 40
+        else { throw SelectiveRemoteCloudError.invalidRequest }
+
+        let body = LoginRequest(
+            email: normalizedEmail,
+            password: password,
+            device: .init(
+                id: device.id,
+                name: normalizedName,
+                platform: device.platform,
+                appVersion: device.appVersion,
+                publicKey: device.publicKey
+            )
+        )
+        var request = JSONRequest(
+            url: endpoint.appending(path: "v1/auth/login"),
+            method: "POST",
+            body: try encoder.encode(body)
+        ).value
+        request.timeoutInterval = 20
+        let (data, response) = try await dataLoader(request)
+        let http = try httpResponse(response)
+        guard (200..<300).contains(http.statusCode) else {
+            throw serviceError(status: http.statusCode, data: data)
+        }
+        guard let result = try? decoder.decode(LoginResponse.self, from: data),
+              (32...256).contains(result.token.count),
+              result.deviceID == device.id
+        else { throw SelectiveRemoteCloudError.invalidResponse }
+        try tokenStore.saveToken(result.token, for: endpoint)
+        return result.user
+    }
+
+    func currentUser(endpoint: URL) async throws -> SelectiveRemoteCloudUser {
+        let data = try await authorizedData(endpoint: endpoint, path: "v1/me")
+        guard let user = try? decoder.decode(SelectiveRemoteCloudUser.self, from: data) else {
+            throw SelectiveRemoteCloudError.invalidResponse
+        }
+        return user
+    }
+
+    func teams(endpoint: URL) async throws -> [SelectiveRemoteCloudTeam] {
+        let data = try await authorizedData(endpoint: endpoint, path: "v1/teams")
+        guard let result = try? decoder.decode(TeamsResponse.self, from: data),
+              result.teams.count <= 1_000,
+              result.teams.allSatisfy({ $0.membershipEpoch > 0 && !$0.name.isEmpty })
+        else { throw SelectiveRemoteCloudError.invalidResponse }
+        return result.teams
+    }
+
+    func logout(endpoint: URL) async throws {
+        guard let token = try storedToken(for: endpoint) else { return }
+        var request = JSONRequest(
+            url: endpoint.appending(path: "v1/auth/logout"),
+            method: "POST",
+            body: nil
+        ).value
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        do {
+            let (data, response) = try await dataLoader(request)
+            let http = try httpResponse(response)
+            guard http.statusCode == 204 || http.statusCode == 401 else {
+                throw serviceError(status: http.statusCode, data: data)
+            }
+        } catch {
+            try? tokenStore.removeToken(for: endpoint)
+            throw error
+        }
+        try tokenStore.removeToken(for: endpoint)
+    }
+
+    private func authorizedData(endpoint: URL, path: String) async throws -> Data {
+        guard let token = try storedToken(for: endpoint) else {
+            throw SelectiveRemoteCloudError.authenticationRequired
+        }
+        var request = JSONRequest(
+            url: endpoint.appending(path: path),
+            method: "GET",
+            body: nil
+        ).value
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        let (data, response) = try await dataLoader(request)
+        let http = try httpResponse(response)
+        if http.statusCode == 401 {
+            try? tokenStore.removeToken(for: endpoint)
+            throw SelectiveRemoteCloudError.authenticationRequired
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw serviceError(status: http.statusCode, data: data)
+        }
+        return data
+    }
+
+    private func storedToken(for endpoint: URL) throws -> String? {
+        guard let token = try tokenStore.token(for: endpoint) else { return nil }
+        guard (32...256).contains(token.count) else {
+            try tokenStore.removeToken(for: endpoint)
+            return nil
+        }
+        return token
+    }
+
+    private func httpResponse(_ response: URLResponse) throws -> HTTPURLResponse {
+        guard let response = response as? HTTPURLResponse else {
+            throw SelectiveRemoteCloudError.invalidResponse
+        }
+        return response
+    }
+
+    private func serviceError(status: Int, data: Data) -> SelectiveRemoteCloudError {
+        let service = try? decoder.decode(CloudServiceError.self, from: data)
+        return .serviceError(status, service?.error)
+    }
+}
+
+private struct JSONRequest {
+    var value: URLRequest
+
+    init(url: URL, method: String, body: Data?) {
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.timeoutInterval = 20
+        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("no-store", forHTTPHeaderField: "Cache-Control")
+        request.setValue("SelectiveRemote/\(AppBuildInfo.version)", forHTTPHeaderField: "User-Agent")
+        if let body {
+            request.httpBody = body
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        value = request
+    }
+}
+
+private struct LoginRequest: Encodable {
+    var email: String
+    var password: String
+    var device: SelectiveRemoteCloudDeviceRegistration
+}
+
+private struct LoginResponse: Decodable {
+    var token: String
+    var user: SelectiveRemoteCloudUser
+    var deviceID: UUID
+}
+
+private struct TeamsResponse: Decodable {
+    var teams: [SelectiveRemoteCloudTeam]
 }
 
 private struct CloudServiceError: Decodable {

--- a/Sources/SelectiveRemote/CloudSessionStore.swift
+++ b/Sources/SelectiveRemote/CloudSessionStore.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Security
+
+protocol SelectiveRemoteCloudTokenStore: Sendable {
+    func token(for endpoint: URL) throws -> String?
+    func saveToken(_ token: String, for endpoint: URL) throws
+    func removeToken(for endpoint: URL) throws
+}
+
+struct SelectiveRemoteCloudKeychainTokenStore: SelectiveRemoteCloudTokenStore {
+    static let service = "local.selectiveremote.cloud.session.v1"
+
+    func token(for endpoint: URL) throws -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.service,
+            kSecAttrAccount as String: account(for: endpoint),
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound { return nil }
+        guard status == errSecSuccess else { throw KeychainError.unexpectedStatus(status) }
+        guard let data = result as? Data,
+              let token = String(data: data, encoding: .utf8)
+        else { throw KeychainError.invalidData }
+        return token
+    }
+
+    func saveToken(_ token: String, for endpoint: URL) throws {
+        guard let data = token.data(using: .utf8) else { throw KeychainError.invalidData }
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.service,
+            kSecAttrAccount as String: account(for: endpoint)
+        ]
+        let updateStatus = SecItemUpdate(
+            query as CFDictionary,
+            [kSecValueData as String: data] as CFDictionary
+        )
+        if updateStatus == errSecSuccess { return }
+        guard updateStatus == errSecItemNotFound else {
+            throw KeychainError.unexpectedStatus(updateStatus)
+        }
+        var addition = query
+        addition[kSecValueData as String] = data
+        addition[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        let addStatus = SecItemAdd(addition as CFDictionary, nil)
+        guard addStatus == errSecSuccess else { throw KeychainError.unexpectedStatus(addStatus) }
+    }
+
+    func removeToken(for endpoint: URL) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.service,
+            kSecAttrAccount as String: account(for: endpoint)
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+
+    private func account(for endpoint: URL) -> String {
+        endpoint.absoluteString
+    }
+}
+
+final class SelectiveRemoteCloudMemoryTokenStore: SelectiveRemoteCloudTokenStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var tokens: [String: String] = [:]
+
+    func token(for endpoint: URL) -> String? {
+        lock.withLock { tokens[endpoint.absoluteString] }
+    }
+
+    func saveToken(_ token: String, for endpoint: URL) {
+        lock.withLock { tokens[endpoint.absoluteString] = token }
+    }
+
+    func removeToken(for endpoint: URL) {
+        lock.withLock { tokens.removeValue(forKey: endpoint.absoluteString) }
+    }
+}

--- a/Sources/SelectiveRemote/CloudTeamCrypto.swift
+++ b/Sources/SelectiveRemote/CloudTeamCrypto.swift
@@ -1,0 +1,201 @@
+import CryptoKit
+import Foundation
+
+enum SelectiveRemoteTeamCryptoError: Error, Equatable {
+    case invalidPublicKey
+    case invalidGeneration
+    case invalidEnvelope
+}
+
+struct SelectiveRemoteTeamDevicePublicKey: Codable, Equatable, Sendable {
+    let kty: String
+    let crv: String
+    let x: String
+    let y: String
+    let ext: Bool
+    let keyOps: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case kty, crv, x, y, ext
+        case keyOps = "key_ops"
+    }
+
+    init(x: String, y: String) throws {
+        guard let xData = Data(selectiveRemoteBase64URL: x, expectedLength: 32),
+              let yData = Data(selectiveRemoteBase64URL: y, expectedLength: 32)
+        else { throw SelectiveRemoteTeamCryptoError.invalidPublicKey }
+        let representation = Data([0x04]) + xData + yData
+        guard (try? P256.KeyAgreement.PublicKey(x963Representation: representation)) != nil else {
+            throw SelectiveRemoteTeamCryptoError.invalidPublicKey
+        }
+        self.kty = "EC"
+        self.crv = "P-256"
+        self.x = x
+        self.y = y
+        self.ext = true
+        self.keyOps = []
+    }
+
+    init(from decoder: any Decoder) throws {
+        let actualKeys = try decoder.container(keyedBy: SelectiveRemoteAnyCodingKey.self)
+            .allKeys.map(\.stringValue).sorted()
+        guard actualKeys == ["crv", "ext", "key_ops", "kty", "x", "y"] else {
+            throw SelectiveRemoteTeamCryptoError.invalidPublicKey
+        }
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        let kty = try values.decode(String.self, forKey: .kty)
+        let crv = try values.decode(String.self, forKey: .crv)
+        let x = try values.decode(String.self, forKey: .x)
+        let y = try values.decode(String.self, forKey: .y)
+        let ext = try values.decode(Bool.self, forKey: .ext)
+        let keyOps = try values.decode([String].self, forKey: .keyOps)
+        guard kty == "EC", crv == "P-256", ext, keyOps.isEmpty else {
+            throw SelectiveRemoteTeamCryptoError.invalidPublicKey
+        }
+        try self.init(x: x, y: y)
+    }
+}
+
+struct SelectiveRemoteTeamWrapperContext: Equatable, Sendable {
+    let teamID: UUID
+    let vaultID: UUID
+    let keyGeneration: Int
+    let membershipID: UUID
+    let membershipEpoch: Int
+    let deviceID: UUID
+
+    init(
+        teamID: UUID,
+        vaultID: UUID,
+        keyGeneration: Int,
+        membershipID: UUID,
+        membershipEpoch: Int,
+        deviceID: UUID
+    ) throws {
+        guard teamID.isSelectiveRemoteCloudUUID,
+              vaultID.isSelectiveRemoteCloudUUID,
+              membershipID.isSelectiveRemoteCloudUUID,
+              deviceID.isSelectiveRemoteCloudUUID,
+              keyGeneration > 0,
+              membershipEpoch > 0
+        else {
+            throw SelectiveRemoteTeamCryptoError.invalidGeneration
+        }
+        self.teamID = teamID
+        self.vaultID = vaultID
+        self.keyGeneration = keyGeneration
+        self.membershipID = membershipID
+        self.membershipEpoch = membershipEpoch
+        self.deviceID = deviceID
+    }
+}
+
+enum SelectiveRemoteTeamVaultCrypto {
+    static let wrapperContextLabel = "selective-remote/team-vault-wrapper/v1"
+    static let wrapperKeyInfo = "selective-remote/team-vault-wrapper-key/v1"
+    static let payloadContextLabel = "selective-remote/team-vault-payload/v1"
+    static let envelopeVersion: UInt8 = 1
+
+    static func deviceFingerprint(_ key: SelectiveRemoteTeamDevicePublicKey) -> String {
+        let canonical = "selective-remote/team-device-key/v1\0\(key.x)\0\(key.y)"
+        let digest = SHA256.hash(data: Data(canonical.utf8))
+        return stride(from: 0, to: digest.count, by: 2).map { offset in
+            digest[offset..<min(offset + 2, digest.count)].map { String(format: "%02x", $0) }.joined()
+        }.joined(separator: "-")
+    }
+
+    static func wrapperContext(_ value: SelectiveRemoteTeamWrapperContext) -> Data {
+        Data([
+            wrapperContextLabel,
+            value.teamID.canonicalCloudString,
+            value.vaultID.canonicalCloudString,
+            String(value.keyGeneration),
+            value.membershipID.canonicalCloudString,
+            String(value.membershipEpoch),
+            value.deviceID.canonicalCloudString
+        ].joined(separator: "\0").utf8)
+    }
+
+    static func wrapperContextHash(_ value: SelectiveRemoteTeamWrapperContext) -> String {
+        Data(SHA256.hash(data: wrapperContext(value))).selectiveRemoteBase64URL
+    }
+
+    static func payloadContext(teamID: UUID, vaultID: UUID, keyGeneration: Int) throws -> Data {
+        guard teamID.isSelectiveRemoteCloudUUID,
+              vaultID.isSelectiveRemoteCloudUUID,
+              keyGeneration > 0
+        else { throw SelectiveRemoteTeamCryptoError.invalidGeneration }
+        return Data([
+            payloadContextLabel,
+            teamID.canonicalCloudString,
+            vaultID.canonicalCloudString,
+            String(keyGeneration)
+        ].joined(separator: "\0").utf8)
+    }
+
+    static func payloadContentHash(
+        teamID: UUID,
+        vaultID: UUID,
+        keyGeneration: Int,
+        nonce: String,
+        ciphertext: String,
+        authTag: String
+    ) throws -> String {
+        guard let nonceData = Data(selectiveRemoteBase64URL: nonce, expectedLength: 12),
+              let ciphertextData = Data(selectiveRemoteBase64URL: ciphertext),
+              ciphertextData.count <= 24 * 1024 * 1024,
+              let authTagData = Data(selectiveRemoteBase64URL: authTag, expectedLength: 16)
+        else { throw SelectiveRemoteTeamCryptoError.invalidEnvelope }
+        let context = try payloadContext(teamID: teamID, vaultID: vaultID, keyGeneration: keyGeneration)
+        let bytes = Data([envelopeVersion]) + context + nonceData + ciphertextData + authTagData
+        return Data(SHA256.hash(data: bytes)).selectiveRemoteBase64URL
+    }
+}
+
+private extension UUID {
+    var canonicalCloudString: String { uuidString.lowercased() }
+
+    var isSelectiveRemoteCloudUUID: Bool {
+        let value = Array(canonicalCloudString)
+        guard value.count == 36 else { return false }
+        return "12345678".contains(value[14])
+            && "89ab".contains(value[19])
+    }
+}
+
+private struct SelectiveRemoteAnyCodingKey: CodingKey {
+    var stringValue: String
+    var intValue: Int?
+
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+    }
+
+    init?(intValue: Int) {
+        self.stringValue = String(intValue)
+        self.intValue = intValue
+    }
+}
+
+private extension Data {
+    init?(selectiveRemoteBase64URL value: String, expectedLength: Int? = nil) {
+        guard !value.isEmpty,
+              value.range(of: "^[A-Za-z0-9_-]+$", options: .regularExpression) != nil
+        else { return nil }
+        var base64 = value.replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        base64 += String(repeating: "=", count: (4 - base64.count % 4) % 4)
+        guard let decoded = Data(base64Encoded: base64),
+              decoded.selectiveRemoteBase64URL == value,
+              expectedLength.map({ decoded.count == $0 }) ?? true
+        else { return nil }
+        self = decoded
+    }
+
+    var selectiveRemoteBase64URL: String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/Sources/SelectiveRemote/CloudTeamCrypto.swift
+++ b/Sources/SelectiveRemote/CloudTeamCrypto.swift
@@ -98,7 +98,7 @@ enum SelectiveRemoteTeamVaultCrypto {
 
     static func deviceFingerprint(_ key: SelectiveRemoteTeamDevicePublicKey) -> String {
         let canonical = "selective-remote/team-device-key/v1\0\(key.x)\0\(key.y)"
-        let digest = SHA256.hash(data: Data(canonical.utf8))
+        let digest = Array(SHA256.hash(data: Data(canonical.utf8)))
         return stride(from: 0, to: digest.count, by: 2).map { offset in
             digest[offset..<min(offset + 2, digest.count)].map { String(format: "%02x", $0) }.joined()
         }.joined(separator: "-")

--- a/Tests/SelectiveRemoteTests/CloudFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudFoundationTests.swift
@@ -27,6 +27,13 @@ struct CloudFoundationTests {
         }
     }
 
+    @Test("Endpoints cannot smuggle an API path")
+    func rejectsEndpointPath() {
+        #expect(throws: SelectiveRemoteCloudError.invalidEndpoint) {
+            try SelectiveRemoteCloudEndpoint.normalized("https://cloud.pastfly.ru/untrusted")
+        }
+    }
+
     @Test("Cloud metadata matches API v1 contract")
     func decodesMetadata() throws {
         let data = Data(#"{"apiVersion":1,"vaultSchemaVersion":1,"registrationEnabled":false}"#.utf8)

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -1,0 +1,209 @@
+import Foundation
+import Testing
+@testable import SelectiveRemote
+
+@Suite("macOS Cloud session and Team crypto foundation")
+struct CloudMacOSFoundationTests {
+    @Test("login keeps the bearer token in the session store and authenticates later requests")
+    func authenticatedFoundation() async throws {
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized("https://cloud.example.invalid")
+        let deviceID = try #require(UUID(uuidString: "44444444-4444-4444-8444-444444444444"))
+        let userID = try #require(UUID(uuidString: "66666666-6666-4666-8666-666666666666"))
+        let membershipID = try #require(UUID(uuidString: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"))
+        let teamID = try #require(UUID(uuidString: "11111111-1111-4111-8111-111111111111"))
+        let token = String(repeating: "t", count: 43)
+        let store = SelectiveRemoteCloudMemoryTokenStore()
+        let stub = CloudHTTPStub { request in
+            switch (request.httpMethod, request.url?.path) {
+            case ("POST", "/v1/auth/login"):
+                let body = try #require(request.httpBody)
+                let object = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+                #expect(object["password"] as? String == "synthetic-password")
+                return Self.response(request, status: 200, json: [
+                    "token": token,
+                    "user": ["id": userID.uuidString.lowercased(), "email": "user@example.invalid", "displayName": "User"],
+                    "deviceID": deviceID.uuidString.lowercased()
+                ])
+            case ("GET", "/v1/me"):
+                #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer \(token)")
+                return Self.response(request, status: 200, json: [
+                    "id": userID.uuidString.lowercased(), "email": "user@example.invalid", "displayName": "User"
+                ])
+            case ("GET", "/v1/teams"):
+                #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer \(token)")
+                return Self.response(request, status: 200, json: ["teams": [[
+                    "id": teamID.uuidString.lowercased(),
+                    "name": "Platform",
+                    "membershipID": membershipID.uuidString.lowercased(),
+                    "role": "owner",
+                    "membershipEpoch": 3,
+                    "createdAt": "2026-09-06T00:00:00.000Z",
+                    "updatedAt": "2026-09-06T00:00:00.000Z"
+                ]]])
+            case ("POST", "/v1/auth/logout"):
+                #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer \(token)")
+                return Self.response(request, status: 204, json: nil)
+            default:
+                Issue.record("Unexpected request: \(request.httpMethod ?? "nil") \(request.url?.path ?? "nil")")
+                return Self.response(request, status: 500, json: ["error": "unexpected_request"])
+            }
+        }
+        let client = SelectiveRemoteCloudAPIClient(
+            tokenStore: store,
+            dataLoader: { request in try stub.data(for: request) }
+        )
+
+        let user = try await client.login(
+            endpoint: endpoint,
+            email: " user@example.invalid ",
+            password: "synthetic-password",
+            device: .thisMac(id: deviceID, name: "Synthetic Mac")
+        )
+        #expect(user == SelectiveRemoteCloudUser(id: userID, email: "user@example.invalid", displayName: "User"))
+        #expect(try store.token(for: endpoint) == token)
+        #expect(try await client.currentUser(endpoint: endpoint) == user)
+        let teams = try await client.teams(endpoint: endpoint)
+        #expect(teams.count == 1)
+        #expect(teams[0].role == .owner)
+        #expect(teams[0].membershipEpoch == 3)
+        try await client.logout(endpoint: endpoint)
+        #expect(try store.token(for: endpoint) == nil)
+    }
+
+    @Test("a 401 response deletes the stored macOS Cloud session")
+    func unauthorizedClearsSession() async throws {
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized("https://cloud.example.invalid")
+        let store = SelectiveRemoteCloudMemoryTokenStore()
+        try store.saveToken(String(repeating: "t", count: 43), for: endpoint)
+        let client = SelectiveRemoteCloudAPIClient(
+            tokenStore: store,
+            dataLoader: { request in Self.response(request, status: 401, json: ["error": "unauthorized"]) }
+        )
+        await #expect(throws: SelectiveRemoteCloudError.authenticationRequired) {
+            try await client.currentUser(endpoint: endpoint)
+        }
+        #expect(try store.token(for: endpoint) == nil)
+    }
+
+    @Test("browser and macOS use the same P-256 fingerprint and Team envelope context")
+    func sharedCryptoFixture() throws {
+        let url = try #require(Bundle.module.url(
+            forResource: "team-vault-v1",
+            withExtension: "json",
+            subdirectory: "Fixtures"
+        ))
+        let fixture = try JSONDecoder().decode(TeamVaultFixture.self, from: Data(contentsOf: url))
+        #expect(fixture.version == 1)
+        #expect(SelectiveRemoteTeamVaultCrypto.deviceFingerprint(fixture.publicKey) == fixture.fingerprint)
+
+        let wrapper = try SelectiveRemoteTeamWrapperContext(
+            teamID: try fixture.wrapper.teamID.uuid,
+            vaultID: try fixture.wrapper.vaultID.uuid,
+            keyGeneration: fixture.wrapper.keyGeneration,
+            membershipID: try fixture.wrapper.membershipID.uuid,
+            membershipEpoch: fixture.wrapper.membershipEpoch,
+            deviceID: try fixture.wrapper.deviceID.uuid
+        )
+        #expect(SelectiveRemoteTeamVaultCrypto.wrapperContext(wrapper).base64URL == fixture.wrapper.contextBase64URL)
+        #expect(SelectiveRemoteTeamVaultCrypto.wrapperContextHash(wrapper) == fixture.wrapper.contextHash)
+        #expect(try SelectiveRemoteTeamVaultCrypto.payloadContext(
+            teamID: fixture.payload.teamID.uuid,
+            vaultID: fixture.payload.vaultID.uuid,
+            keyGeneration: fixture.payload.keyGeneration
+        ).base64URL == fixture.payload.contextBase64URL)
+        #expect(try SelectiveRemoteTeamVaultCrypto.payloadContentHash(
+            teamID: fixture.payload.teamID.uuid,
+            vaultID: fixture.payload.vaultID.uuid,
+            keyGeneration: fixture.payload.keyGeneration,
+            nonce: fixture.payload.nonce,
+            ciphertext: fixture.payload.ciphertext,
+            authTag: fixture.payload.authTag
+        ) == fixture.payload.contentHash)
+    }
+
+    @Test("macOS rejects a private or extended Team JWK before cryptographic use")
+    func rejectsExtendedJWK() {
+        let data = Data(#"{"kty":"EC","crv":"P-256","x":"axfR8uEsQkf4vOblY6RA8ncDfYEt6zOg9KE5RdiYwpY","y":"T-NC4v4af5uO5-tKfA-eFivOM1drMV7Oy7ZAaDe_UfU","ext":true,"key_ops":[],"d":"secret"}"#.utf8)
+        #expect(throws: SelectiveRemoteTeamCryptoError.invalidPublicKey) {
+            try JSONDecoder().decode(SelectiveRemoteTeamDevicePublicKey.self, from: data)
+        }
+    }
+
+    private static func response(
+        _ request: URLRequest,
+        status: Int,
+        json: Any?
+    ) -> (Data, URLResponse) {
+        let data = json.map { try! JSONSerialization.data(withJSONObject: $0) } ?? Data()
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: status,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        return (data, response)
+    }
+}
+
+private final class CloudHTTPStub: @unchecked Sendable {
+    let handler: @Sendable (URLRequest) throws -> (Data, URLResponse)
+
+    init(handler: @escaping @Sendable (URLRequest) throws -> (Data, URLResponse)) {
+        self.handler = handler
+    }
+
+    func data(for request: URLRequest) throws -> (Data, URLResponse) {
+        try handler(request)
+    }
+}
+
+private struct TeamVaultFixture: Decodable {
+    var version: Int
+    var publicKey: SelectiveRemoteTeamDevicePublicKey
+    var fingerprint: String
+    var wrapper: Wrapper
+    var payload: Payload
+
+    struct Wrapper: Decodable {
+        var teamID: String
+        var vaultID: String
+        var keyGeneration: Int
+        var membershipID: String
+        var membershipEpoch: Int
+        var deviceID: String
+        var contextBase64URL: String
+        var contextHash: String
+    }
+
+    struct Payload: Decodable {
+        var teamID: String
+        var vaultID: String
+        var keyGeneration: Int
+        var contextBase64URL: String
+        var envelopeVersion: Int
+        var nonce: String
+        var ciphertext: String
+        var authTag: String
+        var contentHash: String
+    }
+}
+
+private extension String {
+    var uuid: UUID {
+        get throws {
+            guard let value = UUID(uuidString: self) else {
+                throw SelectiveRemoteTeamCryptoError.invalidEnvelope
+            }
+            return value
+        }
+    }
+}
+
+private extension Data {
+    var base64URL: String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/Tests/SelectiveRemoteTests/Fixtures/team-vault-v1.json
+++ b/Tests/SelectiveRemoteTests/Fixtures/team-vault-v1.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "publicKey": {
+    "kty": "EC",
+    "crv": "P-256",
+    "x": "axfR8uEsQkf4vOblY6RA8ncDfYEt6zOg9KE5RdiYwpY",
+    "y": "T-NC4v4af5uO5-tKfA-eFivOM1drMV7Oy7ZAaDe_UfU",
+    "ext": true,
+    "key_ops": []
+  },
+  "fingerprint": "6560-b930-44c0-5320-843e-3e19-6b51-f981-dae3-fb64-dcde-c93e-8978-2c49-c9bf-b874",
+  "wrapper": {
+    "teamID": "11111111-1111-4111-8111-111111111111",
+    "vaultID": "22222222-2222-4222-8222-222222222222",
+    "keyGeneration": 7,
+    "membershipID": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    "membershipEpoch": 3,
+    "deviceID": "44444444-4444-4444-8444-444444444444",
+    "contextBase64URL": "c2VsZWN0aXZlLXJlbW90ZS90ZWFtLXZhdWx0LXdyYXBwZXIvdjEAMTExMTExMTEtMTExMS00MTExLTgxMTEtMTExMTExMTExMTExADIyMjIyMjIyLTIyMjItNDIyMi04MjIyLTIyMjIyMjIyMjIyMgA3AGFhYWFhYWFhLWFhYWEtNGFhYS04YWFhLWFhYWFhYWFhYWFhYQAzADQ0NDQ0NDQ0LTQ0NDQtNDQ0NC04NDQ0LTQ0NDQ0NDQ0NDQ0NA",
+    "contextHash": "hNGPo1pc4cy0J-eMx0RMOgiO4XQLlYlFPLsqZoCnWGE"
+  },
+  "payload": {
+    "teamID": "11111111-1111-4111-8111-111111111111",
+    "vaultID": "22222222-2222-4222-8222-222222222222",
+    "keyGeneration": 7,
+    "contextBase64URL": "c2VsZWN0aXZlLXJlbW90ZS90ZWFtLXZhdWx0LXBheWxvYWQvdjEAMTExMTExMTEtMTExMS00MTExLTgxMTEtMTExMTExMTExMTExADIyMjIyMjIyLTIyMjItNDIyMi04MjIyLTIyMjIyMjIyMjIyMgA3",
+    "envelopeVersion": 1,
+    "nonce": "AAECAwQFBgcICQoL",
+    "ciphertext": "ABEiM0RVZneImaq7zN3u_w",
+    "authTag": "_-7dzLuqmYh3ZlVEMyIRAA",
+    "contentHash": "YtvpsswK9ghmnw0Z20FNE8KtfO2Cu3kZCreugkuyeFk"
+  }
+}

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -21,7 +21,12 @@ atomically transfer ownership after password re-authentication, and archive a
 Team behind exact-name confirmation. Archiving immediately closes Team access,
 retires pending invitations/outbox work and rotation tasks, soft-archives its
 Vaults, and retains ciphertext and audit history. The remaining client
-milestone is the macOS implementation and cross-client acceptance.
+milestone is the complete macOS implementation and cross-client acceptance.
+The first macOS foundation now provides typed login/logout/current-user/Team
+transport, device-only Keychain bearer-session storage and strict P-256
+fingerprint/context/content-hash primitives. A shared JSON fixture is exercised
+by both Swift and browser tests; Vault encryption, sync UI and end-to-end
+interoperability remain pending.
 
 The browser portal can create and unlock a client-encrypted personal Vault,
 perform local CRUD, sign in with an existing verified account and manually

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const sourceRoot = new URL("../../Sources/SelectiveRemote/", import.meta.url);
+
+test("macOS Cloud foundation keeps sessions in device-only Keychain storage", async () => {
+  const [client, store] = await Promise.all([
+    readFile(new URL("CloudAPIClient.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudSessionStore.swift", sourceRoot), "utf8"),
+  ]);
+  assert.match(store, /local\.selectiveremote\.cloud\.session\.v1/);
+  assert.match(store, /kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly/);
+  assert.doesNotMatch(store, /UserDefaults/);
+  assert.match(client, /Bearer.*Authorization/);
+  assert.match(client, /http\.statusCode == 401[\s\S]*removeToken/);
+  assert.match(client, /no-store.*Cache-Control/);
+});
+
+test("macOS Team crypto source pins the browser protocol labels and strict JWK shape", async () => {
+  const source = await readFile(new URL("CloudTeamCrypto.swift", sourceRoot), "utf8");
+  assert.match(source, /selective-remote\/team-device-key\/v1/);
+  assert.match(source, /selective-remote\/team-vault-wrapper\/v1/);
+  assert.match(source, /selective-remote\/team-vault-wrapper-key\/v1/);
+  assert.match(source, /selective-remote\/team-vault-payload\/v1/);
+  assert.match(source, /actualKeys == \["crv", "ext", "key_ops", "kty", "x", "y"\]/);
+  assert.match(source, /P256\.KeyAgreement\.PublicKey/);
+});

--- a/cloud/tests/macos-team-vault-fixture.test.mjs
+++ b/cloud/tests/macos-team-vault-fixture.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { createHash, webcrypto } from "node:crypto";
+import test from "node:test";
+import {
+  teamDevicePublicKeyFingerprint,
+  teamVaultWrapperContext,
+  teamVaultWrapperContextHash,
+} from "../public/team-vault-crypto.js";
+
+const fixtureURL = new URL(
+  "../../Tests/SelectiveRemoteTests/Fixtures/team-vault-v1.json",
+  import.meta.url,
+);
+
+function decodeBase64URL(value) {
+  return Buffer.from(value, "base64url");
+}
+
+test("shared macOS/browser fixture locks Team crypto canonicalization", async () => {
+  const fixture = JSON.parse(await readFile(fixtureURL, "utf8"));
+  assert.equal(fixture.version, 1);
+  assert.equal(
+    await teamDevicePublicKeyFingerprint(fixture.publicKey, webcrypto),
+    fixture.fingerprint,
+  );
+  assert.equal(
+    Buffer.from(teamVaultWrapperContext(fixture.wrapper)).toString("base64url"),
+    fixture.wrapper.contextBase64URL,
+  );
+  assert.equal(
+    await teamVaultWrapperContextHash(fixture.wrapper, webcrypto),
+    fixture.wrapper.contextHash,
+  );
+
+  const payloadContext = [
+    "selective-remote/team-vault-payload/v1",
+    fixture.payload.teamID,
+    fixture.payload.vaultID,
+    String(fixture.payload.keyGeneration),
+  ].join("\0");
+  assert.equal(Buffer.from(payloadContext).toString("base64url"), fixture.payload.contextBase64URL);
+  const contentHash = createHash("sha256").update(Buffer.concat([
+    Buffer.from([fixture.payload.envelopeVersion]),
+    Buffer.from(payloadContext),
+    decodeBase64URL(fixture.payload.nonce),
+    decodeBase64URL(fixture.payload.ciphertext),
+    decodeBase64URL(fixture.payload.authTag),
+  ])).digest("base64url");
+  assert.equal(contentHash, fixture.payload.contentHash);
+});

--- a/docs/cloud-v0.32-architecture.md
+++ b/docs/cloud-v0.32-architecture.md
@@ -13,8 +13,12 @@ device-bound wrappers and fail-closed rotation completion plus explicitly
 scoped authenticated routes. The browser has the interoperable Team
 cryptographic/client layer, Team/member/shared-Vault UI and causal shared-record
 orchestration, fingerprint-confirmed new-device approval/revocation and safe
-rotation completion. The macOS implementation remains a required milestone
-within the final 0.32 scope.
+rotation completion. The macOS client now has its first transport/security
+foundation: typed account/Team reads, a device-only Keychain session store and
+canonical P-256 fingerprint plus Team wrapper/payload context hashing verified
+against one shared browser/Swift fixture. Full macOS device-key persistence,
+Vault encryption/synchronization and UI remain required milestones within the
+final 0.32 scope.
 FIDO2 remains outside the initial 0.32 release scope.
 
 The first production deployment targets:

--- a/docs/cloud-v0.32-team-threat-model.md
+++ b/docs/cloud-v0.32-team-threat-model.md
@@ -7,7 +7,10 @@ shared-Vault metadata, shared ciphertext revisions, approved P-256 devices,
 per-device wrappers and atomic rotation completion are present. The browser has
 Team/member/shared-Vault UI, non-exportable device keys, fingerprint-confirmed
 device approval/revocation, causal shared-record synchronization and atomic
-rotation completion. The macOS client and cross-client acceptance remain.
+rotation completion. The macOS foundation now pins device-only Keychain
+session storage and the exact P-256 fingerprint, wrapper-context and payload
+content-hash encodings through a fixture shared with browser tests. Full macOS
+key wrapping, Vault sync/UI and cross-client acceptance remain.
 
 ## Security outcome
 


### PR DESCRIPTION
## Summary
- add typed macOS Cloud login/logout/current-user/Team transport behind a serialized actor
- persist bearer sessions only in a per-endpoint, device-only macOS Keychain item and clear them on 401/logout failure paths
- add strict public-only P-256 JWK validation, canonical device fingerprints, Team wrapper context hashes and payload content hashes
- add one deterministic JSON fixture consumed by both Swift and browser tests
- keep complete macOS Vault encryption/sync UI, staging deployment and release out of scope

## Verification
- exact head: `d12e72ad1ef6d3867e3c26be76bd0acb7350a0f1`
- CI #493: successful (Swift/macOS and PostgreSQL 16)
- Test DMG #187: successful
- test artifact: `SelectiveRemote-test-49-arm64`, 32,397,918 bytes, `sha256:0082029d02977ba78ffa798071d4fba35ef9e3e9e4bf33edba3dc4042f469205`
- local Cloud suite: 228 passed, 0 failed, 1 PostgreSQL integration skipped because `TEST_DATABASE_URL` is unavailable
- focused macOS source/shared-fixture Node tests: 3 passed
- JSON validation and `git diff --check` passed
- remote tree exactly matches locally verified tree `c06616074f2c643ab079355709074fe9ba1fd1b8`
- compare against public main: 2 commits ahead, 0 behind

The initial head failed only because `SHA256.Digest` is not subscriptable in this CryptoKit toolchain; the exact-head fix materializes the digest as an array before formatting.

Staging is unchanged. Squash merge into public `main` still requires a fresh exact-head Owner approval.