### PR TITLE
Cloud: add macOS Team device key wrapping

### DIFF
--- a/Sources/SelectiveRemote/CloudTeamCrypto.swift
+++ b/Sources/SelectiveRemote/CloudTeamCrypto.swift
@@ -3,8 +3,12 @@ import Foundation
 
 enum SelectiveRemoteTeamCryptoError: Error, Equatable {
     case invalidPublicKey
+    case invalidPrivateKey
     case invalidGeneration
     case invalidEnvelope
+    case wrapperDeviceMismatch
+    case wrapperContextMismatch
+    case keyUnwrapFailed
 }
 
 struct SelectiveRemoteTeamDevicePublicKey: Codable, Equatable, Sendable {
@@ -36,6 +40,26 @@ struct SelectiveRemoteTeamDevicePublicKey: Codable, Equatable, Sendable {
         self.keyOps = []
     }
 
+    init(_ key: P256.KeyAgreement.PublicKey) throws {
+        let representation = key.x963Representation
+        guard representation.count == 65, representation.first == 0x04 else {
+            throw SelectiveRemoteTeamCryptoError.invalidPublicKey
+        }
+        try self.init(
+            x: Data(representation[1..<33]).selectiveRemoteBase64URL,
+            y: Data(representation[33..<65]).selectiveRemoteBase64URL
+        )
+    }
+
+    var keyAgreementPublicKey: P256.KeyAgreement.PublicKey {
+        get throws {
+            guard let xData = Data(selectiveRemoteBase64URL: x, expectedLength: 32),
+                  let yData = Data(selectiveRemoteBase64URL: y, expectedLength: 32)
+            else { throw SelectiveRemoteTeamCryptoError.invalidPublicKey }
+            return try P256.KeyAgreement.PublicKey(x963Representation: Data([0x04]) + xData + yData)
+        }
+    }
+
     init(from decoder: any Decoder) throws {
         let actualKeys = try decoder.container(keyedBy: SelectiveRemoteAnyCodingKey.self)
             .allKeys.map(\.stringValue).sorted()
@@ -53,6 +77,91 @@ struct SelectiveRemoteTeamDevicePublicKey: Codable, Equatable, Sendable {
             throw SelectiveRemoteTeamCryptoError.invalidPublicKey
         }
         try self.init(x: x, y: y)
+    }
+}
+
+struct SelectiveRemoteTeamVaultKeyWrapper: Codable, Equatable, Sendable {
+    let membershipID: UUID
+    let membershipEpoch: Int
+    let deviceID: UUID
+    let wrapperVersion: Int
+    let ephemeralPublicKey: SelectiveRemoteTeamDevicePublicKey
+    let ciphertext: String
+    let nonce: String
+    let authTag: String
+    let contextHash: String
+
+    enum CodingKeys: String, CodingKey {
+        case membershipID, membershipEpoch, deviceID, wrapperVersion
+        case ephemeralPublicKey, ciphertext, nonce, authTag, contextHash
+    }
+
+    init(
+        membershipID: UUID,
+        membershipEpoch: Int,
+        deviceID: UUID,
+        wrapperVersion: Int = 1,
+        ephemeralPublicKey: SelectiveRemoteTeamDevicePublicKey,
+        ciphertext: String,
+        nonce: String,
+        authTag: String,
+        contextHash: String
+    ) throws {
+        guard membershipID.isSelectiveRemoteCloudUUID,
+              deviceID.isSelectiveRemoteCloudUUID,
+              membershipEpoch > 0,
+              wrapperVersion == 1,
+              Data(selectiveRemoteBase64URL: ciphertext, expectedLength: 32) != nil,
+              Data(selectiveRemoteBase64URL: nonce, expectedLength: 12) != nil,
+              Data(selectiveRemoteBase64URL: authTag, expectedLength: 16) != nil,
+              Data(selectiveRemoteBase64URL: contextHash, expectedLength: 32) != nil
+        else { throw SelectiveRemoteTeamCryptoError.invalidEnvelope }
+        self.membershipID = membershipID
+        self.membershipEpoch = membershipEpoch
+        self.deviceID = deviceID
+        self.wrapperVersion = wrapperVersion
+        self.ephemeralPublicKey = ephemeralPublicKey
+        self.ciphertext = ciphertext
+        self.nonce = nonce
+        self.authTag = authTag
+        self.contextHash = contextHash
+    }
+
+    init(from decoder: any Decoder) throws {
+        let actualKeys = try decoder.container(keyedBy: SelectiveRemoteAnyCodingKey.self)
+            .allKeys.map(\.stringValue).sorted()
+        guard actualKeys == [
+            "authTag", "ciphertext", "contextHash", "deviceID", "ephemeralPublicKey",
+            "membershipEpoch", "membershipID", "nonce", "wrapperVersion"
+        ] else { throw SelectiveRemoteTeamCryptoError.invalidEnvelope }
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        guard let membershipID = UUID(uuidString: try values.decode(String.self, forKey: .membershipID)),
+              let deviceID = UUID(uuidString: try values.decode(String.self, forKey: .deviceID))
+        else { throw SelectiveRemoteTeamCryptoError.invalidEnvelope }
+        try self.init(
+            membershipID: membershipID,
+            membershipEpoch: try values.decode(Int.self, forKey: .membershipEpoch),
+            deviceID: deviceID,
+            wrapperVersion: try values.decode(Int.self, forKey: .wrapperVersion),
+            ephemeralPublicKey: try values.decode(SelectiveRemoteTeamDevicePublicKey.self, forKey: .ephemeralPublicKey),
+            ciphertext: try values.decode(String.self, forKey: .ciphertext),
+            nonce: try values.decode(String.self, forKey: .nonce),
+            authTag: try values.decode(String.self, forKey: .authTag),
+            contextHash: try values.decode(String.self, forKey: .contextHash)
+        )
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var values = encoder.container(keyedBy: CodingKeys.self)
+        try values.encode(membershipID.canonicalCloudString, forKey: .membershipID)
+        try values.encode(membershipEpoch, forKey: .membershipEpoch)
+        try values.encode(deviceID.canonicalCloudString, forKey: .deviceID)
+        try values.encode(wrapperVersion, forKey: .wrapperVersion)
+        try values.encode(ephemeralPublicKey, forKey: .ephemeralPublicKey)
+        try values.encode(ciphertext, forKey: .ciphertext)
+        try values.encode(nonce, forKey: .nonce)
+        try values.encode(authTag, forKey: .authTag)
+        try values.encode(contextHash, forKey: .contextHash)
     }
 }
 
