### PR TITLE
Cloud: add macOS Team conflict resolution writes

### DIFF
--- a/Sources/SelectiveRemote/CloudTeamVaultSyncCoordinator.swift
+++ b/Sources/SelectiveRemote/CloudTeamVaultSyncCoordinator.swift
@@ -10,6 +10,7 @@ enum SelectiveRemoteTeamVaultSyncError: Error, Equatable {
     case remoteRevisionDivergence
     case invalidWriteAcknowledgement
     case invalidConflictResponse
+    case staleConflict
 }
 
 protocol SelectiveRemoteTeamVaultRemote: Sendable {
@@ -259,6 +260,92 @@ actor SelectiveRemoteTeamVaultSyncCoordinator {
         )
         try snapshots.save(uploaded, endpoint: endpoint)
         return .uploaded(.init(snapshot: uploaded, payload: localVersion.payload))
+    }
+
+    /// Conditionally uploads a caller-resolved payload from the exact remote
+    /// revision that produced the conflict. The caller must resolve every
+    /// record-level conflict and join both causal histories before calling.
+    ///
+    /// The existing dirty snapshot is left untouched until the remote version
+    /// is revalidated. Once prepared, the resolution remains dirty on disk so
+    /// an unknown network outcome can be retried with the same idempotency key.
+    func resolveConflict(
+        _ conflict: SelectiveRemoteTeamVaultConflict,
+        resolvedPayload: Data,
+        teamID: UUID,
+        vaultID: UUID,
+        identity: SelectiveRemoteTeamDeviceIdentity
+    ) async throws -> SelectiveRemoteTeamVaultPushOutcome {
+        guard let current = try snapshots.load(
+            endpoint: endpoint,
+            teamID: teamID,
+            vaultID: vaultID
+        ) else { throw SelectiveRemoteTeamVaultSyncError.noLocalSnapshot }
+        guard current == conflict.local.snapshot,
+              current.deviceID == identity.deviceID
+        else { throw SelectiveRemoteTeamVaultSyncError.staleConflict }
+        try validateLocalCausality(current)
+        let currentLocal = try decryptedLocalVersion(
+            current,
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+        guard currentLocal.payload == conflict.local.payload else {
+            throw SelectiveRemoteTeamVaultSyncError.staleConflict
+        }
+
+        let remoteEnvelope = try await remote.sharedVault(
+            endpoint: endpoint,
+            teamID: teamID,
+            vaultID: vaultID
+        )
+        guard !remoteEnvelope.rotationRequired else {
+            throw SelectiveRemoteTeamVaultSyncError.rotationRequired
+        }
+        let latestRemote = try decryptedRemoteVersion(
+            remoteEnvelope,
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+        guard latestRemote.revision > current.serverRevision else {
+            throw SelectiveRemoteTeamVaultSyncError.invalidConflictResponse
+        }
+        guard latestRemote == conflict.remote else {
+            return .conflict(.init(local: currentLocal, remote: latestRemote))
+        }
+
+        let (nextLocalRevision, overflow) = current.localRevision.addingReportingOverflow(1)
+        guard !overflow else { throw SelectiveRemoteTeamVaultSyncError.invalidLocalSnapshot }
+        let vaultKey = try SelectiveRemoteTeamVaultCrypto.unwrapVaultKey(
+            latestRemote.wrapper,
+            with: identity,
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: latestRemote.keyGeneration
+        )
+        let resolvedEnvelope = try SelectiveRemoteTeamVaultCrypto.encryptPayload(
+            resolvedPayload,
+            vaultKey: vaultKey,
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: latestRemote.keyGeneration,
+            baseRevision: latestRemote.revision
+        )
+        let prepared = try SelectiveRemoteTeamVaultSnapshot(
+            teamID: teamID,
+            vaultID: vaultID,
+            deviceID: identity.deviceID,
+            keyGeneration: latestRemote.keyGeneration,
+            localRevision: nextLocalRevision,
+            serverRevision: latestRemote.revision,
+            syncedLocalRevision: current.syncedLocalRevision,
+            envelope: resolvedEnvelope,
+            wrapper: latestRemote.wrapper
+        )
+        try snapshots.save(prepared, endpoint: endpoint)
+        return try await push(teamID: teamID, vaultID: vaultID, identity: identity)
     }
 
     private func accept(

--- a/Sources/SelectiveRemote/CloudTeamVaultSyncCoordinator.swift
+++ b/Sources/SelectiveRemote/CloudTeamVaultSyncCoordinator.swift
@@ -316,6 +316,17 @@ actor SelectiveRemoteTeamVaultSyncCoordinator {
             return .conflict(.init(local: currentLocal, remote: latestRemote))
         }
 
+        // Actor methods are re-entrant across the remote fetch above. Refuse
+        // to replace a newer local edit that was staged while this resolution
+        // was waiting for the network.
+        guard let revalidated = try snapshots.load(
+            endpoint: endpoint,
+            teamID: teamID,
+            vaultID: vaultID
+        ), revalidated == current else {
+            throw SelectiveRemoteTeamVaultSyncError.staleConflict
+        }
+
         let (nextLocalRevision, overflow) = current.localRevision.addingReportingOverflow(1)
         guard !overflow else { throw SelectiveRemoteTeamVaultSyncError.invalidLocalSnapshot }
         let vaultKey = try SelectiveRemoteTeamVaultCrypto.unwrapVaultKey(

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -512,9 +512,12 @@ struct CloudMacOSFoundationTests {
                 identity: identity
             )
         }
-        let pendingResolution = try #require(
-            storage.load(endpoint: endpoint, teamID: teamID, vaultID: vaultID)
+        let storedPendingResolution = try storage.load(
+            endpoint: endpoint,
+            teamID: teamID,
+            vaultID: vaultID
         )
+        let pendingResolution = try #require(storedPendingResolution)
         #expect(pendingResolution.envelope.baseRevision == 7)
         #expect(pendingResolution.localRevision > pendingResolution.syncedLocalRevision)
 

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -548,6 +548,97 @@ struct CloudMacOSFoundationTests {
         #expect(resolutionWrites.last?.idempotencyKey != resolutionWrites.first?.idempotencyKey)
     }
 
+    @Test("Team Vault conflict resolution preserves an edit staged during remote revalidation")
+    func teamVaultConflictResolutionReentrancy() async throws {
+        let fixture = try Self.fixture()
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized("https://cloud.example.invalid")
+        let teamID = try fixture.wrapper.teamID.uuid
+        let vaultID = try fixture.wrapper.vaultID.uuid
+        let identity = try SelectiveRemoteTeamDeviceIdentity(
+            deviceID: try fixture.wrapper.deviceID.uuid,
+            privateKeyRepresentation: try fixture.keyWrap.recipientPrivateScalar.base64URLData
+        )
+        let wrapper = try Self.fixtureWrapper(fixture, identity: identity)
+        let remote = TeamVaultRemoteStub(
+            envelope: Self.remoteEnvelope(fixture, wrapper: wrapper),
+            writeResult: .init(conflict: true, revision: 6, keyGeneration: 7, rotationCompleted: nil)
+        )
+        let storage = SelectiveRemoteTeamVaultMemorySnapshotStore()
+        let coordinator = try SelectiveRemoteTeamVaultSyncCoordinator(
+            endpoint: endpoint,
+            remote: remote,
+            snapshots: storage
+        )
+        _ = try await coordinator.refresh(teamID: teamID, vaultID: vaultID, identity: identity)
+        _ = try await coordinator.stage(
+            Data("synthetic original local conflict".utf8),
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+
+        let remotePayload = Data("synthetic remote conflict".utf8)
+        let remoteCiphertext = try SelectiveRemoteTeamVaultCrypto.encryptPayload(
+            remotePayload,
+            vaultKey: try fixture.keyWrap.vaultKey.base64URLData,
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: fixture.payload.keyGeneration,
+            baseRevision: 5,
+            nonce: Data(repeating: 0x26, count: 12)
+        )
+        await remote.setEnvelope(.init(
+            id: vaultID,
+            teamID: teamID,
+            name: "Operations",
+            revision: 6,
+            keyGeneration: fixture.payload.keyGeneration,
+            rotationRequired: false,
+            envelopeVersion: remoteCiphertext.envelopeVersion,
+            ciphertext: remoteCiphertext.ciphertext,
+            nonce: remoteCiphertext.nonce,
+            authTag: remoteCiphertext.authTag,
+            contentHash: remoteCiphertext.contentHash,
+            wrapper: wrapper,
+            createdAt: "2026-09-06T00:00:00.000Z",
+            updatedAt: "2026-09-07T00:00:00.000Z"
+        ))
+        let pushed = try await coordinator.push(teamID: teamID, vaultID: vaultID, identity: identity)
+        guard case let .conflict(conflict) = pushed else {
+            Issue.record("Expected an explicit conflict")
+            return
+        }
+
+        let barrier = TeamVaultReadBarrier()
+        await remote.setReadBarrier(barrier)
+        let resolving = Task {
+            try await coordinator.resolveConflict(
+                conflict,
+                resolvedPayload: Data("must not replace racing edit".utf8),
+                teamID: teamID,
+                vaultID: vaultID,
+                identity: identity
+            )
+        }
+        await barrier.waitUntilSuspended()
+        let racingPayload = Data("synthetic racing local edit".utf8)
+        let racing = try await coordinator.stage(
+            racingPayload,
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+        await barrier.resume()
+
+        await #expect(throws: SelectiveRemoteTeamVaultSyncError.staleConflict) {
+            try await resolving.value
+        }
+        let preserved = try storage.load(endpoint: endpoint, teamID: teamID, vaultID: vaultID)
+        #expect(preserved == racing.snapshot)
+        let writes = await remote.recordedWrites()
+        #expect(writes.count == 1)
+    }
+
     @Test("Team Vault coordinator fails closed while key rotation is required")
     func teamVaultSyncRotationGate() async throws {
         let fixture = try Self.fixture()
@@ -723,6 +814,29 @@ private enum TeamVaultRemoteStubFailure: Error, Equatable, Sendable {
     case unknownOutcome
 }
 
+private actor TeamVaultReadBarrier {
+    private var suspended = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func suspend() async {
+        suspended = true
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func waitUntilSuspended() async {
+        while !suspended {
+            await Task.yield()
+        }
+    }
+
+    func resume() {
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
 private actor TeamVaultRemoteStub: SelectiveRemoteTeamVaultRemote {
     struct RecordedWrite: Equatable, Sendable {
         let upload: SelectiveRemoteCloudTeamVaultUpload
@@ -732,6 +846,7 @@ private actor TeamVaultRemoteStub: SelectiveRemoteTeamVaultRemote {
     private var envelope: SelectiveRemoteCloudSharedVaultEnvelope
     private var writeResult: SelectiveRemoteCloudTeamVaultWriteResult
     private var writeFailure: TeamVaultRemoteStubFailure?
+    private var readBarrier: TeamVaultReadBarrier?
     private var writes: [RecordedWrite] = []
 
     init(
@@ -749,6 +864,10 @@ private actor TeamVaultRemoteStub: SelectiveRemoteTeamVaultRemote {
     ) async throws -> SelectiveRemoteCloudSharedVaultEnvelope {
         #expect(envelope.teamID == teamID)
         #expect(envelope.id == vaultID)
+        if let readBarrier {
+            self.readBarrier = nil
+            await readBarrier.suspend()
+        }
         return envelope
     }
 
@@ -778,6 +897,10 @@ private actor TeamVaultRemoteStub: SelectiveRemoteTeamVaultRemote {
 
     func setWriteFailure(_ value: TeamVaultRemoteStubFailure?) {
         writeFailure = value
+    }
+
+    func setReadBarrier(_ value: TeamVaultReadBarrier?) {
+        readBarrier = value
     }
 
     func recordedWrites() -> [RecordedWrite] {

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -457,6 +457,92 @@ struct CloudMacOSFoundationTests {
         #expect(conflict.local.snapshot.envelope == staged.snapshot.envelope)
         let preserved = try storage.load(endpoint: endpoint, teamID: teamID, vaultID: vaultID)
         #expect(preserved == staged.snapshot)
+
+        let newerRemotePayload = Data("synthetic newer remote conflict".utf8)
+        let newerRemoteCiphertext = try SelectiveRemoteTeamVaultCrypto.encryptPayload(
+            newerRemotePayload,
+            vaultKey: try fixture.keyWrap.vaultKey.base64URLData,
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: fixture.payload.keyGeneration,
+            baseRevision: 6,
+            nonce: Data(repeating: 0x24, count: 12)
+        )
+        await remote.setEnvelope(.init(
+            id: vaultID,
+            teamID: teamID,
+            name: "Operations",
+            revision: 7,
+            keyGeneration: fixture.payload.keyGeneration,
+            rotationRequired: false,
+            envelopeVersion: newerRemoteCiphertext.envelopeVersion,
+            ciphertext: newerRemoteCiphertext.ciphertext,
+            nonce: newerRemoteCiphertext.nonce,
+            authTag: newerRemoteCiphertext.authTag,
+            contentHash: newerRemoteCiphertext.contentHash,
+            wrapper: wrapper,
+            createdAt: "2026-09-06T00:00:00.000Z",
+            updatedAt: "2026-09-07T01:00:00.000Z"
+        ))
+        let staleResolution = try await coordinator.resolveConflict(
+            conflict,
+            resolvedPayload: Data("must not upload".utf8),
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+        guard case let .conflict(updatedConflict) = staleResolution else {
+            Issue.record("Expected a changed remote version to return a new conflict")
+            return
+        }
+        #expect(updatedConflict.remote.revision == 7)
+        #expect(updatedConflict.remote.payload == newerRemotePayload)
+        #expect(try storage.load(endpoint: endpoint, teamID: teamID, vaultID: vaultID) == staged.snapshot)
+        let staleResolutionWrites = await remote.recordedWrites()
+        #expect(staleResolutionWrites.count == 1)
+
+        let resolvedPayload = Data("synthetic joined conflict resolution".utf8)
+        await remote.setWriteFailure(.unknownOutcome)
+        await #expect(throws: TeamVaultRemoteStubFailure.unknownOutcome) {
+            try await coordinator.resolveConflict(
+                updatedConflict,
+                resolvedPayload: resolvedPayload,
+                teamID: teamID,
+                vaultID: vaultID,
+                identity: identity
+            )
+        }
+        let pendingResolution = try #require(
+            storage.load(endpoint: endpoint, teamID: teamID, vaultID: vaultID)
+        )
+        #expect(pendingResolution.envelope.baseRevision == 7)
+        #expect(pendingResolution.localRevision > pendingResolution.syncedLocalRevision)
+
+        await remote.setWriteFailure(nil)
+        await remote.setWriteResult(.init(
+            conflict: false,
+            revision: 8,
+            keyGeneration: fixture.payload.keyGeneration,
+            rotationCompleted: false
+        ))
+        let resolution = try await coordinator.push(
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+        guard case let .uploaded(uploaded) = resolution else {
+            Issue.record("Expected the explicit conflict resolution to upload")
+            return
+        }
+        #expect(uploaded.payload == resolvedPayload)
+        #expect(uploaded.snapshot.serverRevision == 8)
+        #expect(uploaded.snapshot.envelope.baseRevision == 7)
+        #expect(uploaded.snapshot.localRevision == uploaded.snapshot.syncedLocalRevision)
+        let resolutionWrites = await remote.recordedWrites()
+        #expect(resolutionWrites.count == 3)
+        #expect(resolutionWrites.last?.upload.envelope.baseRevision == 7)
+        #expect(resolutionWrites[1].idempotencyKey == resolutionWrites[2].idempotencyKey)
+        #expect(resolutionWrites.last?.idempotencyKey != resolutionWrites.first?.idempotencyKey)
     }
 
     @Test("Team Vault coordinator fails closed while key rotation is required")
@@ -630,6 +716,10 @@ private final class CloudHTTPStub: @unchecked Sendable {
     }
 }
 
+private enum TeamVaultRemoteStubFailure: Error, Equatable, Sendable {
+    case unknownOutcome
+}
+
 private actor TeamVaultRemoteStub: SelectiveRemoteTeamVaultRemote {
     struct RecordedWrite: Equatable, Sendable {
         let upload: SelectiveRemoteCloudTeamVaultUpload
@@ -638,6 +728,7 @@ private actor TeamVaultRemoteStub: SelectiveRemoteTeamVaultRemote {
 
     private var envelope: SelectiveRemoteCloudSharedVaultEnvelope
     private var writeResult: SelectiveRemoteCloudTeamVaultWriteResult
+    private var writeFailure: TeamVaultRemoteStubFailure?
     private var writes: [RecordedWrite] = []
 
     init(
@@ -668,11 +759,22 @@ private actor TeamVaultRemoteStub: SelectiveRemoteTeamVaultRemote {
         #expect(envelope.teamID == teamID)
         #expect(envelope.id == vaultID)
         writes.append(.init(upload: upload, idempotencyKey: idempotencyKey))
+        if let writeFailure {
+            throw writeFailure
+        }
         return writeResult
     }
 
     func setEnvelope(_ value: SelectiveRemoteCloudSharedVaultEnvelope) {
         envelope = value
+    }
+
+    func setWriteResult(_ value: SelectiveRemoteCloudTeamVaultWriteResult) {
+        writeResult = value
+    }
+
+    func setWriteFailure(_ value: TeamVaultRemoteStubFailure?) {
+        writeFailure = value
     }
 
     func recordedWrites() -> [RecordedWrite] {

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -33,9 +33,12 @@ produced exactly by Swift and decrypted by the browser tests. The bounded sync
 coordinator accepts clean remote revisions, stages encrypted offline edits with
 deterministic retry identity, rejects rollback or same-revision divergence,
 fails closed during rotation and preserves both decrypted versions plus the
-dirty ciphertext snapshot on a 409. Personal-Vault recovery wrapping, sync UI,
-explicit conflict-resolution writes and end-to-end service acceptance remain
-pending.
+dirty ciphertext snapshot on a 409. An explicit caller-provided resolution is
+accepted only while both the dirty local snapshot and observed remote version
+still match; it is re-encrypted from the observed remote revision and stays
+dirty until the exact conditional upload acknowledgement. Personal-Vault
+recovery wrapping, record-level conflict UI and end-to-end service acceptance
+remain pending.
 
 The browser portal can create and unlock a client-encrypted personal Vault,
 perform local CRUD, sign in with an existing verified account and manually

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -67,4 +67,8 @@ test("macOS Team Vault coordinator preserves causal dirty and conflict state", a
   assert.match(coordinator, /macos:team-vault:/);
   assert.match(coordinator, /try snapshots\.save\(staged, endpoint: endpoint\)/);
   assert.match(coordinator, /write\.revision == expectedServerRevision/);
+  assert.match(coordinator, /func resolveConflict\(/);
+  assert.match(coordinator, /latestRemote == conflict\.remote/);
+  assert.match(coordinator, /baseRevision: latestRemote\.revision/);
+  assert.match(coordinator, /return try await push\(teamID: teamID, vaultID: vaultID, identity: identity\)/);
 });

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -71,4 +71,5 @@ test("macOS Team Vault coordinator preserves causal dirty and conflict state", a
   assert.match(coordinator, /latestRemote == conflict\.remote/);
   assert.match(coordinator, /baseRevision: latestRemote\.revision/);
   assert.match(coordinator, /return try await push\(teamID: teamID, vaultID: vaultID, identity: identity\)/);
+  assert.match(coordinator, /revalidated == current/);
 });

--- a/docs/cloud-v0.32-team-threat-model.md
+++ b/docs/cloud-v0.32-team-threat-model.md
@@ -190,6 +190,10 @@ or wrappers.
   timestamps never choose a winner.
 - Conflict resolution joins both histories, creates a new local causal event
   and uploads conditionally. The server never sees the selected plaintext.
+- The macOS coordinator revalidates the exact dirty local snapshot and observed
+  remote version before preparing a caller-resolved payload. A changed remote
+  version returns a new conflict without writing; an unknown upload outcome
+  leaves the resolution dirty for deterministic-idempotency retry.
 - Role changes and rotation cannot be smuggled inside an encrypted record
   revision; they use separate authorized endpoints and durable transactions.
 


### PR DESCRIPTION
## Summary
- add an explicit macOS Team Vault conflict-resolution write path on top of the merged sync coordinator
- revalidate the exact dirty local snapshot and observed remote version before preparing a resolution
- return a fresh conflict without writing when the remote version moved
- re-encrypt the caller-resolved, causally joined payload from the observed server revision and conditionally upload it
- preserve a dirty prepared resolution after unknown network outcomes so retry uses the same deterministic idempotency key

## Verification
- full Cloud suite: 232 passed, 0 failed, 1 PostgreSQL-only test skipped locally because TEST_DATABASE_URL is unavailable
- focused macOS source tests: 4 passed
- npm audit --omit=dev --offline: 0 vulnerabilities
- git diff checks passed
- Swift 6 compilation and tests are delegated to CI because Swift is unavailable in this container

## Boundary
No record-level merge model/UI, automatic background sync, full personal-Vault sync/recovery wrapping, staging deployment, registration change or release. Public main and closed staging remain unchanged.