### PR TITLE
Cloud: add macOS causal record conflict workflow

### DIFF
--- a/Sources/SelectiveRemote/CloudVaultRecordModel.swift
+++ b/Sources/SelectiveRemote/CloudVaultRecordModel.swift
@@ -1,0 +1,609 @@
+import Foundation
+
+enum SelectiveRemoteVaultDocumentError: Error, Equatable {
+    case invalidVaultDocument
+    case invalidVaultSchemaVersion
+    case vaultTooLarge
+    case duplicateRecordID
+    case invalidVaultRecord
+    case invalidVaultTombstone
+    case invalidRecordType
+    case invalidRecordID
+    case invalidRecordVersion
+    case invalidModifiedAt
+    case invalidDeletedAt
+    case invalidRecordData
+    case invalidVaultConflict
+    case conflictRecordPresent
+    case invalidDevice
+    case incompleteConflictResolutions
+    case duplicateConflictResolution
+    case unknownConflictResolution
+}
+
+enum SelectiveRemoteVaultRecordType: String, Codable, CaseIterable, Sendable {
+    case host
+    case credential
+    case snippet
+    case forwarding
+}
+
+enum SelectiveRemoteJSONValue: Equatable, Sendable {
+    case null
+    case boolean(Bool)
+    case number(Double)
+    case string(String)
+    case array([SelectiveRemoteJSONValue])
+    case object([String: SelectiveRemoteJSONValue])
+}
+
+extension SelectiveRemoteJSONValue: Codable {
+    init(from decoder: Decoder) throws {
+        let values = try decoder.singleValueContainer()
+        if values.decodeNil() {
+            self = .null
+        } else if let value = try? values.decode(Bool.self) {
+            self = .boolean(value)
+        } else if let value = try? values.decode(Double.self) {
+            guard value.isFinite else {
+                throw SelectiveRemoteVaultDocumentError.invalidRecordData
+            }
+            self = .number(value)
+        } else if let value = try? values.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? values.decode([SelectiveRemoteJSONValue].self) {
+            self = .array(value)
+        } else if let value = try? values.decode([String: SelectiveRemoteJSONValue].self) {
+            self = .object(value)
+        } else {
+            throw SelectiveRemoteVaultDocumentError.invalidRecordData
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var values = encoder.singleValueContainer()
+        switch self {
+        case .null:
+            try values.encodeNil()
+        case let .boolean(value):
+            try values.encode(value)
+        case let .number(value):
+            guard value.isFinite else {
+                throw SelectiveRemoteVaultDocumentError.invalidRecordData
+            }
+            try values.encode(value)
+        case let .string(value):
+            try values.encode(value)
+        case let .array(value):
+            try values.encode(value)
+        case let .object(value):
+            try values.encode(value)
+        }
+    }
+}
+
+struct SelectiveRemoteVaultVersion: Equatable, Sendable {
+    static let maximumCounter = 9_007_199_254_740_991
+
+    let counters: [UUID: Int]
+
+    init(_ counters: [UUID: Int]) throws {
+        guard !counters.isEmpty, counters.count <= 128,
+              counters.values.allSatisfy({ (1 ... Self.maximumCounter).contains($0) })
+        else { throw SelectiveRemoteVaultDocumentError.invalidRecordVersion }
+        self.counters = counters
+    }
+
+    func incrementing(_ deviceID: UUID) throws -> Self {
+        var result = counters
+        let current = result[deviceID] ?? 0
+        guard current < Self.maximumCounter else {
+            throw SelectiveRemoteVaultDocumentError.invalidRecordVersion
+        }
+        result[deviceID] = current + 1
+        return try .init(result)
+    }
+
+    func joined(with other: Self, incrementing deviceID: UUID) throws -> Self {
+        var result = counters
+        for (key, value) in other.counters {
+            result[key] = max(result[key] ?? 0, value)
+        }
+        return try Self(result).incrementing(deviceID)
+    }
+}
+
+extension SelectiveRemoteVaultVersion: Codable {
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: SelectiveRemoteAnyCodingKey.self)
+        guard !values.allKeys.isEmpty, values.allKeys.count <= 128 else {
+            throw SelectiveRemoteVaultDocumentError.invalidRecordVersion
+        }
+        var result: [UUID: Int] = [:]
+        for key in values.allKeys.sorted(by: { $0.stringValue < $1.stringValue }) {
+            let deviceID = try SelectiveRemoteVaultValidation.uuid(
+                key.stringValue,
+                error: .invalidRecordVersion
+            )
+            let counter = try values.decode(Int.self, forKey: key)
+            guard (1 ... Self.maximumCounter).contains(counter) else {
+                throw SelectiveRemoteVaultDocumentError.invalidRecordVersion
+            }
+            result[deviceID] = counter
+        }
+        try self.init(result)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var values = encoder.container(keyedBy: SelectiveRemoteAnyCodingKey.self)
+        for (deviceID, counter) in counters.sorted(by: {
+            $0.key.canonicalCloudString < $1.key.canonicalCloudString
+        }) {
+            let key = SelectiveRemoteAnyCodingKey(stringValue: deviceID.canonicalCloudString)!
+            try values.encode(counter, forKey: key)
+        }
+    }
+}
+
+struct SelectiveRemoteVaultRecord: Equatable, Sendable, Codable {
+    let id: UUID
+    let type: SelectiveRemoteVaultRecordType
+    let version: SelectiveRemoteVaultVersion
+    let modifiedAt: String
+    let data: SelectiveRemoteJSONValue
+
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case id, type, version, modifiedAt, data
+    }
+
+    init(
+        id: UUID,
+        type: SelectiveRemoteVaultRecordType,
+        version: SelectiveRemoteVaultVersion,
+        modifiedAt: String,
+        data: SelectiveRemoteJSONValue
+    ) throws {
+        try SelectiveRemoteVaultValidation.timestamp(modifiedAt, error: .invalidModifiedAt)
+        self.id = id
+        self.type = type
+        self.version = version
+        self.modifiedAt = modifiedAt
+        self.data = data
+    }
+
+    init(from decoder: Decoder) throws {
+        try SelectiveRemoteVaultValidation.exactKeys(
+            decoder,
+            expected: CodingKeys.allCases.map(\.rawValue),
+            error: .invalidVaultRecord
+        )
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        let rawID = try values.decode(String.self, forKey: .id)
+        guard let type = try? values.decode(SelectiveRemoteVaultRecordType.self, forKey: .type) else {
+            throw SelectiveRemoteVaultDocumentError.invalidRecordType
+        }
+        try self.init(
+            id: SelectiveRemoteVaultValidation.uuid(rawID, error: .invalidRecordID),
+            type: type,
+            version: values.decode(SelectiveRemoteVaultVersion.self, forKey: .version),
+            modifiedAt: values.decode(String.self, forKey: .modifiedAt),
+            data: values.decode(SelectiveRemoteJSONValue.self, forKey: .data)
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var values = encoder.container(keyedBy: CodingKeys.self)
+        try values.encode(id.canonicalCloudString, forKey: .id)
+        try values.encode(type, forKey: .type)
+        try values.encode(version, forKey: .version)
+        try values.encode(modifiedAt, forKey: .modifiedAt)
+        try values.encode(data, forKey: .data)
+    }
+}
+
+struct SelectiveRemoteVaultTombstone: Equatable, Sendable, Codable {
+    let id: UUID
+    let version: SelectiveRemoteVaultVersion
+    let deletedAt: String
+
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case id, version, deletedAt
+    }
+
+    init(id: UUID, version: SelectiveRemoteVaultVersion, deletedAt: String) throws {
+        try SelectiveRemoteVaultValidation.timestamp(deletedAt, error: .invalidDeletedAt)
+        self.id = id
+        self.version = version
+        self.deletedAt = deletedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        try SelectiveRemoteVaultValidation.exactKeys(
+            decoder,
+            expected: CodingKeys.allCases.map(\.rawValue),
+            error: .invalidVaultTombstone
+        )
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(
+            id: SelectiveRemoteVaultValidation.uuid(
+                values.decode(String.self, forKey: .id),
+                error: .invalidRecordID
+            ),
+            version: values.decode(SelectiveRemoteVaultVersion.self, forKey: .version),
+            deletedAt: values.decode(String.self, forKey: .deletedAt)
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var values = encoder.container(keyedBy: CodingKeys.self)
+        try values.encode(id.canonicalCloudString, forKey: .id)
+        try values.encode(version, forKey: .version)
+        try values.encode(deletedAt, forKey: .deletedAt)
+    }
+}
+
+enum SelectiveRemoteVaultEntity: Equatable, Sendable {
+    case record(SelectiveRemoteVaultRecord)
+    case tombstone(SelectiveRemoteVaultTombstone)
+
+    var id: UUID {
+        switch self {
+        case let .record(value): value.id
+        case let .tombstone(value): value.id
+        }
+    }
+
+    var version: SelectiveRemoteVaultVersion {
+        switch self {
+        case let .record(value): value.version
+        case let .tombstone(value): value.version
+        }
+    }
+}
+
+struct SelectiveRemoteVaultConflict: Equatable, Sendable {
+    let id: UUID
+    let local: SelectiveRemoteVaultEntity
+    let remote: SelectiveRemoteVaultEntity
+}
+
+struct SelectiveRemoteVaultMerge: Equatable, Sendable {
+    let document: SelectiveRemoteVaultDocument
+    let conflicts: [SelectiveRemoteVaultConflict]
+}
+
+enum SelectiveRemoteVaultConflictChoice: String, Codable, Sendable {
+    case local
+    case remote
+}
+
+struct SelectiveRemoteVaultConflictResolution: Equatable, Sendable {
+    let id: UUID
+    let choice: SelectiveRemoteVaultConflictChoice
+}
+
+struct SelectiveRemoteVaultDocument: Equatable, Sendable, Codable {
+    static let schemaVersion = 1
+    private static let maximumBytes = 24 * 1024 * 1024
+    private static let maximumEntities = 10_000
+
+    let records: [SelectiveRemoteVaultRecord]
+    let tombstones: [SelectiveRemoteVaultTombstone]
+
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case schemaVersion, records, tombstones
+    }
+
+    init(
+        records: [SelectiveRemoteVaultRecord] = [],
+        tombstones: [SelectiveRemoteVaultTombstone] = []
+    ) throws {
+        guard records.count + tombstones.count <= Self.maximumEntities else {
+            throw SelectiveRemoteVaultDocumentError.vaultTooLarge
+        }
+        let allIDs = records.map(\.id) + tombstones.map(\.id)
+        guard Set(allIDs).count == allIDs.count else {
+            throw SelectiveRemoteVaultDocumentError.duplicateRecordID
+        }
+        var budget = 100_000
+        for record in records {
+            try SelectiveRemoteVaultValidation.json(record.data, depth: 0, budget: &budget)
+        }
+        self.records = records.sorted { $0.id.canonicalCloudString < $1.id.canonicalCloudString }
+        self.tombstones = tombstones.sorted { $0.id.canonicalCloudString < $1.id.canonicalCloudString }
+        guard try encoded().count <= Self.maximumBytes else {
+            throw SelectiveRemoteVaultDocumentError.vaultTooLarge
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        try SelectiveRemoteVaultValidation.exactKeys(
+            decoder,
+            expected: CodingKeys.allCases.map(\.rawValue),
+            error: .invalidVaultDocument
+        )
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        guard try values.decode(Int.self, forKey: .schemaVersion) == Self.schemaVersion else {
+            throw SelectiveRemoteVaultDocumentError.invalidVaultSchemaVersion
+        }
+        try self.init(
+            records: values.decode([SelectiveRemoteVaultRecord].self, forKey: .records),
+            tombstones: values.decode([SelectiveRemoteVaultTombstone].self, forKey: .tombstones)
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var values = encoder.container(keyedBy: CodingKeys.self)
+        try values.encode(Self.schemaVersion, forKey: .schemaVersion)
+        try values.encode(records, forKey: .records)
+        try values.encode(tombstones, forKey: .tombstones)
+    }
+
+    static func decode(_ data: Data) throws -> Self {
+        do {
+            return try JSONDecoder().decode(Self.self, from: data)
+        } catch let error as SelectiveRemoteVaultDocumentError {
+            throw error
+        } catch {
+            throw SelectiveRemoteVaultDocumentError.invalidVaultDocument
+        }
+    }
+
+    func encoded() throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        return try encoder.encode(self)
+    }
+
+    func merged(with remote: Self) throws -> SelectiveRemoteVaultMerge {
+        let localEntities = entityMap
+        let remoteEntities = remote.entityMap
+        var records: [SelectiveRemoteVaultRecord] = []
+        var tombstones: [SelectiveRemoteVaultTombstone] = []
+        var conflicts: [SelectiveRemoteVaultConflict] = []
+        let ids = Set(localEntities.keys).union(remoteEntities.keys).sorted {
+            $0.canonicalCloudString < $1.canonicalCloudString
+        }
+
+        for id in ids {
+            let local = localEntities[id]
+            let remote = remoteEntities[id]
+            var selected = local ?? remote
+            if let local, let remote {
+                switch SelectiveRemoteVaultValidation.relation(local.version, remote.version) {
+                case .left:
+                    selected = local
+                case .right:
+                    selected = remote
+                case .equal:
+                    if local == remote {
+                        selected = local
+                    } else {
+                        selected = nil
+                        conflicts.append(.init(id: id, local: local, remote: remote))
+                    }
+                case .concurrent:
+                    selected = nil
+                    conflicts.append(.init(id: id, local: local, remote: remote))
+                }
+            }
+            switch selected {
+            case let .some(.record(value)): records.append(value)
+            case let .some(.tombstone(value)): tombstones.append(value)
+            case .none: break
+            }
+        }
+        return try .init(document: .init(records: records, tombstones: tombstones), conflicts: conflicts)
+    }
+
+    func resolving(
+        _ conflicts: [SelectiveRemoteVaultConflict],
+        with resolutions: [SelectiveRemoteVaultConflictResolution],
+        deviceID: UUID,
+        resolvedAt: String
+    ) throws -> Self {
+        let conflictIDs = Set(conflicts.map(\.id))
+        guard conflictIDs.count == conflicts.count else {
+            throw SelectiveRemoteVaultDocumentError.invalidVaultConflict
+        }
+        var choices: [UUID: SelectiveRemoteVaultConflictChoice] = [:]
+        for resolution in resolutions {
+            guard choices[resolution.id] == nil else {
+                throw SelectiveRemoteVaultDocumentError.duplicateConflictResolution
+            }
+            guard conflictIDs.contains(resolution.id) else {
+                throw SelectiveRemoteVaultDocumentError.unknownConflictResolution
+            }
+            choices[resolution.id] = resolution.choice
+        }
+        guard choices.count == conflicts.count else {
+            throw SelectiveRemoteVaultDocumentError.incompleteConflictResolutions
+        }
+
+        var records = self.records
+        var tombstones = self.tombstones
+        let presentIDs = Set(entityMap.keys)
+        for conflict in conflicts.sorted(by: { $0.id.canonicalCloudString < $1.id.canonicalCloudString }) {
+            guard conflict.local.id == conflict.id,
+                  conflict.remote.id == conflict.id,
+                  let choice = choices[conflict.id]
+            else { throw SelectiveRemoteVaultDocumentError.invalidVaultConflict }
+            guard !presentIDs.contains(conflict.id) else {
+                throw SelectiveRemoteVaultDocumentError.conflictRecordPresent
+            }
+            let selected = choice == .local ? conflict.local : conflict.remote
+            let version = try conflict.local.version.joined(
+                with: conflict.remote.version,
+                incrementing: deviceID
+            )
+            switch selected {
+            case let .record(value):
+                records.append(try .init(
+                    id: value.id,
+                    type: value.type,
+                    version: version,
+                    modifiedAt: resolvedAt,
+                    data: value.data
+                ))
+            case let .tombstone(value):
+                tombstones.append(try .init(id: value.id, version: version, deletedAt: resolvedAt))
+            }
+        }
+        return try .init(records: records, tombstones: tombstones)
+    }
+
+    private var entityMap: [UUID: SelectiveRemoteVaultEntity] {
+        var result: [UUID: SelectiveRemoteVaultEntity] = Dictionary(
+            uniqueKeysWithValues: records.map { ($0.id, .record($0)) }
+        )
+        for tombstone in tombstones { result[tombstone.id] = .tombstone(tombstone) }
+        return result
+    }
+}
+
+struct SelectiveRemoteTeamVaultRecordConflict: Equatable, Sendable {
+    let transport: SelectiveRemoteTeamVaultConflict
+    let mergedDocument: SelectiveRemoteVaultDocument
+    let recordConflicts: [SelectiveRemoteVaultConflict]
+}
+
+enum SelectiveRemoteTeamVaultRecordPushOutcome: Equatable, Sendable {
+    case uploaded(SelectiveRemoteTeamVaultDecryptedSnapshot, SelectiveRemoteVaultDocument)
+    case conflict(SelectiveRemoteTeamVaultRecordConflict)
+}
+
+extension SelectiveRemoteTeamVaultSyncCoordinator {
+    func prepareRecordConflict(
+        _ conflict: SelectiveRemoteTeamVaultConflict
+    ) throws -> SelectiveRemoteTeamVaultRecordConflict {
+        let local = try SelectiveRemoteVaultDocument.decode(conflict.local.payload)
+        let remote = try SelectiveRemoteVaultDocument.decode(conflict.remote.payload)
+        let merge = try local.merged(with: remote)
+        return .init(
+            transport: conflict,
+            mergedDocument: merge.document,
+            recordConflicts: merge.conflicts
+        )
+    }
+
+    func resolveRecordConflicts(
+        _ conflict: SelectiveRemoteTeamVaultRecordConflict,
+        resolutions: [SelectiveRemoteVaultConflictResolution],
+        resolvedAt: String,
+        teamID: UUID,
+        vaultID: UUID,
+        identity: SelectiveRemoteTeamDeviceIdentity
+    ) async throws -> SelectiveRemoteTeamVaultRecordPushOutcome {
+        let resolved = try conflict.mergedDocument.resolving(
+            conflict.recordConflicts,
+            with: resolutions,
+            deviceID: identity.deviceID,
+            resolvedAt: resolvedAt
+        )
+        let outcome = try await resolveConflict(
+            conflict.transport,
+            resolvedPayload: resolved.encoded(),
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+        switch outcome {
+        case let .uploaded(snapshot):
+            return .uploaded(snapshot, try SelectiveRemoteVaultDocument.decode(snapshot.payload))
+        case let .conflict(updated):
+            return .conflict(try prepareRecordConflict(updated))
+        }
+    }
+}
+
+private enum SelectiveRemoteVaultVectorRelation {
+    case left, right, equal, concurrent
+}
+
+private enum SelectiveRemoteVaultValidation {
+    private static let forbiddenKeys: Set<String> = ["__proto__", "constructor", "prototype"]
+
+    static func exactKeys(
+        _ decoder: Decoder,
+        expected: [String],
+        error: SelectiveRemoteVaultDocumentError
+    ) throws {
+        let values = try decoder.container(keyedBy: SelectiveRemoteAnyCodingKey.self)
+        guard Set(values.allKeys.map(\.stringValue)) == Set(expected),
+              values.allKeys.count == expected.count
+        else { throw error }
+    }
+
+    static func uuid(
+        _ value: String,
+        error: SelectiveRemoteVaultDocumentError
+    ) throws -> UUID {
+        let normalized = value.lowercased()
+        guard normalized.range(
+            of: #"^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"#,
+            options: .regularExpression
+        ) != nil, let result = UUID(uuidString: normalized)
+        else { throw error }
+        return result
+    }
+
+    static func timestamp(
+        _ value: String,
+        error: SelectiveRemoteVaultDocumentError
+    ) throws {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        guard let date = formatter.date(from: value), formatter.string(from: date) == value else {
+            throw error
+        }
+    }
+
+    static func json(
+        _ value: SelectiveRemoteJSONValue,
+        depth: Int,
+        budget: inout Int
+    ) throws {
+        budget -= 1
+        guard budget >= 0, depth <= 32 else {
+            throw SelectiveRemoteVaultDocumentError.invalidRecordData
+        }
+        switch value {
+        case .null, .boolean, .string:
+            return
+        case let .number(number):
+            guard number.isFinite else {
+                throw SelectiveRemoteVaultDocumentError.invalidRecordData
+            }
+        case let .array(values):
+            guard values.count <= 10_000 else {
+                throw SelectiveRemoteVaultDocumentError.invalidRecordData
+            }
+            for value in values { try json(value, depth: depth + 1, budget: &budget) }
+        case let .object(values):
+            guard values.count <= 1_000,
+                  values.keys.allSatisfy({ !forbiddenKeys.contains($0) })
+            else { throw SelectiveRemoteVaultDocumentError.invalidRecordData }
+            for key in values.keys.sorted() {
+                try json(values[key]!, depth: depth + 1, budget: &budget)
+            }
+        }
+    }
+
+    static func relation(
+        _ left: SelectiveRemoteVaultVersion,
+        _ right: SelectiveRemoteVaultVersion
+    ) -> SelectiveRemoteVaultVectorRelation {
+        var leftAhead = false
+        var rightAhead = false
+        for deviceID in Set(left.counters.keys).union(right.counters.keys) {
+            let comparison = (left.counters[deviceID] ?? 0) - (right.counters[deviceID] ?? 0)
+            if comparison > 0 { leftAhead = true }
+            if comparison < 0 { rightAhead = true }
+        }
+        if leftAhead, rightAhead { return .concurrent }
+        if leftAhead { return .left }
+        if rightAhead { return .right }
+        return .equal
+    }
+
+}

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -639,6 +639,129 @@ struct CloudMacOSFoundationTests {
         #expect(writes.count == 1)
     }
 
+    @Test("Team Vault record workflow requires a complete causal choice before upload")
+    func teamVaultRecordConflictWorkflow() async throws {
+        let fixture = try Self.fixture()
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized("https://cloud.example.invalid")
+        let teamID = try fixture.wrapper.teamID.uuid
+        let vaultID = try fixture.wrapper.vaultID.uuid
+        let identity = try SelectiveRemoteTeamDeviceIdentity(
+            deviceID: try fixture.wrapper.deviceID.uuid,
+            privateKeyRepresentation: try fixture.keyWrap.recipientPrivateScalar.base64URLData
+        )
+        let wrapper = try Self.fixtureWrapper(fixture, identity: identity)
+        let remote = TeamVaultRemoteStub(
+            envelope: Self.remoteEnvelope(fixture, wrapper: wrapper),
+            writeResult: .init(conflict: true, revision: 6, keyGeneration: 7, rotationCompleted: nil)
+        )
+        let storage = SelectiveRemoteTeamVaultMemorySnapshotStore()
+        let coordinator = try SelectiveRemoteTeamVaultSyncCoordinator(
+            endpoint: endpoint,
+            remote: remote,
+            snapshots: storage
+        )
+        _ = try await coordinator.refresh(teamID: teamID, vaultID: vaultID, identity: identity)
+
+        let deviceA = try #require(UUID(uuidString: "11111111-1111-4111-8111-111111111111"))
+        let deviceB = try #require(UUID(uuidString: "22222222-2222-4222-8222-222222222222"))
+        let recordID = try #require(UUID(uuidString: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"))
+        let localRecord = try SelectiveRemoteVaultRecord(
+            id: recordID,
+            type: .host,
+            version: .init([deviceA: 2]),
+            modifiedAt: "2026-09-07T01:00:00.000Z",
+            data: .object(["title": .string("Local")])
+        )
+        let remoteRecord = try SelectiveRemoteVaultRecord(
+            id: recordID,
+            type: .host,
+            version: .init([deviceA: 1, deviceB: 1]),
+            modifiedAt: "2026-09-07T02:00:00.000Z",
+            data: .object(["title": .string("Remote")])
+        )
+        let localDocument = try SelectiveRemoteVaultDocument(records: [localRecord])
+        let remoteDocument = try SelectiveRemoteVaultDocument(records: [remoteRecord])
+        _ = try await coordinator.stage(
+            localDocument.encoded(),
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+        let remoteCiphertext = try SelectiveRemoteTeamVaultCrypto.encryptPayload(
+            remoteDocument.encoded(),
+            vaultKey: try fixture.keyWrap.vaultKey.base64URLData,
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: fixture.payload.keyGeneration,
+            baseRevision: 5,
+            nonce: Data(repeating: 0x27, count: 12)
+        )
+        await remote.setEnvelope(.init(
+            id: vaultID,
+            teamID: teamID,
+            name: "Operations",
+            revision: 6,
+            keyGeneration: fixture.payload.keyGeneration,
+            rotationRequired: false,
+            envelopeVersion: remoteCiphertext.envelopeVersion,
+            ciphertext: remoteCiphertext.ciphertext,
+            nonce: remoteCiphertext.nonce,
+            authTag: remoteCiphertext.authTag,
+            contentHash: remoteCiphertext.contentHash,
+            wrapper: wrapper,
+            createdAt: "2026-09-06T00:00:00.000Z",
+            updatedAt: "2026-09-07T02:00:00.000Z"
+        ))
+
+        let pushed = try await coordinator.push(teamID: teamID, vaultID: vaultID, identity: identity)
+        guard case let .conflict(transportConflict) = pushed else {
+            Issue.record("Expected a transport conflict")
+            return
+        }
+        let prepared = try await coordinator.prepareRecordConflict(transportConflict)
+        #expect(prepared.mergedDocument.records.isEmpty)
+        #expect(prepared.recordConflicts.map(\.id) == [recordID])
+        await #expect(throws: SelectiveRemoteVaultDocumentError.incompleteConflictResolutions) {
+            try await coordinator.resolveRecordConflicts(
+                prepared,
+                resolutions: [],
+                resolvedAt: "2026-09-07T03:00:00.000Z",
+                teamID: teamID,
+                vaultID: vaultID,
+                identity: identity
+            )
+        }
+
+        await remote.setWriteResult(.init(
+            conflict: false,
+            revision: 7,
+            keyGeneration: fixture.payload.keyGeneration,
+            rotationCompleted: false
+        ))
+        let resolved = try await coordinator.resolveRecordConflicts(
+            prepared,
+            resolutions: [.init(id: recordID, choice: .remote)],
+            resolvedAt: "2026-09-07T03:00:00.000Z",
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+        guard case let .uploaded(snapshot, document) = resolved else {
+            Issue.record("Expected a resolved record upload")
+            return
+        }
+        #expect(snapshot.snapshot.serverRevision == 7)
+        #expect(document.records[0].data == .object(["title": .string("Remote")]))
+        #expect(document.records[0].version.counters == [
+            deviceA: 2,
+            deviceB: 1,
+            identity.deviceID: 1
+        ])
+        let writes = await remote.recordedWrites()
+        #expect(writes.count == 2)
+        #expect(writes.last?.upload.envelope.baseRevision == 6)
+    }
+
     @Test("Team Vault coordinator fails closed while key rotation is required")
     func teamVaultSyncRotationGate() async throws {
         let fixture = try Self.fixture()

--- a/Tests/SelectiveRemoteTests/CloudVaultRecordModelTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudVaultRecordModelTests.swift
@@ -131,6 +131,25 @@ struct CloudVaultRecordModelTests {
                 resolvedAt: secondTime
             )
         }