@@ -150,9 +259,122 @@ enum SelectiveRemoteTeamVaultCrypto {
         let bytes = Data([envelopeVersion]) + context + nonceData + ciphertextData + authTagData
         return Data(SHA256.hash(data: bytes)).selectiveRemoteBase64URL
     }
+
+    static func wrapVaultKey(
+        _ vaultKey: Data,
+        for recipientPublicKey: SelectiveRemoteTeamDevicePublicKey,
+        context: SelectiveRemoteTeamWrapperContext,
+        ephemeralPrivateKeyRepresentation: Data? = nil,
+        nonce: Data? = nil
+    ) throws -> SelectiveRemoteTeamVaultKeyWrapper {
+        guard vaultKey.count == 32 else { throw SelectiveRemoteTeamCryptoError.invalidEnvelope }
+        let ephemeral: P256.KeyAgreement.PrivateKey
+        do {
+            if let ephemeralPrivateKeyRepresentation {
+                ephemeral = try P256.KeyAgreement.PrivateKey(
+                    rawRepresentation: ephemeralPrivateKeyRepresentation
+                )
+            } else {
+                ephemeral = P256.KeyAgreement.PrivateKey()
+            }
+        } catch {
+            throw SelectiveRemoteTeamCryptoError.invalidPrivateKey
+        }
+        let recipientKey = try recipientPublicKey.keyAgreementPublicKey
+        let contextData = wrapperContext(context)
+        let wrappingKey = try deriveWrapperKey(
+            privateKey: ephemeral,
+            publicKey: recipientKey,
+            context: contextData
+        )
+        let nonceData = nonce ?? Data(AES.GCM.Nonce())
+        guard nonceData.count == 12 else { throw SelectiveRemoteTeamCryptoError.invalidEnvelope }
+        do {
+            let sealed = try AES.GCM.seal(
+                vaultKey,
+                using: wrappingKey,
+                nonce: AES.GCM.Nonce(data: nonceData),
+                authenticating: contextData
+            )
+            return try SelectiveRemoteTeamVaultKeyWrapper(
+                membershipID: context.membershipID,
+                membershipEpoch: context.membershipEpoch,
+                deviceID: context.deviceID,
+                ephemeralPublicKey: SelectiveRemoteTeamDevicePublicKey(ephemeral.publicKey),
+                ciphertext: sealed.ciphertext.selectiveRemoteBase64URL,
+                nonce: nonceData.selectiveRemoteBase64URL,
+                authTag: sealed.tag.selectiveRemoteBase64URL,
+                contextHash: wrapperContextHash(context)
+            )
+        } catch let error as SelectiveRemoteTeamCryptoError {
+            throw error
+        } catch {
+            throw SelectiveRemoteTeamCryptoError.invalidEnvelope
+        }
+    }
+
+    static func unwrapVaultKey(
+        _ wrapper: SelectiveRemoteTeamVaultKeyWrapper,
+        with identity: SelectiveRemoteTeamDeviceIdentity,
+        teamID: UUID,
+        vaultID: UUID,
+        keyGeneration: Int
+    ) throws -> Data {
+        guard wrapper.deviceID == identity.deviceID else {
+            throw SelectiveRemoteTeamCryptoError.wrapperDeviceMismatch
+        }
+        let context = try SelectiveRemoteTeamWrapperContext(
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: keyGeneration,
+            membershipID: wrapper.membershipID,
+            membershipEpoch: wrapper.membershipEpoch,
+            deviceID: wrapper.deviceID
+        )
+        guard wrapper.contextHash == wrapperContextHash(context) else {
+            throw SelectiveRemoteTeamCryptoError.wrapperContextMismatch
+        }
+        guard let nonce = Data(selectiveRemoteBase64URL: wrapper.nonce, expectedLength: 12),
+              let ciphertext = Data(selectiveRemoteBase64URL: wrapper.ciphertext, expectedLength: 32),
+              let tag = Data(selectiveRemoteBase64URL: wrapper.authTag, expectedLength: 16)
+        else { throw SelectiveRemoteTeamCryptoError.invalidEnvelope }
+        do {
+            let wrappingKey = try deriveWrapperKey(
+                privateKey: identity.privateKey,
+                publicKey: wrapper.ephemeralPublicKey.keyAgreementPublicKey,
+                context: wrapperContext(context)
+            )
+            let sealed = try AES.GCM.SealedBox(
+                nonce: AES.GCM.Nonce(data: nonce),
+                ciphertext: ciphertext,
+                tag: tag
+            )
+            let rawKey = try AES.GCM.open(sealed, using: wrappingKey, authenticating: wrapperContext(context))
+            guard rawKey.count == 32 else { throw SelectiveRemoteTeamCryptoError.keyUnwrapFailed }
+            return rawKey
+        } catch let error as SelectiveRemoteTeamCryptoError {
+            throw error
+        } catch {
+            throw SelectiveRemoteTeamCryptoError.keyUnwrapFailed
+        }
+    }
+
+    private static func deriveWrapperKey(
+        privateKey: P256.KeyAgreement.PrivateKey,
+        publicKey: P256.KeyAgreement.PublicKey,
+        context: Data
+    ) throws -> SymmetricKey {
+        let secret = try privateKey.sharedSecretFromKeyAgreement(with: publicKey)
+        return secret.hkdfDerivedSymmetricKey(
+            using: SHA256.self,
+            salt: Data(SHA256.hash(data: context)),
+            sharedInfo: Data(wrapperKeyInfo.utf8),
+            outputByteCount: 32
+        )
+    }
 }
 
