### PR TITLE
Cloud: add macOS Team Vault payload sync foundation

### DIFF
--- a/Sources/SelectiveRemote/CloudAPIClient.swift
+++ b/Sources/SelectiveRemote/CloudAPIClient.swift
@@ -79,6 +79,94 @@ struct SelectiveRemoteCloudTeam: Codable, Equatable, Sendable {
     var updatedAt: String
 }
 
+struct SelectiveRemoteCloudSharedVault: Codable, Equatable, Sendable {
+    var id: UUID
+    var teamID: UUID
+    var name: String
+    var revision: Int
+    var keyGeneration: Int
+    var rotationRequired: Bool
+    var createdAt: String
+    var updatedAt: String
+}
+
+struct SelectiveRemoteCloudTeamKeyDevice: Codable, Equatable, Sendable {
+    var membershipID: UUID
+    var membershipEpoch: Int
+    var deviceID: UUID
+    var publicKeyAlgorithm: String
+    var publicKey: SelectiveRemoteTeamDevicePublicKey
+    var hasWrapper: Bool
+}
+
+struct SelectiveRemoteCloudSharedVaultEnvelope: Codable, Equatable, Sendable {
+    var id: UUID
+    var teamID: UUID
+    var name: String
+    var revision: Int
+    var keyGeneration: Int
+    var rotationRequired: Bool
+    var envelopeVersion: Int?
+    var ciphertext: String?
+    var nonce: String?
+    var authTag: String?
+    var contentHash: String?
+    var wrapper: SelectiveRemoteTeamVaultKeyWrapper?
+    var createdAt: String
+    var updatedAt: String
+
+    var payloadEnvelope: SelectiveRemoteTeamVaultPayloadEnvelope? {
+        get throws {
+            guard revision > 0 else { return nil }
+            guard let envelopeVersion, let ciphertext, let nonce, let authTag, let contentHash else {
+                throw SelectiveRemoteCloudError.invalidResponse
+            }
+            do {
+                return try SelectiveRemoteTeamVaultPayloadEnvelope(
+                    baseRevision: revision - 1,
+                    keyGeneration: keyGeneration,
+                    envelopeVersion: envelopeVersion,
+                    ciphertext: ciphertext,
+                    nonce: nonce,
+                    authTag: authTag,
+                    contentHash: contentHash
+                )
+            } catch {
+                throw SelectiveRemoteCloudError.invalidResponse
+            }
+        }
+    }
+}
+
+struct SelectiveRemoteCloudTeamVaultUpload: Encodable, Equatable, Sendable {
+    var envelope: SelectiveRemoteTeamVaultPayloadEnvelope
+    var wrappers: [SelectiveRemoteTeamVaultKeyWrapper]?
+
+    enum CodingKeys: String, CodingKey {
+        case baseRevision, keyGeneration, envelopeVersion
+        case ciphertext, nonce, authTag, contentHash, wrappers
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var values = encoder.container(keyedBy: CodingKeys.self)
+        try values.encode(envelope.baseRevision, forKey: .baseRevision)
+        try values.encode(envelope.keyGeneration, forKey: .keyGeneration)
+        try values.encode(envelope.envelopeVersion, forKey: .envelopeVersion)
+        try values.encode(envelope.ciphertext, forKey: .ciphertext)
+        try values.encode(envelope.nonce, forKey: .nonce)
+        try values.encode(envelope.authTag, forKey: .authTag)
+        try values.encode(envelope.contentHash, forKey: .contentHash)
+        try values.encodeIfPresent(wrappers, forKey: .wrappers)
+    }
+}
+
+struct SelectiveRemoteCloudTeamVaultWriteResult: Equatable, Sendable {
+    var conflict: Bool
+    var revision: Int
+    var keyGeneration: Int
+    var rotationCompleted: Bool?
+}
+
 struct SelectiveRemoteCloudDeviceRegistration: Codable, Equatable, Sendable {
     var id: UUID
     var name: String
@@ -237,6 +325,109 @@ actor SelectiveRemoteCloudAPIClient {
         return result.teams
     }
 
+    func sharedVaults(endpoint: URL, teamID: UUID) async throws -> [SelectiveRemoteCloudSharedVault] {
+        guard teamID.isSelectiveRemoteCloudUUID else { throw SelectiveRemoteCloudError.invalidRequest }
+        let data = try await authorizedData(
+            endpoint: endpoint,
+            path: "v1/teams/\(teamID.canonicalCloudString)/vaults"
+        )
+        guard Self.validSharedVaultsJSON(data),
+              let result = try? decoder.decode(SharedVaultsResponse.self, from: data),
+              result.vaults.count <= 10_000,
+              result.vaults.allSatisfy({ Self.validSharedVault($0, teamID: teamID) }),
+              Set(result.vaults.map(\.id)).count == result.vaults.count
+        else { throw SelectiveRemoteCloudError.invalidResponse }
+        return result.vaults
+    }
+
+    func teamKeyDevices(
+        endpoint: URL,
+        teamID: UUID,
+        vaultID: UUID
+    ) async throws -> [SelectiveRemoteCloudTeamKeyDevice] {
+        guard teamID.isSelectiveRemoteCloudUUID, vaultID.isSelectiveRemoteCloudUUID else {
+            throw SelectiveRemoteCloudError.invalidRequest
+        }
+        let data = try await authorizedData(
+            endpoint: endpoint,
+            path: "v1/teams/\(teamID.canonicalCloudString)/vaults/\(vaultID.canonicalCloudString)/key-devices"
+        )
+        guard Self.validTeamKeyDevicesJSON(data),
+              let result = try? decoder.decode(TeamKeyDevicesResponse.self, from: data),
+              result.devices.count <= 1_024,
+              result.devices.allSatisfy({ device in
+                  device.membershipID.isSelectiveRemoteCloudUUID
+                      && device.deviceID.isSelectiveRemoteCloudUUID
+                      && device.membershipEpoch > 0
+                      && device.publicKeyAlgorithm == "p256-ecdh-v1"
+              }),
+              Set(result.devices.map(\.deviceID)).count == result.devices.count
+        else { throw SelectiveRemoteCloudError.invalidResponse }
+        return result.devices
+    }
+
+    func sharedVault(
+        endpoint: URL,
+        teamID: UUID,
+        vaultID: UUID
+    ) async throws -> SelectiveRemoteCloudSharedVaultEnvelope {
+        guard teamID.isSelectiveRemoteCloudUUID, vaultID.isSelectiveRemoteCloudUUID else {
+            throw SelectiveRemoteCloudError.invalidRequest
+        }
+        let data = try await authorizedData(
+            endpoint: endpoint,
+            path: "v1/teams/\(teamID.canonicalCloudString)/vaults/\(vaultID.canonicalCloudString)"
+        )
+        guard Self.validSharedVaultEnvelopeJSON(data),
+              let result = try? decoder.decode(SelectiveRemoteCloudSharedVaultEnvelope.self, from: data),
+              Self.validSharedVaultEnvelope(result, teamID: teamID, vaultID: vaultID)
+        else { throw SelectiveRemoteCloudError.invalidResponse }
+        return result
+    }
+
+    func putSharedVault(
+        endpoint: URL,
+        teamID: UUID,
+        vaultID: UUID,
+        upload: SelectiveRemoteCloudTeamVaultUpload,
+        idempotencyKey: String
+    ) async throws -> SelectiveRemoteCloudTeamVaultWriteResult {
+        let uploadIsValid = (try? Self.validUpload(upload, teamID: teamID, vaultID: vaultID)) == true
+        guard teamID.isSelectiveRemoteCloudUUID,
+              vaultID.isSelectiveRemoteCloudUUID,
+              Self.validIdempotencyKey(idempotencyKey),
+              uploadIsValid
+        else { throw SelectiveRemoteCloudError.invalidRequest }
+        let (data, http) = try await authorizedResponse(
+            endpoint: endpoint,
+            path: "v1/teams/\(teamID.canonicalCloudString)/vaults/\(vaultID.canonicalCloudString)",
+            method: "PUT",
+            body: try encoder.encode(upload),
+            headers: ["Idempotency-Key": idempotencyKey]
+        )
+        guard http.statusCode == 200 || http.statusCode == 409,
+              Self.validTeamVaultWriteJSON(data, conflict: http.statusCode == 409),
+              let response = try? decoder.decode(TeamVaultWriteResponse.self, from: data),
+              response.conflict == (http.statusCode == 409),
+              response.revision >= 0,
+              response.keyGeneration > 0,
+              (response.conflict
+                  ? response.rotationCompleted == nil
+                  : response.revision > 0 && response.rotationCompleted != nil)
+        else {
+            if !(200..<300).contains(http.statusCode), http.statusCode != 409 {
+                throw serviceError(status: http.statusCode, data: data)
+            }
+            throw SelectiveRemoteCloudError.invalidResponse
+        }
+        return .init(
+            conflict: response.conflict,
+            revision: response.revision,
+            keyGeneration: response.keyGeneration,
+            rotationCompleted: response.rotationCompleted
+        )
+    }
+
     func logout(endpoint: URL) async throws {
         guard let token = try storedToken(for: endpoint) else { return }
         var request = JSONRequest(
@@ -259,25 +450,153 @@ actor SelectiveRemoteCloudAPIClient {
     }
 
     private func authorizedData(endpoint: URL, path: String) async throws -> Data {
+        let (data, http) = try await authorizedResponse(endpoint: endpoint, path: path)
+        guard (200..<300).contains(http.statusCode) else {
+            throw serviceError(status: http.statusCode, data: data)
+        }
+        return data
+    }
+
+    private func authorizedResponse(
+        endpoint: URL,
+        path: String,
+        method: String = "GET",
+        body: Data? = nil,
+        headers: [String: String] = [:]
+    ) async throws -> (Data, HTTPURLResponse) {
         guard let token = try storedToken(for: endpoint) else {
             throw SelectiveRemoteCloudError.authenticationRequired
         }
         var request = JSONRequest(
             url: endpoint.appending(path: path),
-            method: "GET",
-            body: nil
+            method: method,
+            body: body
         ).value
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        for (name, value) in headers {
+            request.setValue(value, forHTTPHeaderField: name)
+        }
         let (data, response) = try await dataLoader(request)
         let http = try httpResponse(response)
         if http.statusCode == 401 {
             try? tokenStore.removeToken(for: endpoint)
             throw SelectiveRemoteCloudError.authenticationRequired
         }
-        guard (200..<300).contains(http.statusCode) else {
-            throw serviceError(status: http.statusCode, data: data)
+        return (data, http)
+    }
+
+    private static func validSharedVault(_ value: SelectiveRemoteCloudSharedVault, teamID: UUID) -> Bool {
+        value.id.isSelectiveRemoteCloudUUID
+            && value.teamID == teamID
+            && !value.name.isEmpty
+            && value.name.count <= 120
+            && value.revision >= 0
+            && value.keyGeneration > 0
+            && !value.createdAt.isEmpty
+            && !value.updatedAt.isEmpty
+    }
+
+    private static func exactKeys(_ value: Any?, expected: Set<String>) -> Bool {
+        guard let object = value as? [String: Any] else { return false }
+        return Set(object.keys) == expected
+    }
+
+    private static func validSharedVaultsJSON(_ data: Data) -> Bool {
+        guard let object = try? JSONSerialization.jsonObject(with: data),
+              exactKeys(object, expected: ["vaults"]),
+              let vaults = (object as? [String: Any])?["vaults"] as? [Any]
+        else { return false }
+        let keys: Set<String> = [
+            "id", "teamID", "name", "revision", "keyGeneration", "rotationRequired",
+            "createdAt", "updatedAt"
+        ]
+        return vaults.allSatisfy { exactKeys($0, expected: keys) }
+    }
+
+    private static func validTeamKeyDevicesJSON(_ data: Data) -> Bool {
+        guard let object = try? JSONSerialization.jsonObject(with: data),
+              exactKeys(object, expected: ["devices"]),
+              let devices = (object as? [String: Any])?["devices"] as? [Any]
+        else { return false }
+        let keys: Set<String> = [
+            "membershipID", "membershipEpoch", "deviceID", "publicKeyAlgorithm",
+            "publicKey", "hasWrapper"
+        ]
+        return devices.allSatisfy { exactKeys($0, expected: keys) }
+    }
+
+    private static func validSharedVaultEnvelopeJSON(_ data: Data) -> Bool {
+        guard let object = try? JSONSerialization.jsonObject(with: data) else { return false }
+        return exactKeys(object, expected: [
+            "id", "teamID", "name", "revision", "keyGeneration", "rotationRequired",
+            "envelopeVersion", "ciphertext", "nonce", "authTag", "contentHash", "wrapper",
+            "createdAt", "updatedAt"
+        ])
+    }
+
+    private static func validTeamVaultWriteJSON(_ data: Data, conflict: Bool) -> Bool {
+        guard let object = try? JSONSerialization.jsonObject(with: data) else { return false }
+        return exactKeys(
+            object,
+            expected: conflict
+                ? ["conflict", "revision", "keyGeneration"]
+                : ["conflict", "revision", "keyGeneration", "rotationCompleted"]
+        )
+    }
+
+    private static func validSharedVaultEnvelope(
+        _ value: SelectiveRemoteCloudSharedVaultEnvelope,
+        teamID: UUID,
+        vaultID: UUID
+    ) -> Bool {
+        let summary = SelectiveRemoteCloudSharedVault(
+            id: value.id,
+            teamID: value.teamID,
+            name: value.name,
+            revision: value.revision,
+            keyGeneration: value.keyGeneration,
+            rotationRequired: value.rotationRequired,
+            createdAt: value.createdAt,
+            updatedAt: value.updatedAt
+        )
+        guard value.id == vaultID, validSharedVault(summary, teamID: teamID) else { return false }
+        if value.revision == 0 {
+            return value.envelopeVersion == nil
+                && value.ciphertext == nil
+                && value.nonce == nil
+                && value.authTag == nil
+                && value.contentHash == nil
+                && value.wrapper == nil
         }
-        return data
+        return (try? value.payloadEnvelope) != nil
+    }
+
+    private static func validIdempotencyKey(_ value: String) -> Bool {
+        (16...128).contains(value.count)
+            && value.range(of: "^[A-Za-z0-9._:-]+$", options: .regularExpression) != nil
+    }
+
+    private static func validUpload(
+        _ upload: SelectiveRemoteCloudTeamVaultUpload,
+        teamID: UUID,
+        vaultID: UUID
+    ) throws -> Bool {
+        guard let wrappers = upload.wrappers else { return true }
+        guard !wrappers.isEmpty,
+              wrappers.count <= 1_024,
+              Set(wrappers.map(\.deviceID)).count == wrappers.count
+        else { return false }
+        return try wrappers.allSatisfy { wrapper in
+            let context = try SelectiveRemoteTeamWrapperContext(
+                teamID: teamID,
+                vaultID: vaultID,
+                keyGeneration: upload.envelope.keyGeneration,
+                membershipID: wrapper.membershipID,
+                membershipEpoch: wrapper.membershipEpoch,
+                deviceID: wrapper.deviceID
+            )
+            return wrapper.contextHash == SelectiveRemoteTeamVaultCrypto.wrapperContextHash(context)
+        }
     }
 
     private func storedToken(for endpoint: URL) throws -> String? {
@@ -335,6 +654,21 @@ private struct LoginResponse: Decodable {
 
 private struct TeamsResponse: Decodable {
     var teams: [SelectiveRemoteCloudTeam]
+}
+
+private struct SharedVaultsResponse: Decodable {
+    var vaults: [SelectiveRemoteCloudSharedVault]
+}
+
+private struct TeamKeyDevicesResponse: Decodable {
+    var devices: [SelectiveRemoteCloudTeamKeyDevice]
+}
+
+private struct TeamVaultWriteResponse: Decodable {
+    var conflict: Bool
+    var revision: Int
+    var keyGeneration: Int
+    var rotationCompleted: Bool?
 }
 
 private struct CloudServiceError: Decodable {

--- a/Sources/SelectiveRemote/CloudTeamCrypto.swift
+++ b/Sources/SelectiveRemote/CloudTeamCrypto.swift
@@ -9,6 +9,9 @@ enum SelectiveRemoteTeamCryptoError: Error, Equatable {
     case wrapperDeviceMismatch
     case wrapperContextMismatch
     case keyUnwrapFailed
+    case payloadContentHashMismatch
+    case payloadEncryptionFailed
+    case payloadDecryptionFailed
 }
 
 struct SelectiveRemoteTeamDevicePublicKey: Codable, Equatable, Sendable {
@@ -165,6 +168,67 @@ struct SelectiveRemoteTeamVaultKeyWrapper: Codable, Equatable, Sendable {
     }
 }
 
+struct SelectiveRemoteTeamVaultPayloadEnvelope: Codable, Equatable, Sendable {
+    let baseRevision: Int
+    let keyGeneration: Int
+    let envelopeVersion: Int
+    let ciphertext: String
+    let nonce: String
+    let authTag: String
+    let contentHash: String
+
+    enum CodingKeys: String, CodingKey {
+        case baseRevision, keyGeneration, envelopeVersion
+        case ciphertext, nonce, authTag, contentHash
+    }
+
+    init(
+        baseRevision: Int,
+        keyGeneration: Int,
+        envelopeVersion: Int = 1,
+        ciphertext: String,
+        nonce: String,
+        authTag: String,
+        contentHash: String
+    ) throws {
+        guard baseRevision >= 0,
+              keyGeneration > 0,
+              envelopeVersion == 1,
+              let ciphertextData = Data(selectiveRemoteBase64URL: ciphertext),
+              ciphertextData.count <= 24 * 1024 * 1024,
+              Data(selectiveRemoteBase64URL: nonce, expectedLength: 12) != nil,
+              Data(selectiveRemoteBase64URL: authTag, expectedLength: 16) != nil,
+              Data(selectiveRemoteBase64URL: contentHash, expectedLength: 32) != nil
+        else { throw SelectiveRemoteTeamCryptoError.invalidEnvelope }
+        self.baseRevision = baseRevision
+        self.keyGeneration = keyGeneration
+        self.envelopeVersion = envelopeVersion
+        self.ciphertext = ciphertext
+        self.nonce = nonce
+        self.authTag = authTag
+        self.contentHash = contentHash
+    }
+
+    init(from decoder: any Decoder) throws {
+        let actualKeys = try decoder.container(keyedBy: SelectiveRemoteAnyCodingKey.self)
+            .allKeys.map(\.stringValue).sorted()
+        guard actualKeys == [
+            "authTag", "baseRevision", "ciphertext", "contentHash",
+            "envelopeVersion", "keyGeneration", "nonce"
+        ] else { throw SelectiveRemoteTeamCryptoError.invalidEnvelope }
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(
+            baseRevision: try values.decode(Int.self, forKey: .baseRevision),
+            keyGeneration: try values.decode(Int.self, forKey: .keyGeneration),
+            envelopeVersion: try values.decode(Int.self, forKey: .envelopeVersion),
+            ciphertext: try values.decode(String.self, forKey: .ciphertext),
+            nonce: try values.decode(String.self, forKey: .nonce),
+            authTag: try values.decode(String.self, forKey: .authTag),
+            contentHash: try values.decode(String.self, forKey: .contentHash)
+        )
+    }
+}
+
 struct SelectiveRemoteTeamWrapperContext: Equatable, Sendable {
     let teamID: UUID
     let vaultID: UUID
@@ -258,6 +322,102 @@ enum SelectiveRemoteTeamVaultCrypto {
         let context = try payloadContext(teamID: teamID, vaultID: vaultID, keyGeneration: keyGeneration)
         let bytes = Data([envelopeVersion]) + context + nonceData + ciphertextData + authTagData
         return Data(SHA256.hash(data: bytes)).selectiveRemoteBase64URL
+    }
+
+    static func encryptPayload(
+        _ payload: Data,
+        vaultKey: Data,
+        teamID: UUID,
+        vaultID: UUID,
+        keyGeneration: Int,
+        baseRevision: Int,
+        nonce: Data? = nil
+    ) throws -> SelectiveRemoteTeamVaultPayloadEnvelope {
+        guard vaultKey.count == 32,
+              payload.count <= 24 * 1024 * 1024,
+              baseRevision >= 0
+        else { throw SelectiveRemoteTeamCryptoError.invalidEnvelope }
+        let context = try payloadContext(
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: keyGeneration
+        )
+        let nonceData = nonce ?? Data(AES.GCM.Nonce())
+        guard nonceData.count == 12 else { throw SelectiveRemoteTeamCryptoError.invalidEnvelope }
+        do {
+            let sealed = try AES.GCM.seal(
+                payload,
+                using: SymmetricKey(data: vaultKey),
+                nonce: AES.GCM.Nonce(data: nonceData),
+                authenticating: context
+            )
+            let ciphertext = sealed.ciphertext.selectiveRemoteBase64URL
+            let authTag = sealed.tag.selectiveRemoteBase64URL
+            return try SelectiveRemoteTeamVaultPayloadEnvelope(
+                baseRevision: baseRevision,
+                keyGeneration: keyGeneration,
+                ciphertext: ciphertext,
+                nonce: nonceData.selectiveRemoteBase64URL,
+                authTag: authTag,
+                contentHash: payloadContentHash(
+                    teamID: teamID,
+                    vaultID: vaultID,
+                    keyGeneration: keyGeneration,
+                    nonce: nonceData.selectiveRemoteBase64URL,
+                    ciphertext: ciphertext,
+                    authTag: authTag
+                )
+            )
+        } catch let error as SelectiveRemoteTeamCryptoError {
+            throw error
+        } catch {
+            throw SelectiveRemoteTeamCryptoError.payloadEncryptionFailed
+        }
+    }
+
+    static func decryptPayload(
+        _ envelope: SelectiveRemoteTeamVaultPayloadEnvelope,
+        vaultKey: Data,
+        teamID: UUID,
+        vaultID: UUID
+    ) throws -> Data {
+        guard vaultKey.count == 32,
+              let nonce = Data(selectiveRemoteBase64URL: envelope.nonce, expectedLength: 12),
+              let ciphertext = Data(selectiveRemoteBase64URL: envelope.ciphertext),
+              ciphertext.count <= 24 * 1024 * 1024,
+              let tag = Data(selectiveRemoteBase64URL: envelope.authTag, expectedLength: 16)
+        else { throw SelectiveRemoteTeamCryptoError.invalidEnvelope }
+        let expectedHash = try payloadContentHash(
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: envelope.keyGeneration,
+            nonce: envelope.nonce,
+            ciphertext: envelope.ciphertext,
+            authTag: envelope.authTag
+        )
+        guard envelope.contentHash == expectedHash else {
+            throw SelectiveRemoteTeamCryptoError.payloadContentHashMismatch
+        }
+        do {
+            let sealed = try AES.GCM.SealedBox(
+                nonce: AES.GCM.Nonce(data: nonce),
+                ciphertext: ciphertext,
+                tag: tag
+            )
+            return try AES.GCM.open(
+                sealed,
+                using: SymmetricKey(data: vaultKey),
+                authenticating: payloadContext(
+                    teamID: teamID,
+                    vaultID: vaultID,
+                    keyGeneration: envelope.keyGeneration
+                )
+            )
+        } catch let error as SelectiveRemoteTeamCryptoError {
+            throw error
+        } catch {
+            throw SelectiveRemoteTeamCryptoError.payloadDecryptionFailed
+        }
     }
 
     static func wrapVaultKey(

--- a/Sources/SelectiveRemote/CloudTeamVaultSnapshotStore.swift
+++ b/Sources/SelectiveRemote/CloudTeamVaultSnapshotStore.swift
@@ -86,14 +86,12 @@ protocol SelectiveRemoteTeamVaultSnapshotStore: Sendable {
 
 struct SelectiveRemoteTeamVaultFileSnapshotStore: SelectiveRemoteTeamVaultSnapshotStore {
     private let root: URL
-    private let fileManager: FileManager
 
-    init(root: URL? = nil, fileManager: FileManager = .default) throws {
-        self.fileManager = fileManager
+    init(root: URL? = nil) throws {
         if let root {
             self.root = root
         } else {
-            guard let applicationSupport = fileManager.urls(
+            guard let applicationSupport = FileManager.default.urls(
                 for: .applicationSupportDirectory,
                 in: .userDomainMask
             ).first else { throw SelectiveRemoteTeamVaultSnapshotError.storageUnavailable }
@@ -105,6 +103,7 @@ struct SelectiveRemoteTeamVaultFileSnapshotStore: SelectiveRemoteTeamVaultSnapsh
 
     func load(endpoint: URL, teamID: UUID, vaultID: UUID) throws -> SelectiveRemoteTeamVaultSnapshot? {
         let url = try snapshotURL(endpoint: endpoint, teamID: teamID, vaultID: vaultID)
+        let fileManager = FileManager.default
         guard fileManager.fileExists(atPath: url.path) else { return nil }
         do {
             let data = try Data(contentsOf: url, options: .mappedIfSafe)
@@ -118,6 +117,7 @@ struct SelectiveRemoteTeamVaultFileSnapshotStore: SelectiveRemoteTeamVaultSnapsh
 
     func save(_ snapshot: SelectiveRemoteTeamVaultSnapshot, endpoint: URL) throws {
         let url = try snapshotURL(endpoint: endpoint, teamID: snapshot.teamID, vaultID: snapshot.vaultID)
+        let fileManager = FileManager.default
         do {
             try fileManager.createDirectory(
                 at: url.deletingLastPathComponent(),
@@ -135,6 +135,7 @@ struct SelectiveRemoteTeamVaultFileSnapshotStore: SelectiveRemoteTeamVaultSnapsh
 
     func remove(endpoint: URL, teamID: UUID, vaultID: UUID) throws {
         let url = try snapshotURL(endpoint: endpoint, teamID: teamID, vaultID: vaultID)
+        let fileManager = FileManager.default
         guard fileManager.fileExists(atPath: url.path) else { return }
         do {
             try fileManager.removeItem(at: url)
@@ -173,7 +174,7 @@ final class SelectiveRemoteTeamVaultMemorySnapshotStore: SelectiveRemoteTeamVaul
 
     func remove(endpoint: URL, teamID: UUID, vaultID: UUID) throws {
         let key = try snapshotKey(endpoint: endpoint, teamID: teamID, vaultID: vaultID)
-        lock.withLock { snapshots.removeValue(forKey: key) }
+        _ = lock.withLock { snapshots.removeValue(forKey: key) }
     }
 
     private func snapshotKey(endpoint: URL, teamID: UUID, vaultID: UUID) throws -> String {

--- a/Sources/SelectiveRemote/CloudTeamVaultSnapshotStore.swift
+++ b/Sources/SelectiveRemote/CloudTeamVaultSnapshotStore.swift
@@ -1,0 +1,186 @@
+import CryptoKit
+import Foundation
+
+enum SelectiveRemoteTeamVaultSnapshotError: Error, Equatable {
+    case invalidSnapshot
+    case storageUnavailable
+}
+
+struct SelectiveRemoteTeamVaultSnapshot: Codable, Equatable, Sendable {
+    let teamID: UUID
+    let vaultID: UUID
+    let deviceID: UUID
+    let keyGeneration: Int
+    let localRevision: Int
+    let serverRevision: Int
+    let syncedLocalRevision: Int
+    let envelope: SelectiveRemoteTeamVaultPayloadEnvelope
+    let wrapper: SelectiveRemoteTeamVaultKeyWrapper
+
+    enum CodingKeys: String, CodingKey {
+        case teamID, vaultID, deviceID, keyGeneration
+        case localRevision, serverRevision, syncedLocalRevision
+        case envelope, wrapper
+    }
+
+    init(
+        teamID: UUID,
+        vaultID: UUID,
+        deviceID: UUID,
+        keyGeneration: Int,
+        localRevision: Int,
+        serverRevision: Int,
+        syncedLocalRevision: Int,
+        envelope: SelectiveRemoteTeamVaultPayloadEnvelope,
+        wrapper: SelectiveRemoteTeamVaultKeyWrapper
+    ) throws {
+        guard teamID.isSelectiveRemoteCloudUUID,
+              vaultID.isSelectiveRemoteCloudUUID,
+              deviceID.isSelectiveRemoteCloudUUID,
+              keyGeneration > 0,
+              localRevision > 0,
+              serverRevision >= 0,
+              syncedLocalRevision >= 0,
+              syncedLocalRevision <= localRevision,
+              envelope.keyGeneration == keyGeneration,
+              wrapper.deviceID == deviceID
+        else { throw SelectiveRemoteTeamVaultSnapshotError.invalidSnapshot }
+        self.teamID = teamID
+        self.vaultID = vaultID
+        self.deviceID = deviceID
+        self.keyGeneration = keyGeneration
+        self.localRevision = localRevision
+        self.serverRevision = serverRevision
+        self.syncedLocalRevision = syncedLocalRevision
+        self.envelope = envelope
+        self.wrapper = wrapper
+    }
+
+    init(from decoder: any Decoder) throws {
+        let actualKeys = try decoder.container(keyedBy: SelectiveRemoteAnyCodingKey.self)
+            .allKeys.map(\.stringValue).sorted()
+        guard actualKeys == [
+            "deviceID", "envelope", "keyGeneration", "localRevision", "serverRevision",
+            "syncedLocalRevision", "teamID", "vaultID", "wrapper"
+        ] else { throw SelectiveRemoteTeamVaultSnapshotError.invalidSnapshot }
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(
+            teamID: values.decode(UUID.self, forKey: .teamID),
+            vaultID: values.decode(UUID.self, forKey: .vaultID),
+            deviceID: values.decode(UUID.self, forKey: .deviceID),
+            keyGeneration: values.decode(Int.self, forKey: .keyGeneration),
+            localRevision: values.decode(Int.self, forKey: .localRevision),
+            serverRevision: values.decode(Int.self, forKey: .serverRevision),
+            syncedLocalRevision: values.decode(Int.self, forKey: .syncedLocalRevision),
+            envelope: values.decode(SelectiveRemoteTeamVaultPayloadEnvelope.self, forKey: .envelope),
+            wrapper: values.decode(SelectiveRemoteTeamVaultKeyWrapper.self, forKey: .wrapper)
+        )
+    }
+}
+
+protocol SelectiveRemoteTeamVaultSnapshotStore: Sendable {
+    func load(endpoint: URL, teamID: UUID, vaultID: UUID) throws -> SelectiveRemoteTeamVaultSnapshot?
+    func save(_ snapshot: SelectiveRemoteTeamVaultSnapshot, endpoint: URL) throws
+    func remove(endpoint: URL, teamID: UUID, vaultID: UUID) throws
+}
+
+struct SelectiveRemoteTeamVaultFileSnapshotStore: SelectiveRemoteTeamVaultSnapshotStore {
+    private let root: URL
+    private let fileManager: FileManager
+
+    init(root: URL? = nil, fileManager: FileManager = .default) throws {
+        self.fileManager = fileManager
+        if let root {
+            self.root = root
+        } else {
+            guard let applicationSupport = fileManager.urls(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask
+            ).first else { throw SelectiveRemoteTeamVaultSnapshotError.storageUnavailable }
+            self.root = applicationSupport
+                .appending(path: "Selective Remote", directoryHint: .isDirectory)
+                .appending(path: "CloudTeamVaults", directoryHint: .isDirectory)
+        }
+    }
+
+    func load(endpoint: URL, teamID: UUID, vaultID: UUID) throws -> SelectiveRemoteTeamVaultSnapshot? {
+        let url = try snapshotURL(endpoint: endpoint, teamID: teamID, vaultID: vaultID)
+        guard fileManager.fileExists(atPath: url.path) else { return nil }
+        do {
+            let data = try Data(contentsOf: url, options: .mappedIfSafe)
+            return try JSONDecoder().decode(SelectiveRemoteTeamVaultSnapshot.self, from: data)
+        } catch let error as SelectiveRemoteTeamVaultSnapshotError {
+            throw error
+        } catch {
+            throw SelectiveRemoteTeamVaultSnapshotError.invalidSnapshot
+        }
+    }
+
+    func save(_ snapshot: SelectiveRemoteTeamVaultSnapshot, endpoint: URL) throws {
+        let url = try snapshotURL(endpoint: endpoint, teamID: snapshot.teamID, vaultID: snapshot.vaultID)
+        do {
+            try fileManager.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            try encoder.encode(snapshot).write(to: url, options: [.atomic])
+            try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+        } catch {
+            throw SelectiveRemoteTeamVaultSnapshotError.storageUnavailable
+        }
+    }
+
+    func remove(endpoint: URL, teamID: UUID, vaultID: UUID) throws {
+        let url = try snapshotURL(endpoint: endpoint, teamID: teamID, vaultID: vaultID)
+        guard fileManager.fileExists(atPath: url.path) else { return }
+        do {
+            try fileManager.removeItem(at: url)
+        } catch {
+            throw SelectiveRemoteTeamVaultSnapshotError.storageUnavailable
+        }
+    }
+
+    private func snapshotURL(endpoint: URL, teamID: UUID, vaultID: UUID) throws -> URL {
+        guard teamID.isSelectiveRemoteCloudUUID, vaultID.isSelectiveRemoteCloudUUID else {
+            throw SelectiveRemoteTeamVaultSnapshotError.invalidSnapshot
+        }
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized(endpoint.absoluteString)
+        let endpointID = Data(SHA256.hash(data: Data(endpoint.absoluteString.utf8)))
+            .map { String(format: "%02x", $0) }
+            .joined()
+        return root
+            .appending(path: endpointID, directoryHint: .isDirectory)
+            .appending(path: "\(teamID.canonicalCloudString)-\(vaultID.canonicalCloudString).json")
+    }
+}
+
+final class SelectiveRemoteTeamVaultMemorySnapshotStore: SelectiveRemoteTeamVaultSnapshotStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var snapshots: [String: SelectiveRemoteTeamVaultSnapshot] = [:]
+
+    func load(endpoint: URL, teamID: UUID, vaultID: UUID) throws -> SelectiveRemoteTeamVaultSnapshot? {
+        let key = try snapshotKey(endpoint: endpoint, teamID: teamID, vaultID: vaultID)
+        return lock.withLock { snapshots[key] }
+    }
+
+    func save(_ snapshot: SelectiveRemoteTeamVaultSnapshot, endpoint: URL) throws {
+        let key = try snapshotKey(endpoint: endpoint, teamID: snapshot.teamID, vaultID: snapshot.vaultID)
+        lock.withLock { snapshots[key] = snapshot }
+    }
+
+    func remove(endpoint: URL, teamID: UUID, vaultID: UUID) throws {
+        let key = try snapshotKey(endpoint: endpoint, teamID: teamID, vaultID: vaultID)
+        lock.withLock { snapshots.removeValue(forKey: key) }
+    }
+
+    private func snapshotKey(endpoint: URL, teamID: UUID, vaultID: UUID) throws -> String {
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized(endpoint.absoluteString)
+        guard teamID.isSelectiveRemoteCloudUUID, vaultID.isSelectiveRemoteCloudUUID else {
+            throw SelectiveRemoteTeamVaultSnapshotError.invalidSnapshot
+        }
+        return "\(endpoint.absoluteString)|\(teamID.canonicalCloudString)|\(vaultID.canonicalCloudString)"
+    }
+}

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -192,6 +192,196 @@ struct CloudMacOSFoundationTests {
         }
     }
 
+    @Test("macOS deterministic payload decrypts in the browser fixture format")
+    func sharedPayloadFixture() throws {
+        let fixture = try Self.fixture()
+        let payload = try fixture.payload.plaintext.base64URLData
+        let vaultKey = try fixture.keyWrap.vaultKey.base64URLData
+        let teamID = try fixture.payload.teamID.uuid
+        let vaultID = try fixture.payload.vaultID.uuid
+        let envelope = try SelectiveRemoteTeamVaultCrypto.encryptPayload(
+            payload,
+            vaultKey: vaultKey,
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: fixture.payload.keyGeneration,
+            baseRevision: fixture.payload.baseRevision,
+            nonce: try fixture.payload.nonce.base64URLData
+        )
+        #expect(envelope.ciphertext == fixture.payload.ciphertext)
+        #expect(envelope.authTag == fixture.payload.authTag)
+        #expect(envelope.contentHash == fixture.payload.contentHash)
+        #expect(try SelectiveRemoteTeamVaultCrypto.decryptPayload(
+            envelope,
+            vaultKey: vaultKey,
+            teamID: teamID,
+            vaultID: vaultID
+        ) == payload)
+
+        let otherTeamID = try #require(UUID(uuidString: "99999999-9999-4999-8999-999999999999"))
+        #expect(throws: SelectiveRemoteTeamCryptoError.payloadContentHashMismatch) {
+            try SelectiveRemoteTeamVaultCrypto.decryptPayload(
+                envelope,
+                vaultKey: vaultKey,
+                teamID: otherTeamID,
+                vaultID: vaultID
+            )
+        }
+    }
+
+    @Test("typed macOS Team Vault transport preserves conditional conflict state")
+    func teamVaultTransport() async throws {
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized("https://cloud.example.invalid")
+        let teamID = try #require(UUID(uuidString: "11111111-1111-4111-8111-111111111111"))
+        let vaultID = try #require(UUID(uuidString: "22222222-2222-4222-8222-222222222222"))
+        let deviceID = try #require(UUID(uuidString: "44444444-4444-4444-8444-444444444444"))
+        let membershipID = try #require(UUID(uuidString: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"))
+        let fixture = try Self.fixture()
+        let token = String(repeating: "t", count: 43)
+        let store = SelectiveRemoteCloudMemoryTokenStore()
+        try store.saveToken(token, for: endpoint)
+        let stub = CloudHTTPStub { request in
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer \(token)")
+            switch (request.httpMethod, request.url?.path) {
+            case ("GET", "/v1/teams/\(teamID.canonicalCloudString)/vaults"):
+                return Self.response(request, status: 200, json: ["vaults": [[
+                    "id": vaultID.canonicalCloudString,
+                    "teamID": teamID.canonicalCloudString,
+                    "name": "Operations",
+                    "revision": 5,
+                    "keyGeneration": 7,
+                    "rotationRequired": false,
+                    "createdAt": "2026-09-06T00:00:00.000Z",
+                    "updatedAt": "2026-09-06T00:00:00.000Z"
+                ]]])
+            case ("GET", "/v1/teams/\(teamID.canonicalCloudString)/vaults/\(vaultID.canonicalCloudString)/key-devices"):
+                return Self.response(request, status: 200, json: ["devices": [[
+                    "membershipID": membershipID.canonicalCloudString,
+                    "membershipEpoch": 3,
+                    "deviceID": deviceID.canonicalCloudString,
+                    "publicKeyAlgorithm": "p256-ecdh-v1",
+                    "publicKey": [
+                        "kty": fixture.publicKey.kty, "crv": fixture.publicKey.crv,
+                        "x": fixture.publicKey.x, "y": fixture.publicKey.y,
+                        "ext": fixture.publicKey.ext, "key_ops": fixture.publicKey.keyOps
+                    ],
+                    "hasWrapper": true
+                ]]])
+            case ("GET", "/v1/teams/\(teamID.canonicalCloudString)/vaults/\(vaultID.canonicalCloudString)"):
+                return Self.response(request, status: 200, json: [
+                    "id": vaultID.canonicalCloudString,
+                    "teamID": teamID.canonicalCloudString,
+                    "name": "Operations",
+                    "revision": 5,
+                    "keyGeneration": 7,
+                    "rotationRequired": false,
+                    "envelopeVersion": fixture.payload.envelopeVersion,
+                    "ciphertext": fixture.payload.ciphertext,
+                    "nonce": fixture.payload.nonce,
+                    "authTag": fixture.payload.authTag,
+                    "contentHash": fixture.payload.contentHash,
+                    "wrapper": NSNull(),
+                    "createdAt": "2026-09-06T00:00:00.000Z",
+                    "updatedAt": "2026-09-06T00:00:00.000Z"
+                ])
+            case ("PUT", "/v1/teams/\(teamID.canonicalCloudString)/vaults/\(vaultID.canonicalCloudString)"):
+                #expect(request.value(forHTTPHeaderField: "Idempotency-Key") == "macos:team:vault:synthetic-1")
+                #expect(request.httpBody.map { String(decoding: $0, as: UTF8.self) }?.contains("schemaVersion") == false)
+                return Self.response(request, status: 409, json: [
+                    "conflict": true, "revision": 6, "keyGeneration": 7
+                ])
+            default:
+                Issue.record("Unexpected request: \(request.httpMethod ?? "nil") \(request.url?.path ?? "nil")")
+                return Self.response(request, status: 500, json: ["error": "unexpected_request"])
+            }
+        }
+        let client = SelectiveRemoteCloudAPIClient(
+            tokenStore: store,
+            dataLoader: { request in try stub.data(for: request) }
+        )
+        #expect(try await client.sharedVaults(endpoint: endpoint, teamID: teamID).map(\.id) == [vaultID])
+        #expect(try await client.teamKeyDevices(
+            endpoint: endpoint,
+            teamID: teamID,
+            vaultID: vaultID
+        ).map(\.deviceID) == [deviceID])
+        let remote = try await client.sharedVault(endpoint: endpoint, teamID: teamID, vaultID: vaultID)
+        let downloadedEnvelope = try remote.payloadEnvelope
+        let envelope = try #require(downloadedEnvelope)
+        #expect(envelope.contentHash == fixture.payload.contentHash)
+        let result = try await client.putSharedVault(
+            endpoint: endpoint,
+            teamID: teamID,
+            vaultID: vaultID,
+            upload: .init(envelope: envelope, wrappers: nil),
+            idempotencyKey: "macos:team:vault:synthetic-1"
+        )
+        #expect(result == .init(conflict: true, revision: 6, keyGeneration: 7, rotationCompleted: nil))
+    }
+
+    @Test("offline Team Vault storage persists only the strict ciphertext snapshot")
+    func ciphertextOnlySnapshot() throws {
+        let fixture = try Self.fixture()
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized("https://cloud.example.invalid")
+        let teamID = try fixture.wrapper.teamID.uuid
+        let vaultID = try fixture.wrapper.vaultID.uuid
+        let deviceID = try fixture.wrapper.deviceID.uuid
+        let identity = try SelectiveRemoteTeamDeviceIdentity(
+            deviceID: deviceID,
+            privateKeyRepresentation: try fixture.keyWrap.recipientPrivateScalar.base64URLData
+        )
+        let wrapper = try SelectiveRemoteTeamVaultCrypto.wrapVaultKey(
+            try fixture.keyWrap.vaultKey.base64URLData,
+            for: identity.publicKey,
+            context: SelectiveRemoteTeamWrapperContext(
+                teamID: teamID,
+                vaultID: vaultID,
+                keyGeneration: fixture.payload.keyGeneration,
+                membershipID: try fixture.wrapper.membershipID.uuid,
+                membershipEpoch: fixture.wrapper.membershipEpoch,
+                deviceID: deviceID
+            ),
+            ephemeralPrivateKeyRepresentation: try fixture.keyWrap.ephemeralPrivateScalar.base64URLData,
+            nonce: try fixture.keyWrap.nonce.base64URLData
+        )
+        let envelope = try SelectiveRemoteTeamVaultCrypto.encryptPayload(
+            try fixture.payload.plaintext.base64URLData,
+            vaultKey: try fixture.keyWrap.vaultKey.base64URLData,
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: fixture.payload.keyGeneration,
+            baseRevision: fixture.payload.baseRevision,
+            nonce: try fixture.payload.nonce.base64URLData
+        )
+        let snapshot = try SelectiveRemoteTeamVaultSnapshot(
+            teamID: teamID,
+            vaultID: vaultID,
+            deviceID: deviceID,
+            keyGeneration: fixture.payload.keyGeneration,
+            localRevision: 2,
+            serverRevision: 5,
+            syncedLocalRevision: 1,
+            envelope: envelope,
+            wrapper: wrapper
+        )
+        let root = FileManager.default.temporaryDirectory
+            .appending(path: "selective-remote-team-vault-\(UUID().uuidString)", directoryHint: .isDirectory)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let storage = try SelectiveRemoteTeamVaultFileSnapshotStore(root: root)
+        try storage.save(snapshot, endpoint: endpoint)
+        #expect(try storage.load(endpoint: endpoint, teamID: teamID, vaultID: vaultID) == snapshot)
+        let files = try FileManager.default.subpathsOfDirectory(atPath: root.path)
+            .filter { $0.hasSuffix(".json") }
+        let storedFile = try #require(files.first)
+        let fileURL = root.appending(path: storedFile)
+        let bytes = try Data(contentsOf: fileURL)
+        #expect(!String(decoding: bytes, as: UTF8.self).contains("schemaVersion"))
+        let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        #expect(attributes[.posixPermissions] as? Int == 0o600)
+        try storage.remove(endpoint: endpoint, teamID: teamID, vaultID: vaultID)
+        #expect(try storage.load(endpoint: endpoint, teamID: teamID, vaultID: vaultID) == nil)
+    }
+
     private static func fixture() throws -> TeamVaultFixture {
         let url = try #require(Bundle.module.url(
             forResource: "team-vault-v1",
@@ -229,7 +419,7 @@ private final class CloudHTTPStub: @unchecked Sendable {
     }
 }
 
-private struct TeamVaultFixture: Decodable {
+private struct TeamVaultFixture: Decodable, Sendable {
     var version: Int
     var publicKey: SelectiveRemoteTeamDevicePublicKey
     var fingerprint: String
@@ -237,7 +427,7 @@ private struct TeamVaultFixture: Decodable {
     var keyWrap: KeyWrap
     var payload: Payload
 
-    struct Wrapper: Decodable {
+    struct Wrapper: Decodable, Sendable {
         var teamID: String
         var vaultID: String
         var keyGeneration: Int
@@ -248,19 +438,21 @@ private struct TeamVaultFixture: Decodable {
         var contextHash: String
     }
 
-    struct Payload: Decodable {
+    struct Payload: Decodable, Sendable {
         var teamID: String
         var vaultID: String
         var keyGeneration: Int
         var contextBase64URL: String
         var envelopeVersion: Int
+        var baseRevision: Int
+        var plaintext: String
         var nonce: String
         var ciphertext: String
         var authTag: String
         var contentHash: String
     }
 
-    struct KeyWrap: Decodable {
+    struct KeyWrap: Decodable, Sendable {
         var recipientPrivateScalar: String
         var ephemeralPrivateScalar: String
         var ephemeralPublicKey: SelectiveRemoteTeamDevicePublicKey

--- a/Tests/SelectiveRemoteTests/Fixtures/team-vault-v1.json
+++ b/Tests/SelectiveRemoteTests/Fixtures/team-vault-v1.json
@@ -41,9 +41,11 @@
     "keyGeneration": 7,
     "contextBase64URL": "c2VsZWN0aXZlLXJlbW90ZS90ZWFtLXZhdWx0LXBheWxvYWQvdjEAMTExMTExMTEtMTExMS00MTExLTgxMTEtMTExMTExMTExMTExADIyMjIyMjIyLTIyMjItNDIyMi04MjIyLTIyMjIyMjIyMjIyMgA3",
     "envelopeVersion": 1,
+    "baseRevision": 4,
+    "plaintext": "eyJzY2hlbWFWZXJzaW9uIjoxLCJyZWNvcmRzIjpbXSwidG9tYnN0b25lcyI6W119",
     "nonce": "AAECAwQFBgcICQoL",
-    "ciphertext": "ABEiM0RVZneImaq7zN3u_w",
-    "authTag": "_-7dzLuqmYh3ZlVEMyIRAA",
-    "contentHash": "YtvpsswK9ghmnw0Z20FNE8KtfO2Cu3kZCreugkuyeFk"
+    "ciphertext": "PCCleK2Ar3rbJOX42IYWT7nnqxaCHjwTSgOWpycyXZ4jZMGRzbJm9xrBDM-y3HVF",
+    "authTag": "jqEFDz8qlc31mlD_P2EvwQ",
+    "contentHash": "El7H2EzE4PydPIKRZlBfzop391y015HyfqY6bf5NpFI"
   }
 }

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -25,9 +25,13 @@ milestone is the complete macOS implementation and cross-client acceptance.
 The macOS foundation now provides typed login/logout/current-user/Team
 transport, device-only Keychain bearer-session and P-256 device-identity
 storage, strict fingerprint/context/content-hash primitives, and interoperable
-ECDH/HKDF/AES-GCM Team Vault-key wrap/unwrap. A deterministic synthetic JSON
-fixture is produced exactly by Swift and decrypted by the browser tests; Vault
-payload encryption, sync UI and end-to-end service acceptance remain pending.
+ECDH/HKDF/AES-GCM Team Vault-key wrap/unwrap. This bounded macOS layer adds
+scope/generation-bound Team payload encryption/decryption, strict shared-Vault
+list/key-device/download/conditional-upload transport and atomic local storage
+of ciphertext-only offline snapshots. A deterministic synthetic JSON fixture is
+produced exactly by Swift and decrypted by the browser tests. Full sync
+orchestration, personal-Vault recovery wrapping, sync UI and end-to-end service
+acceptance remain pending.
 
 The browser portal can create and unlock a client-encrypted personal Vault,
 perform local CRUD, sign in with an existing verified account and manually

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -35,3 +35,20 @@ test("macOS Team crypto source pins the browser protocol labels and strict JWK s
   assert.match(identity, /savePrivateKeyIfAbsent/);
   assert.doesNotMatch(identity, /UserDefaults/);
 });
+
+test("macOS Team payload transport persists ciphertext-only offline snapshots", async () => {
+  const [client, crypto, snapshots] = await Promise.all([
+    readFile(new URL("CloudAPIClient.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudTeamCrypto.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudTeamVaultSnapshotStore.swift", sourceRoot), "utf8"),
+  ]);
+  assert.match(crypto, /static func encryptPayload/);
+  assert.match(crypto, /static func decryptPayload/);
+  assert.match(crypto, /payloadContentHashMismatch/);
+  assert.match(client, /Idempotency-Key/);
+  assert.match(client, /http\.statusCode == 200 \|\| http\.statusCode == 409/);
+  assert.match(client, /key-devices/);
+  assert.match(snapshots, /\.write\(to: url, options: \[\.atomic\]\)/);
+  assert.match(snapshots, /posixPermissions: 0o600/);
+  assert.doesNotMatch(snapshots, /\b(?:let|var)\s+(?:vaultKey|plaintext|password|token)\b/iu);
+});

--- a/cloud/tests/macos-team-vault-fixture.test.mjs
+++ b/cloud/tests/macos-team-vault-fixture.test.mjs
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import { createHash, webcrypto } from "node:crypto";
 import test from "node:test";
 import {
+  decryptTeamVaultPayload,
   teamDevicePublicKeyFingerprint,
   teamVaultWrapperContext,
   teamVaultWrapperContextHash,
@@ -88,4 +89,35 @@ test("browser unwraps the deterministic macOS Team Vault key wrapper", async () 
     Buffer.from(await webcrypto.subtle.exportKey("raw", key)).toString("base64url"),
     fixture.keyWrap.vaultKey,
   );
+});
+
+test("browser decrypts the deterministic macOS Team Vault payload", async () => {
+  const fixture = JSON.parse(await readFile(fixtureURL, "utf8"));
+  const vaultKey = await webcrypto.subtle.importKey(
+    "raw",
+    decodeBase64URL(fixture.keyWrap.vaultKey),
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["decrypt"],
+  );
+  const envelope = {
+    baseRevision: fixture.payload.baseRevision,
+    keyGeneration: fixture.payload.keyGeneration,
+    envelopeVersion: fixture.payload.envelopeVersion,
+    ciphertext: fixture.payload.ciphertext,
+    nonce: fixture.payload.nonce,
+    authTag: fixture.payload.authTag,
+    contentHash: fixture.payload.contentHash,
+  };
+  const payload = await decryptTeamVaultPayload({
+    vaultKey,
+    envelope,
+    scope: {
+      type: "team",
+      teamID: fixture.payload.teamID,
+      vaultID: fixture.payload.vaultID,
+    },
+    cryptoValue: webcrypto,
+  });
+  assert.deepEqual(payload, JSON.parse(decodeBase64URL(fixture.payload.plaintext).toString("utf8")));
 });

--- a/docs/cloud-v0.32-team-threat-model.md
+++ b/docs/cloud-v0.32-team-threat-model.md
@@ -10,8 +10,11 @@ device approval/revocation, causal shared-record synchronization and atomic
 rotation completion. The macOS foundation now pins device-only Keychain
 session and P-256 identity storage, exact fingerprints/context hashes, and
 ECDH/HKDF/AES-GCM Team Vault-key wrapping. A deterministic synthetic wrapper
-created by Swift must decrypt in browser code. Full macOS payload encryption,
-Vault sync/UI and service-level cross-client acceptance remain.
+created by Swift must decrypt in browser code. The bounded follow-up also adds
+scope/generation-bound Team payload encryption, strict conditional API transport
+and atomic ciphertext-only offline snapshots; the browser decrypts the exact
+Swift payload fixture. Full sync orchestration, personal-Vault recovery
+wrapping, Vault UI and service-level cross-client acceptance remain.
 
 ## Security outcome
 


### PR DESCRIPTION
## Summary
- add scope/generation-bound AES-256-GCM Team Vault payload encryption/decryption with pre-decrypt content-hash verification
- add strict typed macOS shared-Vault list, key-device, download, and idempotent conditional upload transport
- atomically persist only ciphertext envelopes/wrappers and revision metadata for offline Team snapshots
- extend the shared synthetic fixture so Swift emits a payload that browser WebCrypto decrypts exactly

## Verification
- Cloud suite: 231 passed, 0 failed, 1 PostgreSQL-only test skipped locally because TEST_DATABASE_URL is unavailable
- focused source/cross-client tests: 15 passed
- npm audit --omit=dev: 0 vulnerabilities
- JSON, JavaScript syntax, and git diff checks passed
- Swift/macOS compilation and tests are delegated to CI because Swift is unavailable in this container

## Boundary
No UI, full sync/conflict orchestration, personal-Vault recovery wrapping, staging deployment, registration change, or release. Public main is unchanged.