### PR TITLE
Cloud: add macOS Team Vault sync coordinator

### DIFF
--- a/Sources/SelectiveRemote/CloudTeamVaultSyncCoordinator.swift
+++ b/Sources/SelectiveRemote/CloudTeamVaultSyncCoordinator.swift
@@ -1,0 +1,365 @@
+import Foundation
+
+enum SelectiveRemoteTeamVaultSyncError: Error, Equatable {
+    case rotationRequired
+    case missingDeviceWrapper
+    case noLocalSnapshot
+    case noLocalChanges
+    case invalidLocalSnapshot
+    case remoteRevisionRollback
+    case remoteRevisionDivergence
+    case invalidWriteAcknowledgement
+    case invalidConflictResponse
+}
+
+protocol SelectiveRemoteTeamVaultRemote: Sendable {
+    func sharedVault(
+        endpoint: URL,
+        teamID: UUID,
+        vaultID: UUID
+    ) async throws -> SelectiveRemoteCloudSharedVaultEnvelope
+
+    func putSharedVault(
+        endpoint: URL,
+        teamID: UUID,
+        vaultID: UUID,
+        upload: SelectiveRemoteCloudTeamVaultUpload,
+        idempotencyKey: String
+    ) async throws -> SelectiveRemoteCloudTeamVaultWriteResult
+}
+
+extension SelectiveRemoteCloudAPIClient: SelectiveRemoteTeamVaultRemote {}
+
+struct SelectiveRemoteTeamVaultDecryptedSnapshot: Equatable, Sendable {
+    let snapshot: SelectiveRemoteTeamVaultSnapshot
+    let payload: Data
+}
+
+struct SelectiveRemoteTeamVaultRemoteVersion: Equatable, Sendable {
+    let revision: Int
+    let keyGeneration: Int
+    let envelope: SelectiveRemoteTeamVaultPayloadEnvelope
+    let wrapper: SelectiveRemoteTeamVaultKeyWrapper
+    let payload: Data
+}
+
+struct SelectiveRemoteTeamVaultConflict: Equatable, Sendable {
+    let local: SelectiveRemoteTeamVaultDecryptedSnapshot
+    let remote: SelectiveRemoteTeamVaultRemoteVersion
+}
+
+enum SelectiveRemoteTeamVaultRefreshOutcome: Equatable, Sendable {
+    case empty(SelectiveRemoteCloudSharedVaultEnvelope)
+    case synchronized(SelectiveRemoteTeamVaultDecryptedSnapshot)
+    case localChanges(SelectiveRemoteTeamVaultDecryptedSnapshot)
+    case conflict(SelectiveRemoteTeamVaultConflict)
+}
+
+enum SelectiveRemoteTeamVaultPushOutcome: Equatable, Sendable {
+    case uploaded(SelectiveRemoteTeamVaultDecryptedSnapshot)
+    case conflict(SelectiveRemoteTeamVaultConflict)
+}
+
+actor SelectiveRemoteTeamVaultSyncCoordinator {
+    private let endpoint: URL
+    private let remote: any SelectiveRemoteTeamVaultRemote
+    private let snapshots: any SelectiveRemoteTeamVaultSnapshotStore
+
+    init(
+        endpoint: URL,
+        remote: any SelectiveRemoteTeamVaultRemote,
+        snapshots: any SelectiveRemoteTeamVaultSnapshotStore
+    ) throws {
+        self.endpoint = try SelectiveRemoteCloudEndpoint.normalized(endpoint.absoluteString)
+        self.remote = remote
+        self.snapshots = snapshots
+    }
+
+    func refresh(
+        teamID: UUID,
+        vaultID: UUID,
+        identity: SelectiveRemoteTeamDeviceIdentity
+    ) async throws -> SelectiveRemoteTeamVaultRefreshOutcome {
+        let remoteEnvelope = try await remote.sharedVault(
+            endpoint: endpoint,
+            teamID: teamID,
+            vaultID: vaultID
+        )
+        guard !remoteEnvelope.rotationRequired else {
+            throw SelectiveRemoteTeamVaultSyncError.rotationRequired
+        }
+
+        let local = try snapshots.load(endpoint: endpoint, teamID: teamID, vaultID: vaultID)
+        guard remoteEnvelope.revision > 0 else {
+            guard local == nil else {
+                throw SelectiveRemoteTeamVaultSyncError.remoteRevisionRollback
+            }
+            return .empty(remoteEnvelope)
+        }
+
+        let remoteVersion = try decryptedRemoteVersion(
+            remoteEnvelope,
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+        guard let local else {
+            return .synchronized(try accept(
+                remoteVersion,
+                replacing: nil,
+                teamID: teamID,
+                vaultID: vaultID,
+                identity: identity
+            ))
+        }
+        guard local.deviceID == identity.deviceID else {
+            throw SelectiveRemoteTeamVaultSyncError.missingDeviceWrapper
+        }
+        try validateLocalCausality(local)
+        guard remoteVersion.revision >= local.serverRevision else {
+            throw SelectiveRemoteTeamVaultSyncError.remoteRevisionRollback
+        }
+
+        let localVersion = try decryptedLocalVersion(
+            local,
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+        let hasLocalChanges = local.localRevision > local.syncedLocalRevision
+
+        if remoteVersion.revision == local.serverRevision {
+            if remoteVersion.keyGeneration != local.keyGeneration {
+                throw SelectiveRemoteTeamVaultSyncError.remoteRevisionDivergence
+            }
+            if hasLocalChanges {
+                return .localChanges(localVersion)
+            }
+            guard remoteVersion.envelope.contentHash == local.envelope.contentHash else {
+                throw SelectiveRemoteTeamVaultSyncError.remoteRevisionDivergence
+            }
+            return .synchronized(try accept(
+                remoteVersion,
+                replacing: local,
+                teamID: teamID,
+                vaultID: vaultID,
+                identity: identity
+            ))
+        }
+
+        if hasLocalChanges {
+            return .conflict(.init(local: localVersion, remote: remoteVersion))
+        }
+        return .synchronized(try accept(
+            remoteVersion,
+            replacing: local,
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        ))
+    }
+
+    func stage(
+        _ payload: Data,
+        teamID: UUID,
+        vaultID: UUID,
+        identity: SelectiveRemoteTeamDeviceIdentity
+    ) throws -> SelectiveRemoteTeamVaultDecryptedSnapshot {
+        guard let current = try snapshots.load(endpoint: endpoint, teamID: teamID, vaultID: vaultID) else {
+            throw SelectiveRemoteTeamVaultSyncError.noLocalSnapshot
+        }
+        guard current.deviceID == identity.deviceID else {
+            throw SelectiveRemoteTeamVaultSyncError.missingDeviceWrapper
+        }
+        try validateLocalCausality(current)
+        let (nextLocalRevision, overflow) = current.localRevision.addingReportingOverflow(1)
+        guard !overflow else { throw SelectiveRemoteTeamVaultSyncError.invalidLocalSnapshot }
+        let vaultKey = try SelectiveRemoteTeamVaultCrypto.unwrapVaultKey(
+            current.wrapper,
+            with: identity,
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: current.keyGeneration
+        )
+        let envelope = try SelectiveRemoteTeamVaultCrypto.encryptPayload(
+            payload,
+            vaultKey: vaultKey,
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: current.keyGeneration,
+            baseRevision: current.serverRevision
+        )
+        let staged = try SelectiveRemoteTeamVaultSnapshot(
+            teamID: teamID,
+            vaultID: vaultID,
+            deviceID: identity.deviceID,
+            keyGeneration: current.keyGeneration,
+            localRevision: nextLocalRevision,
+            serverRevision: current.serverRevision,
+            syncedLocalRevision: current.syncedLocalRevision,
+            envelope: envelope,
+            wrapper: current.wrapper
+        )
+        try snapshots.save(staged, endpoint: endpoint)
+        return .init(snapshot: staged, payload: payload)
+    }
+
+    func push(
+        teamID: UUID,
+        vaultID: UUID,
+        identity: SelectiveRemoteTeamDeviceIdentity
+    ) async throws -> SelectiveRemoteTeamVaultPushOutcome {
+        guard let local = try snapshots.load(endpoint: endpoint, teamID: teamID, vaultID: vaultID) else {
+            throw SelectiveRemoteTeamVaultSyncError.noLocalSnapshot
+        }
+        guard local.localRevision > local.syncedLocalRevision else {
+            throw SelectiveRemoteTeamVaultSyncError.noLocalChanges
+        }
+        try validateLocalCausality(local)
+        let localVersion = try decryptedLocalVersion(
+            local,
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+        let write = try await remote.putSharedVault(
+            endpoint: endpoint,
+            teamID: teamID,
+            vaultID: vaultID,
+            upload: .init(envelope: local.envelope, wrappers: nil),
+            idempotencyKey: Self.idempotencyKey(vaultID: vaultID, snapshot: local)
+        )
+        if write.conflict {
+            guard write.revision >= local.serverRevision,
+                  write.keyGeneration > 0
+            else { throw SelectiveRemoteTeamVaultSyncError.invalidConflictResponse }
+            let refreshed = try await refresh(teamID: teamID, vaultID: vaultID, identity: identity)
+            guard case let .conflict(conflict) = refreshed else {
+                throw SelectiveRemoteTeamVaultSyncError.invalidConflictResponse
+            }
+            return .conflict(conflict)
+        }
+        let (expectedServerRevision, overflow) = local.serverRevision.addingReportingOverflow(1)
+        guard !overflow,
+              write.revision == expectedServerRevision,
+              write.keyGeneration == local.keyGeneration,
+              write.rotationCompleted == false
+        else { throw SelectiveRemoteTeamVaultSyncError.invalidWriteAcknowledgement }
+
+        let uploaded = try SelectiveRemoteTeamVaultSnapshot(
+            teamID: teamID,
+            vaultID: vaultID,
+            deviceID: identity.deviceID,
+            keyGeneration: local.keyGeneration,
+            localRevision: local.localRevision,
+            serverRevision: write.revision,
+            syncedLocalRevision: local.localRevision,
+            envelope: local.envelope,
+            wrapper: local.wrapper
+        )
+        try snapshots.save(uploaded, endpoint: endpoint)
+        return .uploaded(.init(snapshot: uploaded, payload: localVersion.payload))
+    }
+
+    private func accept(
+        _ remoteVersion: SelectiveRemoteTeamVaultRemoteVersion,
+        replacing local: SelectiveRemoteTeamVaultSnapshot?,
+        teamID: UUID,
+        vaultID: UUID,
+        identity: SelectiveRemoteTeamDeviceIdentity
+    ) throws -> SelectiveRemoteTeamVaultDecryptedSnapshot {
+        let sameRevision = local?.serverRevision == remoteVersion.revision
+        let previousLocalRevision = local?.localRevision ?? 0
+        let (advancedLocalRevision, overflow) = previousLocalRevision.addingReportingOverflow(1)
+        guard !overflow else { throw SelectiveRemoteTeamVaultSyncError.invalidLocalSnapshot }
+        let localRevision = sameRevision ? (local?.localRevision ?? 1) : advancedLocalRevision
+        let accepted = try SelectiveRemoteTeamVaultSnapshot(
+            teamID: teamID,
+            vaultID: vaultID,
+            deviceID: identity.deviceID,
+            keyGeneration: remoteVersion.keyGeneration,
+            localRevision: localRevision,
+            serverRevision: remoteVersion.revision,
+            syncedLocalRevision: localRevision,
+            envelope: remoteVersion.envelope,
+            wrapper: remoteVersion.wrapper
+        )
+        try snapshots.save(accepted, endpoint: endpoint)
+        return .init(snapshot: accepted, payload: remoteVersion.payload)
+    }
+
+    private func decryptedRemoteVersion(
+        _ value: SelectiveRemoteCloudSharedVaultEnvelope,
+        teamID: UUID,
+        vaultID: UUID,
+        identity: SelectiveRemoteTeamDeviceIdentity
+    ) throws -> SelectiveRemoteTeamVaultRemoteVersion {
+        guard let envelope = try value.payloadEnvelope,
+              let wrapper = value.wrapper,
+              wrapper.deviceID == identity.deviceID
+        else { throw SelectiveRemoteTeamVaultSyncError.missingDeviceWrapper }
+        let vaultKey = try SelectiveRemoteTeamVaultCrypto.unwrapVaultKey(
+            wrapper,
+            with: identity,
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: value.keyGeneration
+        )
+        let payload = try SelectiveRemoteTeamVaultCrypto.decryptPayload(
+            envelope,
+            vaultKey: vaultKey,
+            teamID: teamID,
+            vaultID: vaultID
+        )
+        return .init(
+            revision: value.revision,
+            keyGeneration: value.keyGeneration,
+            envelope: envelope,
+            wrapper: wrapper,
+            payload: payload
+        )
+    }
+
+    private func decryptedLocalVersion(
+        _ value: SelectiveRemoteTeamVaultSnapshot,
+        teamID: UUID,
+        vaultID: UUID,
+        identity: SelectiveRemoteTeamDeviceIdentity
+    ) throws -> SelectiveRemoteTeamVaultDecryptedSnapshot {
+        guard value.teamID == teamID,
+              value.vaultID == vaultID,
+              value.deviceID == identity.deviceID
+        else { throw SelectiveRemoteTeamVaultSyncError.missingDeviceWrapper }
+        let vaultKey = try SelectiveRemoteTeamVaultCrypto.unwrapVaultKey(
+            value.wrapper,
+            with: identity,
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: value.keyGeneration
+        )
+        let payload = try SelectiveRemoteTeamVaultCrypto.decryptPayload(
+            value.envelope,
+            vaultKey: vaultKey,
+            teamID: teamID,
+            vaultID: vaultID
+        )
+        return .init(snapshot: value, payload: payload)
+    }
+
+    private func validateLocalCausality(_ value: SelectiveRemoteTeamVaultSnapshot) throws {
+        let hasLocalChanges = value.localRevision > value.syncedLocalRevision
+        let expectedBaseRevision = hasLocalChanges
+            ? value.serverRevision
+            : max(0, value.serverRevision - 1)
+        guard value.envelope.baseRevision == expectedBaseRevision else {
+            throw SelectiveRemoteTeamVaultSyncError.invalidLocalSnapshot
+        }
+    }
+
+    private static func idempotencyKey(
+        vaultID: UUID,
+        snapshot: SelectiveRemoteTeamVaultSnapshot
+    ) -> String {
+        "macos:team-vault:\(vaultID.canonicalCloudString):\(snapshot.localRevision):\(snapshot.envelope.contentHash)"
+    }
+}

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -351,7 +351,8 @@ struct CloudMacOSFoundationTests {
             Issue.record("Expected the first remote revision to be synchronized")
             return
         }
-        #expect(initial.payload == (try fixture.payload.plaintext.base64URLData))
+        let initialPayload = try fixture.payload.plaintext.base64URLData
+        #expect(initial.payload == initialPayload)
         #expect(initial.snapshot.serverRevision == 5)
         #expect(initial.snapshot.localRevision == initial.snapshot.syncedLocalRevision)
 

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -319,6 +319,174 @@ struct CloudMacOSFoundationTests {
         #expect(result == .init(conflict: true, revision: 6, keyGeneration: 7, rotationCompleted: nil))
     }
 
+    @Test("Team Vault coordinator stages and acknowledges one causal upload")
+    func teamVaultSyncUpload() async throws {
+        let fixture = try Self.fixture()
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized("https://cloud.example.invalid")
+        let teamID = try fixture.wrapper.teamID.uuid
+        let vaultID = try fixture.wrapper.vaultID.uuid
+        let deviceID = try fixture.wrapper.deviceID.uuid
+        let identity = try SelectiveRemoteTeamDeviceIdentity(
+            deviceID: deviceID,
+            privateKeyRepresentation: try fixture.keyWrap.recipientPrivateScalar.base64URLData
+        )
+        let wrapper = try Self.fixtureWrapper(fixture, identity: identity)
+        let remote = TeamVaultRemoteStub(
+            envelope: Self.remoteEnvelope(fixture, wrapper: wrapper),
+            writeResult: .init(conflict: false, revision: 6, keyGeneration: 7, rotationCompleted: false)
+        )
+        let storage = SelectiveRemoteTeamVaultMemorySnapshotStore()
+        let coordinator = try SelectiveRemoteTeamVaultSyncCoordinator(
+            endpoint: endpoint,
+            remote: remote,
+            snapshots: storage
+        )
+
+        let refreshed = try await coordinator.refresh(
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+        guard case let .synchronized(initial) = refreshed else {
+            Issue.record("Expected the first remote revision to be synchronized")
+            return
+        }
+        #expect(initial.payload == (try fixture.payload.plaintext.base64URLData))
+        #expect(initial.snapshot.serverRevision == 5)
+        #expect(initial.snapshot.localRevision == initial.snapshot.syncedLocalRevision)
+
+        let editedPayload = Data("synthetic local edit".utf8)
+        let staged = try await coordinator.stage(
+            editedPayload,
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+        #expect(staged.snapshot.envelope.baseRevision == 5)
+        #expect(staged.snapshot.localRevision == 2)
+        #expect(staged.snapshot.syncedLocalRevision == 1)
+
+        let pushed = try await coordinator.push(
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+        guard case let .uploaded(uploaded) = pushed else {
+            Issue.record("Expected the staged payload to upload")
+            return
+        }
+        #expect(uploaded.payload == editedPayload)
+        #expect(uploaded.snapshot.serverRevision == 6)
+        #expect(uploaded.snapshot.localRevision == uploaded.snapshot.syncedLocalRevision)
+        let writes = await remote.recordedWrites()
+        #expect(writes.count == 1)
+        #expect(writes.first?.upload.envelope == staged.snapshot.envelope)
+        #expect(writes.first?.idempotencyKey.contains(staged.snapshot.envelope.contentHash) == true)
+    }
+
+    @Test("Team Vault coordinator preserves the dirty snapshot and both conflict versions")
+    func teamVaultSyncConflict() async throws {
+        let fixture = try Self.fixture()
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized("https://cloud.example.invalid")
+        let teamID = try fixture.wrapper.teamID.uuid
+        let vaultID = try fixture.wrapper.vaultID.uuid
+        let deviceID = try fixture.wrapper.deviceID.uuid
+        let identity = try SelectiveRemoteTeamDeviceIdentity(
+            deviceID: deviceID,
+            privateKeyRepresentation: try fixture.keyWrap.recipientPrivateScalar.base64URLData
+        )
+        let wrapper = try Self.fixtureWrapper(fixture, identity: identity)
+        let remote = TeamVaultRemoteStub(
+            envelope: Self.remoteEnvelope(fixture, wrapper: wrapper),
+            writeResult: .init(conflict: true, revision: 6, keyGeneration: 7, rotationCompleted: nil)
+        )
+        let storage = SelectiveRemoteTeamVaultMemorySnapshotStore()
+        let coordinator = try SelectiveRemoteTeamVaultSyncCoordinator(
+            endpoint: endpoint,
+            remote: remote,
+            snapshots: storage
+        )
+        _ = try await coordinator.refresh(teamID: teamID, vaultID: vaultID, identity: identity)
+
+        let localPayload = Data("synthetic local conflict".utf8)
+        let staged = try await coordinator.stage(
+            localPayload,
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+        let remotePayload = Data("synthetic remote conflict".utf8)
+        let remoteCiphertext = try SelectiveRemoteTeamVaultCrypto.encryptPayload(
+            remotePayload,
+            vaultKey: try fixture.keyWrap.vaultKey.base64URLData,
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: fixture.payload.keyGeneration,
+            baseRevision: 5,
+            nonce: Data(repeating: 0x23, count: 12)
+        )
+        await remote.setEnvelope(.init(
+            id: vaultID,
+            teamID: teamID,
+            name: "Operations",
+            revision: 6,
+            keyGeneration: fixture.payload.keyGeneration,
+            rotationRequired: false,
+            envelopeVersion: remoteCiphertext.envelopeVersion,
+            ciphertext: remoteCiphertext.ciphertext,
+            nonce: remoteCiphertext.nonce,
+            authTag: remoteCiphertext.authTag,
+            contentHash: remoteCiphertext.contentHash,
+            wrapper: wrapper,
+            createdAt: "2026-09-06T00:00:00.000Z",
+            updatedAt: "2026-09-07T00:00:00.000Z"
+        ))
+
+        let pushed = try await coordinator.push(
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+        guard case let .conflict(conflict) = pushed else {
+            Issue.record("Expected an explicit causal conflict")
+            return
+        }
+        #expect(conflict.local.payload == localPayload)
+        #expect(conflict.remote.payload == remotePayload)
+        #expect(conflict.local.snapshot.envelope == staged.snapshot.envelope)
+        let preserved = try storage.load(endpoint: endpoint, teamID: teamID, vaultID: vaultID)
+        #expect(preserved == staged.snapshot)
+    }
+
+    @Test("Team Vault coordinator fails closed while key rotation is required")
+    func teamVaultSyncRotationGate() async throws {
+        let fixture = try Self.fixture()
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized("https://cloud.example.invalid")
+        let identity = try SelectiveRemoteTeamDeviceIdentity(
+            deviceID: try fixture.wrapper.deviceID.uuid,
+            privateKeyRepresentation: try fixture.keyWrap.recipientPrivateScalar.base64URLData
+        )
+        let wrapper = try Self.fixtureWrapper(fixture, identity: identity)
+        var blocked = Self.remoteEnvelope(fixture, wrapper: wrapper)
+        blocked.rotationRequired = true
+        let remote = TeamVaultRemoteStub(
+            envelope: blocked,
+            writeResult: .init(conflict: false, revision: 6, keyGeneration: 7, rotationCompleted: false)
+        )
+        let coordinator = try SelectiveRemoteTeamVaultSyncCoordinator(
+            endpoint: endpoint,
+            remote: remote,
+            snapshots: SelectiveRemoteTeamVaultMemorySnapshotStore()
+        )
+        await #expect(throws: SelectiveRemoteTeamVaultSyncError.rotationRequired) {
+            try await coordinator.refresh(
+                teamID: try fixture.wrapper.teamID.uuid,
+                vaultID: try fixture.wrapper.vaultID.uuid,
+                identity: identity
+            )
+        }
+    }
+
     @Test("offline Team Vault storage persists only the strict ciphertext snapshot")
     func ciphertextOnlySnapshot() throws {
         let fixture = try Self.fixture()
@@ -391,6 +559,48 @@ struct CloudMacOSFoundationTests {
         return try JSONDecoder().decode(TeamVaultFixture.self, from: Data(contentsOf: url))
     }
 
+    private static func fixtureWrapper(
+        _ fixture: TeamVaultFixture,
+        identity: SelectiveRemoteTeamDeviceIdentity
+    ) throws -> SelectiveRemoteTeamVaultKeyWrapper {
+        try SelectiveRemoteTeamVaultCrypto.wrapVaultKey(
+            fixture.keyWrap.vaultKey.base64URLData,
+            for: identity.publicKey,
+            context: SelectiveRemoteTeamWrapperContext(
+                teamID: try fixture.wrapper.teamID.uuid,
+                vaultID: try fixture.wrapper.vaultID.uuid,
+                keyGeneration: fixture.wrapper.keyGeneration,
+                membershipID: try fixture.wrapper.membershipID.uuid,
+                membershipEpoch: fixture.wrapper.membershipEpoch,
+                deviceID: identity.deviceID
+            ),
+            ephemeralPrivateKeyRepresentation: fixture.keyWrap.ephemeralPrivateScalar.base64URLData,
+            nonce: fixture.keyWrap.nonce.base64URLData
+        )
+    }
+
+    private static func remoteEnvelope(
+        _ fixture: TeamVaultFixture,
+        wrapper: SelectiveRemoteTeamVaultKeyWrapper
+    ) -> SelectiveRemoteCloudSharedVaultEnvelope {
+        .init(
+            id: UUID(uuidString: fixture.wrapper.vaultID)!,
+            teamID: UUID(uuidString: fixture.wrapper.teamID)!,
+            name: "Operations",
+            revision: fixture.payload.baseRevision + 1,
+            keyGeneration: fixture.payload.keyGeneration,
+            rotationRequired: false,
+            envelopeVersion: fixture.payload.envelopeVersion,
+            ciphertext: fixture.payload.ciphertext,
+            nonce: fixture.payload.nonce,
+            authTag: fixture.payload.authTag,
+            contentHash: fixture.payload.contentHash,
+            wrapper: wrapper,
+            createdAt: "2026-09-06T00:00:00.000Z",
+            updatedAt: "2026-09-06T00:00:00.000Z"
+        )
+    }
+
     private static func response(
         _ request: URLRequest,
         status: Int,
@@ -416,6 +626,56 @@ private final class CloudHTTPStub: @unchecked Sendable {
 
     func data(for request: URLRequest) throws -> (Data, URLResponse) {
         try handler(request)
+    }
+}
+
+private actor TeamVaultRemoteStub: SelectiveRemoteTeamVaultRemote {
+    struct RecordedWrite: Equatable, Sendable {
+        let upload: SelectiveRemoteCloudTeamVaultUpload
+        let idempotencyKey: String
+    }
+
+    private var envelope: SelectiveRemoteCloudSharedVaultEnvelope
+    private var writeResult: SelectiveRemoteCloudTeamVaultWriteResult
+    private var writes: [RecordedWrite] = []
+
+    init(
+        envelope: SelectiveRemoteCloudSharedVaultEnvelope,
+        writeResult: SelectiveRemoteCloudTeamVaultWriteResult
+    ) {
+        self.envelope = envelope
+        self.writeResult = writeResult
+    }
+
+    func sharedVault(
+        endpoint _: URL,
+        teamID: UUID,
+        vaultID: UUID
+    ) async throws -> SelectiveRemoteCloudSharedVaultEnvelope {
+        #expect(envelope.teamID == teamID)
+        #expect(envelope.id == vaultID)
+        return envelope
+    }
+
+    func putSharedVault(
+        endpoint _: URL,
+        teamID: UUID,
+        vaultID: UUID,
+        upload: SelectiveRemoteCloudTeamVaultUpload,
+        idempotencyKey: String
+    ) async throws -> SelectiveRemoteCloudTeamVaultWriteResult {
+        #expect(envelope.teamID == teamID)
+        #expect(envelope.id == vaultID)
+        writes.append(.init(upload: upload, idempotencyKey: idempotencyKey))
+        return writeResult
+    }
+
+    func setEnvelope(_ value: SelectiveRemoteCloudSharedVaultEnvelope) {
+        envelope = value
+    }
+
+    func recordedWrites() -> [RecordedWrite] {
+        writes
     }
 }
 

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -29,9 +29,13 @@ ECDH/HKDF/AES-GCM Team Vault-key wrap/unwrap. This bounded macOS layer adds
 scope/generation-bound Team payload encryption/decryption, strict shared-Vault
 list/key-device/download/conditional-upload transport and atomic local storage
 of ciphertext-only offline snapshots. A deterministic synthetic JSON fixture is
-produced exactly by Swift and decrypted by the browser tests. Full sync
-orchestration, personal-Vault recovery wrapping, sync UI and end-to-end service
-acceptance remain pending.
+produced exactly by Swift and decrypted by the browser tests. The bounded sync
+coordinator accepts clean remote revisions, stages encrypted offline edits with
+deterministic retry identity, rejects rollback or same-revision divergence,
+fails closed during rotation and preserves both decrypted versions plus the
+dirty ciphertext snapshot on a 409. Personal-Vault recovery wrapping, sync UI,
+explicit conflict-resolution writes and end-to-end service acceptance remain
+pending.
 
 The browser portal can create and unlock a client-encrypted personal Vault,
 perform local CRUD, sign in with an existing verified account and manually

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -52,3 +52,19 @@ test("macOS Team payload transport persists ciphertext-only offline snapshots", 
   assert.match(snapshots, /posixPermissions: 0o600/);
   assert.doesNotMatch(snapshots, /\b(?:let|var)\s+(?:vaultKey|plaintext|password|token)\b/iu);
 });
+
+test("macOS Team Vault coordinator preserves causal dirty and conflict state", async () => {
+  const coordinator = await readFile(
+    new URL("CloudTeamVaultSyncCoordinator.swift", sourceRoot),
+    "utf8",
+  );
+  assert.match(coordinator, /actor SelectiveRemoteTeamVaultSyncCoordinator/);
+  assert.match(coordinator, /case rotationRequired/);
+  assert.match(coordinator, /case remoteRevisionRollback/);
+  assert.match(coordinator, /case remoteRevisionDivergence/);
+  assert.match(coordinator, /localRevision > local\.syncedLocalRevision/);
+  assert.match(coordinator, /return \.conflict\(\.init\(local: localVersion, remote: remoteVersion\)\)/);
+  assert.match(coordinator, /macos:team-vault:/);
+  assert.match(coordinator, /try snapshots\.save\(staged, endpoint: endpoint\)/);
+  assert.match(coordinator, /write\.revision == expectedServerRevision/);
+});

--- a/docs/cloud-v0.32-team-threat-model.md
+++ b/docs/cloud-v0.32-team-threat-model.md
@@ -13,8 +13,11 @@ ECDH/HKDF/AES-GCM Team Vault-key wrapping. A deterministic synthetic wrapper
 created by Swift must decrypt in browser code. The bounded follow-up also adds
 scope/generation-bound Team payload encryption, strict conditional API transport
 and atomic ciphertext-only offline snapshots; the browser decrypts the exact
-Swift payload fixture. Full sync orchestration, personal-Vault recovery
-wrapping, Vault UI and service-level cross-client acceptance remain.
+Swift payload fixture. The bounded macOS coordinator now stages causal encrypted
+edits, uses deterministic idempotency for retry, fails closed on rotation,
+rejects remote rollback/divergence and preserves local and remote versions on
+an optimistic conflict. Personal-Vault recovery wrapping, conflict-resolution
+writes, Vault UI and service-level cross-client acceptance remain.
 
 ## Security outcome
 
@@ -225,6 +228,7 @@ or wrappers.
   present.
 
 Team/shared Vault release status remains `planned_required`: the server-side
-protocol and browser Team UI/cryptography/causal sync/device approval/rotation
-completion are implemented, but macOS interoperability and the complete
+protocol, browser Team UI/cryptography/causal sync/device approval/rotation and
+the bounded macOS crypto/transport/offline coordinator are implemented, but
+macOS UI, explicit conflict-resolution writes and the complete cross-client
 acceptance suite must pass before Cloud 0.32 is complete.


### PR DESCRIPTION
## Summary
- add an actor-isolated macOS Team Vault sync coordinator over the merged transport, crypto and ciphertext snapshot layers
- accept clean remote revisions, stage causal encrypted offline edits, and acknowledge only exact next-revision writes
- preserve the dirty local snapshot and both decrypted versions on 409 conflicts
- fail closed on rotation, remote rollback/divergence, invalid local causal metadata, missing wrappers and inconsistent write acknowledgements
- derive deterministic idempotency keys from Vault/local revision/content hash so unknown network outcomes can be retried safely

## Verification
- full Cloud suite: 232 passed, 0 failed, 1 PostgreSQL-only test skipped locally because TEST_DATABASE_URL is unavailable
- focused macOS source/cross-client tests: 7 passed
- npm audit --omit=dev --offline: 0 vulnerabilities
- git diff checks passed
- Swift 6 compilation and tests are delegated to CI because Swift is unavailable in this container

## Boundary
No macOS UI, automatic background sync, explicit conflict-resolution write path, personal-Vault recovery wrapping, staging deployment, registration change or release. Public main remains unchanged.