+        #expect(throws: SelectiveRemoteVaultDocumentError.duplicateConflictResolution) {
+            try merge.document.resolving(
+                merge.conflicts,
+                with: [
+                    .init(id: recordB, choice: .local),
+                    .init(id: recordB, choice: .remote)
+                ],
+                deviceID: deviceC,
+                resolvedAt: secondTime
+            )
+        }
+        #expect(throws: SelectiveRemoteVaultDocumentError.unknownConflictResolution) {
+            try merge.document.resolving(
+                merge.conflicts,
+                with: [.init(id: recordC, choice: .local)],
+                deviceID: deviceC,
+                resolvedAt: secondTime
+            )
+        }
         let resolved = try merge.document.resolving(
             merge.conflicts,
             with: [.init(id: recordB, choice: .local)],

--- a/Tests/SelectiveRemoteTests/CloudVaultRecordModelTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudVaultRecordModelTests.swift
@@ -143,6 +143,37 @@ struct CloudVaultRecordModelTests {
         #expect(resolved.records[0].modifiedAt == secondTime)
     }
 
+    @Test("A concurrent edit and deletion remain a conflict and can resolve to a tombstone")
+    func editDeletionResolution() throws {
+        let edited = try record(
+            id: recordA,
+            version: [deviceA: 2],
+            value: "edited-offline",
+            modifiedAt: secondTime
+        )
+        let deleted = try SelectiveRemoteVaultTombstone(
+            id: recordA,
+            version: .init([deviceA: 1, deviceB: 1]),
+            deletedAt: secondTime
+        )
+        let merge = try SelectiveRemoteVaultDocument(records: [edited]).merged(
+            with: SelectiveRemoteVaultDocument(tombstones: [deleted])
+        )
+
+        #expect(merge.conflicts.count == 1)
+        #expect(merge.conflicts[0].local == .record(edited))
+        #expect(merge.conflicts[0].remote == .tombstone(deleted))
+        let resolved = try merge.document.resolving(
+            merge.conflicts,
+            with: [.init(id: recordA, choice: .remote)],
+            deviceID: deviceC,
+            resolvedAt: secondTime
+        )
+        #expect(resolved.records.isEmpty)
+        #expect(resolved.tombstones[0].version.counters == [deviceA: 2, deviceB: 1, deviceC: 1])
+        #expect(resolved.tombstones[0].deletedAt == secondTime)
+    }
+
     private func record(
         id: UUID,
         version: [UUID: Int],

--- a/Tests/SelectiveRemoteTests/CloudVaultRecordModelTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudVaultRecordModelTests.swift
@@ -1,0 +1,160 @@
+import Foundation
+import Testing
+@testable import SelectiveRemote
+
+@Suite("macOS Cloud Vault causal record model")
+struct CloudVaultRecordModelTests {
+    private let deviceA = UUID(uuidString: "11111111-1111-4111-8111-111111111111")!
+    private let deviceB = UUID(uuidString: "22222222-2222-4222-8222-222222222222")!
+    private let deviceC = UUID(uuidString: "33333333-3333-4333-8333-333333333333")!
+    private let recordA = UUID(uuidString: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")!
+    private let recordB = UUID(uuidString: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")!
+    private let recordC = UUID(uuidString: "cccccccc-cccc-4ccc-8ccc-cccccccccccc")!
+    private let firstTime = "2026-09-06T00:00:00.000Z"
+    private let secondTime = "2026-09-07T00:00:00.000Z"
+
+    @Test("Swift decodes and canonically re-encodes the browser Vault schema")
+    func browserSchemaRoundTrip() throws {
+        let source = Data(#"""
+        {
+          "schemaVersion": 1,
+          "records": [{
+            "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            "type": "credential",
+            "version": {"22222222-2222-4222-8222-222222222222": 1, "11111111-1111-4111-8111-111111111111": 2},
+            "modifiedAt": "2026-09-06T00:00:00.000Z",
+            "data": {"username": "operator", "secret": "synthetic", "metadata": [true, null, 3]}
+          }],
+          "tombstones": []
+        }
+        """#.utf8)
+
+        let document = try SelectiveRemoteVaultDocument.decode(source)
+        #expect(document.records.map(\.id) == [recordA])
+        #expect(document.records[0].version.counters == [deviceA: 2, deviceB: 1])
+        let encoded = String(decoding: try document.encoded(), as: UTF8.self)
+        #expect(encoded.hasPrefix(#"{"records":[{"data":{"metadata":[true,null,3]"#))
+        #expect(try SelectiveRemoteVaultDocument.decode(Data(encoded.utf8)) == document)
+    }
+
+    @Test("Vault validation rejects unknown structure and unsafe record data")
+    func strictValidation() {
+        let unknownField = Data(#"""
+        {
+          "schemaVersion": 1,
+          "records": [],
+          "tombstones": [],
+          "plaintext": "must fail"
+        }
+        """#.utf8)
+        #expect(throws: SelectiveRemoteVaultDocumentError.invalidVaultDocument) {
+            try SelectiveRemoteVaultDocument.decode(unknownField)
+        }
+
+        let forbiddenData = Data(#"""
+        {
+          "schemaVersion": 1,
+          "records": [{
+            "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            "type": "host",
+            "version": {"11111111-1111-4111-8111-111111111111": 1},
+            "modifiedAt": "2026-09-06T00:00:00.000Z",
+            "data": {"constructor": "must fail"}
+          }],
+          "tombstones": []
+        }
+        """#.utf8)
+        #expect(throws: SelectiveRemoteVaultDocumentError.invalidRecordData) {
+            try SelectiveRemoteVaultDocument.decode(forbiddenData)
+        }
+    }
+
+    @Test("Causal dominance merges automatically and concurrency remains explicit")
+    func causalMerge() throws {
+        let localDominant = try record(
+            id: recordA,
+            version: [deviceA: 2],
+            value: "local-newer",
+            modifiedAt: secondTime
+        )
+        let remoteOlder = try record(
+            id: recordA,
+            version: [deviceA: 1],
+            value: "remote-older",
+            modifiedAt: firstTime
+        )
+        let localConcurrent = try record(
+            id: recordB,
+            version: [deviceA: 1],
+            value: "local-choice",
+            modifiedAt: firstTime
+        )
+        let remoteConcurrent = try record(
+            id: recordB,
+            version: [deviceB: 1],
+            value: "remote-choice",
+            modifiedAt: secondTime
+        )
+        let remoteOnly = try SelectiveRemoteVaultTombstone(
+            id: recordC,
+            version: .init([deviceB: 1]),
+            deletedAt: secondTime
+        )
+
+        let local = try SelectiveRemoteVaultDocument(records: [localConcurrent, localDominant])
+        let remote = try SelectiveRemoteVaultDocument(
+            records: [remoteOlder, remoteConcurrent],
+            tombstones: [remoteOnly]
+        )
+        let merge = try local.merged(with: remote)
+
+        #expect(merge.document.records == [localDominant])
+        #expect(merge.document.tombstones == [remoteOnly])
+        #expect(merge.conflicts.map(\.id) == [recordB])
+        #expect(merge.conflicts[0].local == .record(localConcurrent))
+        #expect(merge.conflicts[0].remote == .record(remoteConcurrent))
+    }
+
+    @Test("A complete manual choice joins both histories and records the resolver event")
+    func completeResolution() throws {
+        let local = try record(id: recordB, version: [deviceA: 2], value: "local", modifiedAt: firstTime)
+        let remote = try record(id: recordB, version: [deviceB: 1], value: "remote", modifiedAt: secondTime)
+        let merge = try SelectiveRemoteVaultDocument(records: [local]).merged(
+            with: SelectiveRemoteVaultDocument(records: [remote])
+        )
+
+        #expect(throws: SelectiveRemoteVaultDocumentError.incompleteConflictResolutions) {
+            try merge.document.resolving(
+                merge.conflicts,
+                with: [],
+                deviceID: deviceC,
+                resolvedAt: secondTime
+            )
+        }
+        let resolved = try merge.document.resolving(
+            merge.conflicts,
+            with: [.init(id: recordB, choice: .local)],
+            deviceID: deviceC,
+            resolvedAt: secondTime
+        )
+        #expect(resolved.records.count == 1)
+        #expect(resolved.records[0].data == .object(["value": .string("local")]))
+        #expect(resolved.records[0].version.counters == [deviceA: 2, deviceB: 1, deviceC: 1])
+        #expect(resolved.records[0].modifiedAt == secondTime)
+    }
+
+    private func record(
+        id: UUID,
+        version: [UUID: Int],
+        value: String,
+        modifiedAt: String
+    ) throws -> SelectiveRemoteVaultRecord {
+        try .init(
+            id: id,
+            type: .host,
+            version: .init(version),
+            modifiedAt: modifiedAt,
+            data: .object(["value": .string(value)])
+        )
+    }
+}

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -73,3 +73,16 @@ test("macOS Team Vault coordinator preserves causal dirty and conflict state", a
   assert.match(coordinator, /return try await push\(teamID: teamID, vaultID: vaultID, identity: identity\)/);
   assert.match(coordinator, /revalidated == current/);
 });
+
+test("macOS Team Vault record workflow mirrors the bounded browser causal model", async () => {
+  const model = await readFile(new URL("CloudVaultRecordModel.swift", sourceRoot), "utf8");
+  assert.match(model, /static let schemaVersion = 1/);
+  assert.match(model, /case host[\s\S]*case credential[\s\S]*case snippet[\s\S]*case forwarding/);
+  assert.match(model, /maximumBytes = 24 \* 1024 \* 1024/);
+  assert.match(model, /maximumEntities = 10_000/);
+  assert.match(model, /case left, right, equal, concurrent/);
+  assert.match(model, /incompleteConflictResolutions/);
+  assert.match(model, /func prepareRecordConflict\(/);
+  assert.match(model, /func resolveRecordConflicts\(/);
+  assert.match(model, /resolvedPayload: resolved\.encoded\(\)/);
+});


### PR DESCRIPTION
## Summary
- port the strict browser Vault document schema to Swift for macOS Team Vault payloads
- merge records and tombstones by version-vector dominance while surfacing concurrent entities
- require one explicit local/remote choice for every conflict, then join both histories and record the resolver device event
- connect the typed record workflow to the revalidated conditional encrypted-write path from PR #53
- cover strict schema validation, deterministic ordering, causal merge, record/deletion conflicts, complete-choice enforcement and an end-to-end coordinator upload

## Verification
- full local Cloud suite: 233 passed, 0 failed, 1 PostgreSQL-only test skipped because `TEST_DATABASE_URL` is unavailable
- focused macOS source tests: 5 passed
- `npm audit --omit=dev --offline`: 0 vulnerabilities
- `git diff --check`: passed
- exact-head CI 34118197076 (#506): success, including Swift 6 tests, PostgreSQL 16, Cloud/browser tests and Release build
- exact-head Test DMG 34118197148 (#196): success
- artifact `SelectiveRemote-test-54-arm64`: id `10017327084`, 32,477,599 bytes, digest `sha256:d9604dfb27f31916c56e9b89ed0448982adae20ab6c49ac97aba1b2f1957053f`, expires 2026-09-14T11:51:35Z

## Stack
- base: #53 (`ad8134fd614fafcbd5004451c67432064a2d9fa8`)
- this head: `4047d175bb1f4d0b22b349d132f99c8657c40f9a`

## Boundary
No SwiftUI conflict screen, background sync, personal-Vault recovery wrapping, staging deployment, registration change, release or `main` mutation.