-private extension UUID {
+extension UUID {
     var canonicalCloudString: String { uuidString.lowercased() }
 
     var isSelectiveRemoteCloudUUID: Bool {
@@ -163,7 +385,7 @@ private extension UUID {
     }
 }
 
-private struct SelectiveRemoteAnyCodingKey: CodingKey {
+struct SelectiveRemoteAnyCodingKey: CodingKey {
     var stringValue: String
     var intValue: Int?
 
@@ -177,7 +399,7 @@ private struct SelectiveRemoteAnyCodingKey: CodingKey {
     }
 }
 
-private extension Data {
+extension Data {
     init?(selectiveRemoteBase64URL value: String, expectedLength: Int? = nil) {
         guard !value.isEmpty,
               value.range(of: "^[A-Za-z0-9_-]+$", options: .regularExpression) != nil

--- a/Sources/SelectiveRemote/CloudTeamDeviceIdentity.swift
+++ b/Sources/SelectiveRemote/CloudTeamDeviceIdentity.swift
@@ -1,0 +1,149 @@
+import CryptoKit
+import Foundation
+import Security
+
+protocol SelectiveRemoteTeamDeviceKeyStore: Sendable {
+    func privateKeyRepresentation(for endpoint: URL, deviceID: UUID) throws -> Data?
+    func savePrivateKeyIfAbsent(_ representation: Data, for endpoint: URL, deviceID: UUID) throws -> Data
+    func removePrivateKey(for endpoint: URL, deviceID: UUID) throws
+}
+
+struct SelectiveRemoteTeamDeviceIdentity: @unchecked Sendable {
+    let deviceID: UUID
+    let publicKey: SelectiveRemoteTeamDevicePublicKey
+    let privateKey: P256.KeyAgreement.PrivateKey
+
+    init(deviceID: UUID, privateKeyRepresentation: Data) throws {
+        guard deviceID.isSelectiveRemoteCloudUUID, privateKeyRepresentation.count == 32 else {
+            throw SelectiveRemoteTeamCryptoError.invalidPrivateKey
+        }
+        do {
+            let privateKey = try P256.KeyAgreement.PrivateKey(rawRepresentation: privateKeyRepresentation)
+            self.deviceID = deviceID
+            self.publicKey = try SelectiveRemoteTeamDevicePublicKey(privateKey.publicKey)
+            self.privateKey = privateKey
+        } catch let error as SelectiveRemoteTeamCryptoError {
+            throw error
+        } catch {
+            throw SelectiveRemoteTeamCryptoError.invalidPrivateKey
+        }
+    }
+}
+
+actor SelectiveRemoteTeamDeviceIdentityManager {
+    private let store: any SelectiveRemoteTeamDeviceKeyStore
+
+    init(store: any SelectiveRemoteTeamDeviceKeyStore = SelectiveRemoteTeamDeviceKeychainStore()) {
+        self.store = store
+    }
+
+    func identity(endpoint: URL, deviceID: UUID) throws -> SelectiveRemoteTeamDeviceIdentity {
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized(endpoint.absoluteString)
+        if let stored = try store.privateKeyRepresentation(for: endpoint, deviceID: deviceID) {
+            return try SelectiveRemoteTeamDeviceIdentity(deviceID: deviceID, privateKeyRepresentation: stored)
+        }
+        let generated = P256.KeyAgreement.PrivateKey()
+        let committed = try store.savePrivateKeyIfAbsent(
+            generated.rawRepresentation,
+            for: endpoint,
+            deviceID: deviceID
+        )
+        return try SelectiveRemoteTeamDeviceIdentity(deviceID: deviceID, privateKeyRepresentation: committed)
+    }
+
+    func removeIdentity(endpoint: URL, deviceID: UUID) throws {
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized(endpoint.absoluteString)
+        try store.removePrivateKey(for: endpoint, deviceID: deviceID)
+    }
+}
+
+struct SelectiveRemoteTeamDeviceKeychainStore: SelectiveRemoteTeamDeviceKeyStore {
+    static let service = "local.selectiveremote.cloud.team-device-key.v1"
+
+    func privateKeyRepresentation(for endpoint: URL, deviceID: UUID) throws -> Data? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.service,
+            kSecAttrAccount as String: account(endpoint: endpoint, deviceID: deviceID),
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound { return nil }
+        guard status == errSecSuccess else { throw KeychainError.unexpectedStatus(status) }
+        guard let data = result as? Data else { throw KeychainError.invalidData }
+        return data
+    }
+
+    func savePrivateKeyIfAbsent(
+        _ representation: Data,
+        for endpoint: URL,
+        deviceID: UUID
+    ) throws -> Data {
+        guard representation.count == 32 else { throw SelectiveRemoteTeamCryptoError.invalidPrivateKey }
+        let item: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.service,
+            kSecAttrAccount as String: account(endpoint: endpoint, deviceID: deviceID),
+            kSecValueData as String: representation,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        ]
+        let status = SecItemAdd(item as CFDictionary, nil)
+        if status == errSecSuccess { return representation }
+        if status == errSecDuplicateItem,
+           let existing = try privateKeyRepresentation(for: endpoint, deviceID: deviceID) {
+            return existing
+        }
+        throw KeychainError.unexpectedStatus(status)
+    }
+
+    func removePrivateKey(for endpoint: URL, deviceID: UUID) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.service,
+            kSecAttrAccount as String: account(endpoint: endpoint, deviceID: deviceID)
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+
+    private func account(endpoint: URL, deviceID: UUID) -> String {
+        "\(endpoint.absoluteString)|\(deviceID.uuidString.lowercased())"
+    }
+}
+
+final class SelectiveRemoteTeamDeviceMemoryKeyStore: SelectiveRemoteTeamDeviceKeyStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var keys: [String: Data] = [:]
+
+    func privateKeyRepresentation(for endpoint: URL, deviceID: UUID) -> Data? {
+        lock.withLock { keys[account(endpoint: endpoint, deviceID: deviceID)] }
+    }
+
+    func savePrivateKeyIfAbsent(
+        _ representation: Data,
+        for endpoint: URL,
+        deviceID: UUID
+    ) throws -> Data {
+        guard representation.count == 32 else {
+            throw SelectiveRemoteTeamCryptoError.invalidPrivateKey
+        }
+        return lock.withLock {
+            let account = account(endpoint: endpoint, deviceID: deviceID)
+            if let existing = keys[account] { return existing }
+            keys[account] = representation
+            return representation
+        }
+    }
+
+    func removePrivateKey(for endpoint: URL, deviceID: UUID) {
+        lock.withLock { keys.removeValue(forKey: account(endpoint: endpoint, deviceID: deviceID)) }
+    }
+
+    private func account(endpoint: URL, deviceID: UUID) -> String {
+        "\(endpoint.absoluteString)|\(deviceID.uuidString.lowercased())"
+    }
+}

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -129,6 +129,78 @@ struct CloudMacOSFoundationTests {
         }
     }
 
+    @Test("device identity converges on one device-only stored P-256 key")
+    func persistentDeviceIdentity() async throws {
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized("https://cloud.example.invalid")
+        let deviceID = try #require(UUID(uuidString: "44444444-4444-4444-8444-444444444444"))
+        let store = SelectiveRemoteTeamDeviceMemoryKeyStore()
+        let first = try await SelectiveRemoteTeamDeviceIdentityManager(store: store)
+            .identity(endpoint: endpoint, deviceID: deviceID)
+        let second = try await SelectiveRemoteTeamDeviceIdentityManager(store: store)
+            .identity(endpoint: endpoint, deviceID: deviceID)
+        #expect(first.deviceID == deviceID)
+        #expect(first.publicKey == second.publicKey)
+        #expect(first.privateKey.rawRepresentation == second.privateKey.rawRepresentation)
+    }
+
+    @Test("macOS deterministic wrapper decrypts in the browser fixture format")
+    func sharedKeyWrapFixture() throws {
+        let fixture = try Self.fixture()
+        let deviceID = try fixture.wrapper.deviceID.uuid
+        let identity = try SelectiveRemoteTeamDeviceIdentity(
+            deviceID: deviceID,
+            privateKeyRepresentation: try fixture.keyWrap.recipientPrivateScalar.base64URLData
+        )
+        #expect(identity.publicKey == fixture.publicKey)
+        let context = try SelectiveRemoteTeamWrapperContext(
+            teamID: try fixture.wrapper.teamID.uuid,
+            vaultID: try fixture.wrapper.vaultID.uuid,
+            keyGeneration: fixture.wrapper.keyGeneration,
+            membershipID: try fixture.wrapper.membershipID.uuid,
+            membershipEpoch: fixture.wrapper.membershipEpoch,
+            deviceID: deviceID
+        )
+        let wrapper = try SelectiveRemoteTeamVaultCrypto.wrapVaultKey(
+            try fixture.keyWrap.vaultKey.base64URLData,
+            for: fixture.publicKey,
+            context: context,
+            ephemeralPrivateKeyRepresentation: try fixture.keyWrap.ephemeralPrivateScalar.base64URLData,
+            nonce: try fixture.keyWrap.nonce.base64URLData
+        )
+        #expect(wrapper.ephemeralPublicKey == fixture.keyWrap.ephemeralPublicKey)
+        #expect(wrapper.ciphertext == fixture.keyWrap.ciphertext)
+        #expect(wrapper.authTag == fixture.keyWrap.authTag)
+        #expect(wrapper.contextHash == fixture.wrapper.contextHash)
+        let expectedVaultKey = try fixture.keyWrap.vaultKey.base64URLData
+        #expect(try SelectiveRemoteTeamVaultCrypto.unwrapVaultKey(
+            wrapper,
+            with: identity,
+            teamID: context.teamID,
+            vaultID: context.vaultID,
+            keyGeneration: context.keyGeneration
+        ) == expectedVaultKey)
+
+        let otherVaultID = try #require(UUID(uuidString: "33333333-3333-4333-8333-333333333333"))
+        #expect(throws: SelectiveRemoteTeamCryptoError.wrapperContextMismatch) {
+            try SelectiveRemoteTeamVaultCrypto.unwrapVaultKey(
+                wrapper,
+                with: identity,
+                teamID: context.teamID,
+                vaultID: otherVaultID,
+                keyGeneration: context.keyGeneration
+            )
+        }
+    }
+
+    private static func fixture() throws -> TeamVaultFixture {
+        let url = try #require(Bundle.module.url(
+            forResource: "team-vault-v1",
+            withExtension: "json",
+            subdirectory: "Fixtures"
+        ))
+        return try JSONDecoder().decode(TeamVaultFixture.self, from: Data(contentsOf: url))
+    }
+
     private static func response(
         _ request: URLRequest,
         status: Int,
@@ -162,6 +234,7 @@ private struct TeamVaultFixture: Decodable {
     var publicKey: SelectiveRemoteTeamDevicePublicKey
     var fingerprint: String
     var wrapper: Wrapper
+    var keyWrap: KeyWrap
     var payload: Payload
 
     struct Wrapper: Decodable {
@@ -186,12 +259,31 @@ private struct TeamVaultFixture: Decodable {
         var authTag: String
         var contentHash: String
     }
+
+    struct KeyWrap: Decodable {
+        var recipientPrivateScalar: String
+        var ephemeralPrivateScalar: String
+        var ephemeralPublicKey: SelectiveRemoteTeamDevicePublicKey
+        var vaultKey: String
+        var nonce: String
+        var ciphertext: String
+        var authTag: String
+    }
 }
 
 private extension String {
     var uuid: UUID {
         get throws {
             guard let value = UUID(uuidString: self) else {
+                throw SelectiveRemoteTeamCryptoError.invalidEnvelope
+            }
+            return value
+        }
+    }
+
+    var base64URLData: Data {
+        get throws {
+            guard let value = Data(selectiveRemoteBase64URL: self) else {
                 throw SelectiveRemoteTeamCryptoError.invalidEnvelope
             }
             return value

--- a/Tests/SelectiveRemoteTests/Fixtures/team-vault-v1.json
+++ b/Tests/SelectiveRemoteTests/Fixtures/team-vault-v1.json
@@ -19,6 +19,22 @@
     "contextBase64URL": "c2VsZWN0aXZlLXJlbW90ZS90ZWFtLXZhdWx0LXdyYXBwZXIvdjEAMTExMTExMTEtMTExMS00MTExLTgxMTEtMTExMTExMTExMTExADIyMjIyMjIyLTIyMjItNDIyMi04MjIyLTIyMjIyMjIyMjIyMgA3AGFhYWFhYWFhLWFhYWEtNGFhYS04YWFhLWFhYWFhYWFhYWFhYQAzADQ0NDQ0NDQ0LTQ0NDQtNDQ0NC04NDQ0LTQ0NDQ0NDQ0NDQ0NA",
     "contextHash": "hNGPo1pc4cy0J-eMx0RMOgiO4XQLlYlFPLsqZoCnWGE"
   },
+  "keyWrap": {
+    "recipientPrivateScalar": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE",
+    "ephemeralPrivateScalar": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAI",
+    "ephemeralPublicKey": {
+      "kty": "EC",
+      "crv": "P-256",
+      "x": "fPJ7GI0DT36KUjgDBLUaw8CJaeJ38hs1pgtI_EdmmXg",
+      "y": "B3dVENuO0EApPZrGn3Qw27p9reY86YIpngS3nSJ4c9E",
+      "ext": true,
+      "key_ops": []
+    },
+    "vaultKey": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
+    "nonce": "AAECAwQFBgcICQoL",
+    "ciphertext": "V-HAtGNGImS9cQf9cENQpiFfyE3_uiwASobWUIi71Qc",
+    "authTag": "rsP1O7zoyyMMeQYL872k5Q"
+  },
   "payload": {
     "teamID": "11111111-1111-4111-8111-111111111111",
     "vaultID": "22222222-2222-4222-8222-222222222222",

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -22,11 +22,12 @@ Team behind exact-name confirmation. Archiving immediately closes Team access,
 retires pending invitations/outbox work and rotation tasks, soft-archives its
 Vaults, and retains ciphertext and audit history. The remaining client
 milestone is the complete macOS implementation and cross-client acceptance.
-The first macOS foundation now provides typed login/logout/current-user/Team
-transport, device-only Keychain bearer-session storage and strict P-256
-fingerprint/context/content-hash primitives. A shared JSON fixture is exercised
-by both Swift and browser tests; Vault encryption, sync UI and end-to-end
-interoperability remain pending.
+The macOS foundation now provides typed login/logout/current-user/Team
+transport, device-only Keychain bearer-session and P-256 device-identity
+storage, strict fingerprint/context/content-hash primitives, and interoperable
+ECDH/HKDF/AES-GCM Team Vault-key wrap/unwrap. A deterministic synthetic JSON
+fixture is produced exactly by Swift and decrypted by the browser tests; Vault
+payload encryption, sync UI and end-to-end service acceptance remain pending.
 
 The browser portal can create and unlock a client-encrypted personal Vault,
 perform local CRUD, sign in with an existing verified account and manually

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -18,11 +18,20 @@ test("macOS Cloud foundation keeps sessions in device-only Keychain storage", as
 });
 
 test("macOS Team crypto source pins the browser protocol labels and strict JWK shape", async () => {
-  const source = await readFile(new URL("CloudTeamCrypto.swift", sourceRoot), "utf8");
+  const [source, identity] = await Promise.all([
+    readFile(new URL("CloudTeamCrypto.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudTeamDeviceIdentity.swift", sourceRoot), "utf8"),
+  ]);
   assert.match(source, /selective-remote\/team-device-key\/v1/);
   assert.match(source, /selective-remote\/team-vault-wrapper\/v1/);
   assert.match(source, /selective-remote\/team-vault-wrapper-key\/v1/);
   assert.match(source, /selective-remote\/team-vault-payload\/v1/);
   assert.match(source, /actualKeys == \["crv", "ext", "key_ops", "kty", "x", "y"\]/);
   assert.match(source, /P256\.KeyAgreement\.PublicKey/);
+  assert.match(source, /hkdfDerivedSymmetricKey/);
+  assert.match(source, /AES\.GCM\.(seal|SealedBox)/);
+  assert.match(identity, /local\.selectiveremote\.cloud\.team-device-key\.v1/);
+  assert.match(identity, /kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly/);
+  assert.match(identity, /savePrivateKeyIfAbsent/);
+  assert.doesNotMatch(identity, /UserDefaults/);
 });

--- a/cloud/tests/macos-team-vault-fixture.test.mjs
+++ b/cloud/tests/macos-team-vault-fixture.test.mjs
@@ -6,6 +6,7 @@ import {
   teamDevicePublicKeyFingerprint,
   teamVaultWrapperContext,
   teamVaultWrapperContextHash,
+  unwrapTeamVaultKeyForDevice,
 } from "../public/team-vault-crypto.js";
 
 const fixtureURL = new URL(
@@ -48,4 +49,43 @@ test("shared macOS/browser fixture locks Team crypto canonicalization", async ()
     decodeBase64URL(fixture.payload.authTag),
   ])).digest("base64url");
   assert.equal(contentHash, fixture.payload.contentHash);
+});
+
+test("browser unwraps the deterministic macOS Team Vault key wrapper", async () => {
+  const fixture = JSON.parse(await readFile(fixtureURL, "utf8"));
+  const privateKey = await webcrypto.subtle.importKey(
+    "jwk",
+    {
+      ...fixture.publicKey,
+      d: fixture.keyWrap.recipientPrivateScalar,
+      key_ops: ["deriveBits"],
+    },
+    { name: "ECDH", namedCurve: "P-256" },
+    false,
+    ["deriveBits"],
+  );
+  const wrapper = {
+    membershipID: fixture.wrapper.membershipID,
+    membershipEpoch: fixture.wrapper.membershipEpoch,
+    deviceID: fixture.wrapper.deviceID,
+    wrapperVersion: 1,
+    ephemeralPublicKey: fixture.keyWrap.ephemeralPublicKey,
+    ciphertext: fixture.keyWrap.ciphertext,
+    nonce: fixture.keyWrap.nonce,
+    authTag: fixture.keyWrap.authTag,
+    contextHash: fixture.wrapper.contextHash,
+  };
+  const key = await unwrapTeamVaultKeyForDevice({
+    privateKey,
+    wrapper,
+    teamID: fixture.wrapper.teamID,
+    vaultID: fixture.wrapper.vaultID,
+    keyGeneration: fixture.wrapper.keyGeneration,
+    deviceID: fixture.wrapper.deviceID,
+    cryptoValue: webcrypto,
+  });
+  assert.equal(
+    Buffer.from(await webcrypto.subtle.exportKey("raw", key)).toString("base64url"),
+    fixture.keyWrap.vaultKey,
+  );
 });

--- a/docs/cloud-v0.32-architecture.md
+++ b/docs/cloud-v0.32-architecture.md
@@ -14,10 +14,11 @@ scoped authenticated routes. The browser has the interoperable Team
 cryptographic/client layer, Team/member/shared-Vault UI and causal shared-record
 orchestration, fingerprint-confirmed new-device approval/revocation and safe
 rotation completion. The macOS client now has its first transport/security
-foundation: typed account/Team reads, a device-only Keychain session store and
-canonical P-256 fingerprint plus Team wrapper/payload context hashing verified
-against one shared browser/Swift fixture. Full macOS device-key persistence,
-Vault encryption/synchronization and UI remain required milestones within the
+foundation: typed account/Team reads, device-only Keychain session and P-256
+identity storage, canonical fingerprints/context hashing, and ECDH/HKDF/
+AES-GCM Team Vault-key wrapping. One deterministic synthetic fixture requires
+Swift to emit the exact wrapper that browser code decrypts. Full macOS payload
+encryption, Vault synchronization and UI remain required milestones within the
 final 0.32 scope.
 FIDO2 remains outside the initial 0.32 release scope.
 

--- a/docs/cloud-v0.32-team-threat-model.md
+++ b/docs/cloud-v0.32-team-threat-model.md
@@ -8,9 +8,10 @@ per-device wrappers and atomic rotation completion are present. The browser has
 Team/member/shared-Vault UI, non-exportable device keys, fingerprint-confirmed
 device approval/revocation, causal shared-record synchronization and atomic
 rotation completion. The macOS foundation now pins device-only Keychain
-session storage and the exact P-256 fingerprint, wrapper-context and payload
-content-hash encodings through a fixture shared with browser tests. Full macOS
-key wrapping, Vault sync/UI and cross-client acceptance remain.
+session and P-256 identity storage, exact fingerprints/context hashes, and
+ECDH/HKDF/AES-GCM Team Vault-key wrapping. A deterministic synthetic wrapper
+created by Swift must decrypt in browser code. Full macOS payload encryption,
+Vault sync/UI and service-level cross-client acceptance remain.
 
 ## Security outcome
 


### PR DESCRIPTION
## Summary
- persist one P-256 Team device identity per normalized Cloud endpoint/device in a device-only macOS Keychain item
- converge concurrent/repeated creation through create-if-absent semantics without replacing an approved identity
- add strict Team Vault key-wrapper decoding and P-256 ECDH + HKDF-SHA-256 + AES-256-GCM wrap/unwrap
- extend the shared deterministic fixture so Swift emits the exact wrapper that browser WebCrypto decrypts
- keep payload encryption, Vault synchronization/UI, staging deployment and release out of scope

## Security boundaries
- private scalars are never sent to the Cloud API or included in public models
- production identities and wrapper nonces are random; committed scalar/nonce values are explicitly synthetic test vectors
- wrapper AAD and HKDF salt bind Team, Vault, generation, membership, membership epoch and device
- replay under another device, Vault or generation fails closed
- Keychain accessibility is `AfterFirstUnlockThisDeviceOnly`; no UserDefaults or synchronizable storage

## Verification
- exact head: `d1ae77b921d15813353887db24cb30be848270a5`
- exact tree: `c2b94e54baf48f0c52439d63a9dbe70db4f613e5`, matching the locally verified tree
- compare against public main: 1 commit ahead, 0 behind
- CI #495: successful (Swift/macOS and PostgreSQL 16)
- Test DMG #188: successful
- artifact: `SelectiveRemote-test-50-arm64`, id `9997600684`, 32,400,274 bytes, `sha256:4f5e19cced98d125de3e23576cd5d12d4f9bfb6c25b0e7fb8c4666bf9b7f2d61`
- Cloud suite: 229 passed, 0 failed, 1 local PostgreSQL integration skipped because `TEST_DATABASE_URL` is unavailable; CI ran PostgreSQL 16 successfully
- focused macOS source/shared-fixture tests: 4 passed
- `npm audit --omit=dev`: 0 vulnerabilities
- JSON, JavaScript syntax and `git diff --check`: passed

Staging is unchanged. Squash merge into public `main` still requires a fresh exact-head Owner approval.