### PR TITLE
feat: connect macOS Cloud sign-in and Team inventory

### DIFF
--- a/Sources/SelectiveRemote/CloudAPIClient.swift
+++ b/Sources/SelectiveRemote/CloudAPIClient.swift
@@ -69,7 +69,7 @@ enum SelectiveRemoteCloudTeamRole: String, Codable, Equatable, Sendable {
     case viewer
 }
 
-struct SelectiveRemoteCloudTeam: Codable, Equatable, Sendable {
+struct SelectiveRemoteCloudTeam: Codable, Equatable, Identifiable, Sendable {
     var id: UUID
     var name: String
     var membershipID: UUID
@@ -79,7 +79,7 @@ struct SelectiveRemoteCloudTeam: Codable, Equatable, Sendable {
     var updatedAt: String
 }
 
-struct SelectiveRemoteCloudSharedVault: Codable, Equatable, Sendable {
+struct SelectiveRemoteCloudSharedVault: Codable, Equatable, Identifiable, Sendable {
     var id: UUID
     var teamID: UUID
     var name: String
@@ -300,9 +300,11 @@ actor SelectiveRemoteCloudAPIClient {
         guard (200..<300).contains(http.statusCode) else {
             throw serviceError(status: http.statusCode, data: data)
         }
-        guard let result = try? decoder.decode(LoginResponse.self, from: data),
+        guard Self.validLoginJSON(data),
+              let result = try? decoder.decode(LoginResponse.self, from: data),
               (32...256).contains(result.token.count),
-              result.deviceID == device.id
+              result.deviceID == device.id,
+              Self.validUser(result.user)
         else { throw SelectiveRemoteCloudError.invalidResponse }
         try tokenStore.saveToken(result.token, for: endpoint)
         return result.user
@@ -310,7 +312,10 @@ actor SelectiveRemoteCloudAPIClient {
 
     func currentUser(endpoint: URL) async throws -> SelectiveRemoteCloudUser {
         let data = try await authorizedData(endpoint: endpoint, path: "v1/me")
-        guard let user = try? decoder.decode(SelectiveRemoteCloudUser.self, from: data) else {
+        guard Self.validUserJSON(data),
+              let user = try? decoder.decode(SelectiveRemoteCloudUser.self, from: data),
+              Self.validUser(user)
+        else {
             throw SelectiveRemoteCloudError.invalidResponse
         }
         return user
@@ -318,9 +323,20 @@ actor SelectiveRemoteCloudAPIClient {
 
     func teams(endpoint: URL) async throws -> [SelectiveRemoteCloudTeam] {
         let data = try await authorizedData(endpoint: endpoint, path: "v1/teams")
-        guard let result = try? decoder.decode(TeamsResponse.self, from: data),
+        guard Self.validTeamsJSON(data),
+              let result = try? decoder.decode(TeamsResponse.self, from: data),
               result.teams.count <= 1_000,
-              result.teams.allSatisfy({ $0.membershipEpoch > 0 && !$0.name.isEmpty })
+              result.teams.allSatisfy({ team in
+                  team.id.isSelectiveRemoteCloudUUID
+                      && team.membershipID.isSelectiveRemoteCloudUUID
+                      && team.membershipEpoch > 0
+                      && !team.name.isEmpty
+                      && team.name.count <= 120
+                      && !team.createdAt.isEmpty
+                      && !team.updatedAt.isEmpty
+              }),
+              Set(result.teams.map(\.id)).count == result.teams.count,
+              Set(result.teams.map(\.membershipID)).count == result.teams.count
         else { throw SelectiveRemoteCloudError.invalidResponse }
         return result.teams
     }
@@ -501,6 +517,31 @@ actor SelectiveRemoteCloudAPIClient {
         return Set(object.keys) == expected
     }
 
+    private static func validUser(_ user: SelectiveRemoteCloudUser) -> Bool {
+        user.id.isSelectiveRemoteCloudUUID
+            && !user.email.isEmpty
+            && user.email.count <= 254
+            && !user.displayName.isEmpty
+            && user.displayName.count <= 120
+    }
+
+    private static func validUserObject(_ value: Any?) -> Bool {
+        exactKeys(value, expected: ["id", "email", "displayName"])
+    }
+
+    private static func validUserJSON(_ data: Data) -> Bool {
+        guard let object = try? JSONSerialization.jsonObject(with: data) else { return false }
+        return validUserObject(object)
+    }
+
+    private static func validLoginJSON(_ data: Data) -> Bool {
+        guard let object = try? JSONSerialization.jsonObject(with: data),
+              exactKeys(object, expected: ["token", "user", "deviceID"]),
+              let user = (object as? [String: Any])?["user"]
+        else { return false }
+        return validUserObject(user)
+    }
+
     private static func validSharedVaultsJSON(_ data: Data) -> Bool {
         guard let object = try? JSONSerialization.jsonObject(with: data),
               exactKeys(object, expected: ["vaults"]),
@@ -511,6 +552,18 @@ actor SelectiveRemoteCloudAPIClient {
             "createdAt", "updatedAt"
         ]
         return vaults.allSatisfy { exactKeys($0, expected: keys) }
+    }
+
+    private static func validTeamsJSON(_ data: Data) -> Bool {
+        guard let object = try? JSONSerialization.jsonObject(with: data),
+              exactKeys(object, expected: ["teams"]),
+              let teams = (object as? [String: Any])?["teams"] as? [Any]
+        else { return false }
+        let keys: Set<String> = [
+            "id", "name", "membershipID", "role", "membershipEpoch",
+            "createdAt", "updatedAt"
+        ]
+        return teams.allSatisfy { exactKeys($0, expected: keys) }
     }
 
     private static func validTeamKeyDevicesJSON(_ data: Data) -> Bool {

--- a/Sources/SelectiveRemote/CloudAccountViews.swift
+++ b/Sources/SelectiveRemote/CloudAccountViews.swift
@@ -1,0 +1,172 @@
+import SwiftUI
+
+struct SelectiveRemoteCloudSignInView: View {
+    let endpoint: URL
+    let isSigningIn: Bool
+    let errorMessage: String?
+    let onCancel: () -> Void
+    let onSignIn: (String, String) -> Void
+
+    @State private var email = ""
+    @State private var password = ""
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField(UpdateLocalization.text(ru: "Электронная почта", en: "Email"), text: $email)
+                        .textContentType(.username)
+                        .disabled(isSigningIn)
+                    SecureField(UpdateLocalization.text(ru: "Пароль", en: "Password"), text: $password)
+                        .textContentType(.password)
+                        .disabled(isSigningIn)
+                        .onSubmit(submit)
+                }
+
+                Section {
+                    LabeledContent(UpdateLocalization.text(ru: "Сервер", en: "Server")) {
+                        Text(endpoint.host ?? endpoint.absoluteString)
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                    }
+
+                    Label(
+                        UpdateLocalization.text(
+                            ru: "Сессия хранится в Keychain только на этом Mac. Пароль существует только в этой форме и не становится ключом Vault.",
+                            en: "The session is stored in Keychain on this Mac only. The password exists only in this form and never becomes a Vault key."
+                        ),
+                        systemImage: "lock.shield"
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+
+                if let errorMessage {
+                    Section {
+                        Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+            .formStyle(.grouped)
+            .navigationTitle(UpdateLocalization.text(ru: "Вход в Cloud", en: "Cloud Sign In"))
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(UpdateLocalization.text(ru: "Отмена", en: "Cancel"), action: onCancel)
+                        .disabled(isSigningIn)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(UpdateLocalization.text(ru: "Войти", en: "Sign In"), action: submit)
+                        .buttonStyle(.borderedProminent)
+                        .disabled(!canSubmit || isSigningIn)
+                }
+            }
+        }
+        .frame(width: 500, height: 390)
+    }
+
+    private var canSubmit: Bool {
+        !email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && (12...1_024).contains(password.count)
+    }
+
+    private func submit() {
+        guard canSubmit, !isSigningIn else { return }
+        onSignIn(email, password)
+    }
+}
+
+struct SelectiveRemoteCloudTeamInventoryView: View {
+    let teams: [SelectiveRemoteCloudTeam]
+    let vaultsByTeam: [UUID: [SelectiveRemoteCloudSharedVault]]
+    let isRefreshing: Bool
+    let errorMessage: String?
+    let onRefresh: () -> Void
+
+    var body: some View {
+        Section(UpdateLocalization.text(ru: "Teams и общие Vaults", en: "Teams & Shared Vaults")) {
+            HStack {
+                Text(UpdateLocalization.text(
+                    ru: "Доступно команд: \(teams.count)",
+                    en: "Available teams: \(teams.count)"
+                ))
+                .foregroundStyle(.secondary)
+                Spacer()
+                if isRefreshing {
+                    ProgressView().controlSize(.small)
+                }
+                Button(UpdateLocalization.text(ru: "Обновить", en: "Refresh"), systemImage: "arrow.clockwise") {
+                    onRefresh()
+                }
+                .disabled(isRefreshing)
+            }
+
+            if teams.isEmpty, errorMessage == nil, !isRefreshing {
+                Label(
+                    UpdateLocalization.text(ru: "Команды пока не назначены.", en: "No teams are assigned yet."),
+                    systemImage: "person.3"
+                )
+                .foregroundStyle(.secondary)
+            }
+
+            ForEach(teams) { team in
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Label(team.name, systemImage: "person.3.fill")
+                            .font(.headline)
+                        Spacer()
+                        Text(roleTitle(team.role))
+                            .font(.caption.weight(.semibold))
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 3)
+                            .background(.quaternary, in: Capsule())
+                    }
+
+                    let vaults = vaultsByTeam[team.id] ?? []
+                    if vaults.isEmpty {
+                        Text(UpdateLocalization.text(ru: "Нет общих Vaults", en: "No shared Vaults"))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(vaults) { vault in
+                            HStack(alignment: .firstTextBaseline) {
+                                Label(vault.name, systemImage: "lock.square.stack.fill")
+                                Spacer()
+                                Text("r\(vault.revision) · k\(vault.keyGeneration)")
+                                    .font(.caption.monospacedDigit())
+                                    .foregroundStyle(.secondary)
+                                if vault.rotationRequired {
+                                    Label(
+                                        UpdateLocalization.text(ru: "Нужна ротация", en: "Rotation required"),
+                                        systemImage: "arrow.triangle.2.circlepath"
+                                    )
+                                    .font(.caption)
+                                    .foregroundStyle(.orange)
+                                }
+                            }
+                            .padding(.leading, 8)
+                        }
+                    }
+                }
+                .padding(.vertical, 5)
+            }
+
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .font(.caption)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private func roleTitle(_ role: SelectiveRemoteCloudTeamRole) -> String {
+        switch role {
+        case .owner: UpdateLocalization.text(ru: "Владелец", en: "Owner")
+        case .admin: UpdateLocalization.text(ru: "Администратор", en: "Admin")
+        case .editor: UpdateLocalization.text(ru: "Редактор", en: "Editor")
+        case .viewer: UpdateLocalization.text(ru: "Читатель", en: "Viewer")
+        }
+    }
+}

--- a/Sources/SelectiveRemote/CloudSettingsView.swift
+++ b/Sources/SelectiveRemote/CloudSettingsView.swift
@@ -7,6 +7,8 @@ struct CloudSettingsView: View {
     @State private var phase = Phase.idle
     @State private var metadata: SelectiveRemoteCloudMetadata?
     @State private var errorMessage: String?
+    @State private var showsConflictReview = false
+    @State private var conflictReviewMessage: String?
 
     private let client = SelectiveRemoteCloudAPIClient()
 
@@ -100,8 +102,38 @@ struct CloudSettingsView: View {
                     systemImage: "server.rack"
                 )
             }
+
+            Section(UpdateLocalization.text(ru: "Ручная проверка", en: "Manual Test")) {
+                Button(
+                    UpdateLocalization.text(
+                        ru: "Открыть тестовый конфликт…",
+                        en: "Open Test Conflict…"
+                    ),
+                    systemImage: "arrow.triangle.branch"
+                ) {
+                    conflictReviewMessage = nil
+                    showsConflictReview = true
+                }
+
+                if let conflictReviewMessage {
+                    Label(conflictReviewMessage, systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                        .font(.caption)
+                }
+
+                Text(UpdateLocalization.text(
+                    ru: "Офлайн-сценарий использует только синтетические записи. Он проверяет полный выбор версий, скрытие секретов и итоговое объединение, но ничего не отправляет в Cloud.",
+                    en: "This offline scenario uses synthetic records only. It checks complete choices, secret redaction and the final merge, but sends nothing to Cloud."
+                ))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
         }
         .formStyle(.grouped)
+        .sheet(isPresented: $showsConflictReview) {
+            conflictReviewSheet
+        }
     }
 
     @ViewBuilder
@@ -140,6 +172,34 @@ struct CloudSettingsView: View {
                 errorMessage = error.localizedDescription
                 phase = .failed
             }
+        }
+    }
+
+    @ViewBuilder
+    private var conflictReviewSheet: some View {
+        if let scenario = try? SelectiveRemoteVaultConflictReviewScenario.synthetic() {
+            SelectiveRemoteVaultConflictReviewView(
+                mergedDocument: scenario.mergedDocument,
+                conflicts: scenario.conflicts,
+                onCancel: { showsConflictReview = false },
+                onResolve: { resolutions in
+                    do {
+                        let resolved = try scenario.resolve(resolutions)
+                        conflictReviewMessage = UpdateLocalization.text(
+                            ru: "Проверка пройдена: разрешено \(resolutions.count), итоговых записей \(resolved.records.count), удалений \(resolved.tombstones.count).",
+                            en: "Test passed: resolved \(resolutions.count), final records \(resolved.records.count), deletions \(resolved.tombstones.count)."
+                        )
+                        showsConflictReview = false
+                    } catch {
+                        conflictReviewMessage = nil
+                    }
+                }
+            )
+        } else {
+            ContentUnavailableView(
+                UpdateLocalization.text(ru: "Тест недоступен", en: "Test Unavailable"),
+                systemImage: "exclamationmark.triangle"
+            )
         }
     }
 

--- a/Sources/SelectiveRemote/CloudSettingsView.swift
+++ b/Sources/SelectiveRemote/CloudSettingsView.swift
@@ -3,14 +3,25 @@ import SwiftUI
 struct CloudSettingsView: View {
     @AppStorage("SelectiveRemote.cloud.endpoint.v1")
     private var endpoint = SelectiveRemoteCloudEndpoint.production
+    @AppStorage("SelectiveRemote.cloud.device-id.v1")
+    private var storedDeviceID = ""
 
     @State private var phase = Phase.idle
     @State private var metadata: SelectiveRemoteCloudMetadata?
     @State private var errorMessage: String?
+    @State private var accountPhase = AccountPhase.signedOut
+    @State private var accountUser: SelectiveRemoteCloudUser?
+    @State private var teams: [SelectiveRemoteCloudTeam] = []
+    @State private var vaultsByTeam: [UUID: [SelectiveRemoteCloudSharedVault]] = [:]
+    @State private var accountErrorMessage: String?
+    @State private var inventoryErrorMessage: String?
+    @State private var accountEndpoint: String?
+    @State private var showsSignIn = false
     @State private var showsConflictReview = false
     @State private var conflictReviewMessage: String?
 
     private let client = SelectiveRemoteCloudAPIClient()
+    private let identityManager = SelectiveRemoteTeamDeviceIdentityManager()
 
     var body: some View {
         Form {
@@ -58,11 +69,7 @@ struct CloudSettingsView: View {
 
             Section(UpdateLocalization.text(ru: "Аккаунт и Vault", en: "Account & Vault")) {
                 LabeledContent(UpdateLocalization.text(ru: "Состояние", en: "Status")) {
-                    Text(UpdateLocalization.text(
-                        ru: "Не подключён",
-                        en: "Not connected"
-                    ))
-                    .foregroundStyle(.secondary)
+                    accountStatus
                 }
                 LabeledContent("API") {
                     Text(metadata.map { "v\($0.apiVersion)" } ?? "—")
@@ -73,17 +80,64 @@ struct CloudSettingsView: View {
                         .monospacedDigit()
                 }
 
-                Button(UpdateLocalization.text(ru: "Войти в Selective Remote Cloud…", en: "Sign In to Selective Remote Cloud…"), systemImage: "person.crop.circle.badge.checkmark") {}
+                if let accountUser {
+                    LabeledContent(UpdateLocalization.text(ru: "Пользователь", en: "User")) {
+                        VStack(alignment: .trailing, spacing: 2) {
+                            Text(accountUser.displayName)
+                            Text(accountUser.email)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .textSelection(.enabled)
+                        }
+                    }
+
+                    Button(
+                        UpdateLocalization.text(ru: "Выйти из Cloud", en: "Sign Out of Cloud"),
+                        systemImage: "rectangle.portrait.and.arrow.right",
+                        role: .destructive
+                    ) {
+                        signOut()
+                    }
+                    .disabled(accountPhase.isBusy)
+                } else {
+                    Button(
+                        UpdateLocalization.text(
+                            ru: "Войти в Selective Remote Cloud…",
+                            en: "Sign In to Selective Remote Cloud…"
+                        ),
+                        systemImage: "person.crop.circle.badge.checkmark"
+                    ) {
+                        accountErrorMessage = nil
+                        showsSignIn = true
+                    }
                     .buttonStyle(.borderedProminent)
-                    .disabled(true)
+                    .disabled(accountPhase.isBusy)
+                }
+
+                if let accountErrorMessage {
+                    Label(accountErrorMessage, systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                        .font(.caption)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
 
                 Text(UpdateLocalization.text(
-                    ru: "Вход будет включён после развёртывания API и проверки первого зашифрованного обмена. Пароль аккаунта не используется как ключ Vault.",
-                    en: "Sign-in will be enabled after the API is deployed and the first encrypted exchange is verified. The account password is not used as the Vault key."
+                    ru: "Токен сессии и закрытый ключ устройства хранятся в Keychain только на этом Mac. Пароль аккаунта не сохраняется и не используется как ключ Vault.",
+                    en: "The session token and device private key are stored in Keychain on this Mac only. The account password is not saved and is not used as the Vault key."
                 ))
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if accountUser != nil {
+                SelectiveRemoteCloudTeamInventoryView(
+                    teams: teams,
+                    vaultsByTeam: vaultsByTeam,
+                    isRefreshing: accountPhase == .refreshing,
+                    errorMessage: inventoryErrorMessage,
+                    onRefresh: refreshInventory
+                )
             }
 
             Section(UpdateLocalization.text(ru: "Конфиденциальность", en: "Privacy")) {
@@ -131,8 +185,44 @@ struct CloudSettingsView: View {
             }
         }
         .formStyle(.grouped)
+        .task {
+            await restoreStoredSessionIfNeeded()
+        }
+        .sheet(isPresented: $showsSignIn) {
+            signInSheet
+        }
         .sheet(isPresented: $showsConflictReview) {
             conflictReviewSheet
+        }
+    }
+
+    @ViewBuilder
+    private var accountStatus: some View {
+        switch accountPhase {
+        case .signedOut:
+            Text(UpdateLocalization.text(ru: "Не подключён", en: "Not connected"))
+                .foregroundStyle(.secondary)
+        case .restoring:
+            HStack(spacing: 7) {
+                ProgressView().controlSize(.small)
+                Text(UpdateLocalization.text(ru: "Восстановление сессии…", en: "Restoring session…"))
+            }
+            .foregroundStyle(.secondary)
+        case .signingIn:
+            HStack(spacing: 7) {
+                ProgressView().controlSize(.small)
+                Text(UpdateLocalization.text(ru: "Вход…", en: "Signing in…"))
+            }
+            .foregroundStyle(.secondary)
+        case .signedIn:
+            Label(UpdateLocalization.text(ru: "Подключён", en: "Connected"), systemImage: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+        case .refreshing:
+            Label(UpdateLocalization.text(ru: "Обновление…", en: "Refreshing…"), systemImage: "arrow.clockwise")
+                .foregroundStyle(.secondary)
+        case .signingOut:
+            Text(UpdateLocalization.text(ru: "Выход…", en: "Signing out…"))
+                .foregroundStyle(.secondary)
         }
     }
 
@@ -168,11 +258,166 @@ struct CloudSettingsView: View {
                 endpoint = url.absoluteString
                 metadata = try await client.metadata(endpoint: url)
                 phase = .available
+                await restoreStoredSession(at: url, force: true)
             } catch {
                 errorMessage = error.localizedDescription
                 phase = .failed
             }
         }
+    }
+
+    @ViewBuilder
+    private var signInSheet: some View {
+        if let url = try? SelectiveRemoteCloudEndpoint.normalized(endpoint) {
+            SelectiveRemoteCloudSignInView(
+                endpoint: url,
+                isSigningIn: accountPhase == .signingIn,
+                errorMessage: accountErrorMessage,
+                onCancel: {
+                    guard accountPhase != .signingIn else { return }
+                    showsSignIn = false
+                    accountErrorMessage = nil
+                },
+                onSignIn: { email, password in
+                    signIn(email: email, password: password, endpoint: url)
+                }
+            )
+        } else {
+            ContentUnavailableView(
+                UpdateLocalization.text(ru: "Некорректный адрес Cloud", en: "Invalid Cloud Address"),
+                systemImage: "exclamationmark.triangle"
+            )
+            .frame(width: 500, height: 300)
+        }
+    }
+
+    private func restoreStoredSessionIfNeeded() async {
+        guard let url = try? SelectiveRemoteCloudEndpoint.normalized(endpoint) else { return }
+        await restoreStoredSession(at: url, force: false)
+    }
+
+    @MainActor
+    private func restoreStoredSession(at url: URL, force: Bool) async {
+        if !force, accountEndpoint == url.absoluteString { return }
+        resetAccountPresentation(endpoint: url)
+        guard await client.hasStoredSession(endpoint: url) else { return }
+        accountPhase = .restoring
+        do {
+            accountUser = try await client.currentUser(endpoint: url)
+            accountPhase = .signedIn
+            await loadInventory(endpoint: url)
+        } catch {
+            resetAccountPresentation(endpoint: url)
+            accountErrorMessage = error.localizedDescription
+        }
+    }
+
+    private func signIn(email: String, password: String, endpoint url: URL) {
+        accountPhase = .signingIn
+        accountErrorMessage = nil
+        inventoryErrorMessage = nil
+        Task { @MainActor in
+            do {
+                let deviceID = resolvedDeviceID()
+                let identity = try await identityManager.identity(endpoint: url, deviceID: deviceID)
+                accountUser = try await client.login(
+                    endpoint: url,
+                    email: email,
+                    password: password,
+                    device: .thisMac(id: deviceID, publicKey: identity.publicKey)
+                )
+                accountEndpoint = url.absoluteString
+                accountPhase = .signedIn
+                showsSignIn = false
+                await loadInventory(endpoint: url)
+            } catch {
+                accountPhase = .signedOut
+                accountErrorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func refreshInventory() {
+        guard let accountUser,
+              let url = try? SelectiveRemoteCloudEndpoint.normalized(endpoint)
+        else { return }
+        Task { @MainActor in
+            do {
+                self.accountUser = try await client.currentUser(endpoint: url)
+                await loadInventory(endpoint: url)
+            } catch {
+                if error as? SelectiveRemoteCloudError == .authenticationRequired {
+                    resetAccountPresentation(endpoint: url)
+                } else {
+                    self.accountUser = accountUser
+                    accountPhase = .signedIn
+                }
+                accountErrorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    @MainActor
+    private func loadInventory(endpoint url: URL) async {
+        accountPhase = .refreshing
+        inventoryErrorMessage = nil
+        do {
+            let loadedTeams = try await client.teams(endpoint: url)
+            var loadedVaults: [UUID: [SelectiveRemoteCloudSharedVault]] = [:]
+            for team in loadedTeams {
+                loadedVaults[team.id] = try await client.sharedVaults(endpoint: url, teamID: team.id)
+            }
+            teams = loadedTeams.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+            vaultsByTeam = loadedVaults.mapValues {
+                $0.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+            }
+        } catch {
+            if error as? SelectiveRemoteCloudError == .authenticationRequired {
+                resetAccountPresentation(endpoint: url)
+                accountErrorMessage = error.localizedDescription
+                return
+            }
+            teams = []
+            vaultsByTeam = [:]
+            inventoryErrorMessage = error.localizedDescription
+        }
+        accountPhase = .signedIn
+    }
+
+    private func signOut() {
+        guard let url = try? SelectiveRemoteCloudEndpoint.normalized(endpoint) else { return }
+        accountPhase = .signingOut
+        accountErrorMessage = nil
+        Task { @MainActor in
+            do {
+                try await client.logout(endpoint: url)
+                resetAccountPresentation(endpoint: url)
+            } catch {
+                resetAccountPresentation(endpoint: url)
+                accountErrorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    @MainActor
+    private func resetAccountPresentation(endpoint url: URL) {
+        accountEndpoint = url.absoluteString
+        accountPhase = .signedOut
+        accountUser = nil
+        teams = []
+        vaultsByTeam = [:]
+        accountErrorMessage = nil
+        inventoryErrorMessage = nil
+    }
+
+    @MainActor
+    private func resolvedDeviceID() -> UUID {
+        if let existing = UUID(uuidString: storedDeviceID), existing.isSelectiveRemoteCloudUUID {
+            return existing
+        }
+        let generated = UUID()
+        storedDeviceID = generated.canonicalCloudString
+        return generated
     }
 
     @ViewBuilder
@@ -208,5 +453,21 @@ struct CloudSettingsView: View {
         case checking
         case available
         case failed
+    }
+
+    private enum AccountPhase: Equatable {
+        case signedOut
+        case restoring
+        case signingIn
+        case signedIn
+        case refreshing
+        case signingOut
+
+        var isBusy: Bool {
+            switch self {
+            case .restoring, .signingIn, .refreshing, .signingOut: true
+            case .signedOut, .signedIn: false
+            }
+        }
     }
 }

--- a/Sources/SelectiveRemote/CloudTeamVaultSyncCoordinator.swift
+++ b/Sources/SelectiveRemote/CloudTeamVaultSyncCoordinator.swift
@@ -10,6 +10,7 @@ enum SelectiveRemoteTeamVaultSyncError: Error, Equatable {
     case remoteRevisionDivergence
     case invalidWriteAcknowledgement
     case invalidConflictResponse
+    case staleConflict
 }
 
 protocol SelectiveRemoteTeamVaultRemote: Sendable {
@@ -259,6 +260,92 @@ actor SelectiveRemoteTeamVaultSyncCoordinator {
         )
         try snapshots.save(uploaded, endpoint: endpoint)
         return .uploaded(.init(snapshot: uploaded, payload: localVersion.payload))
+    }
+
+    /// Conditionally uploads a caller-resolved payload from the exact remote
+    /// revision that produced the conflict. The caller must resolve every
+    /// record-level conflict and join both causal histories before calling.
+    ///
+    /// The existing dirty snapshot is left untouched until the remote version
+    /// is revalidated. Once prepared, the resolution remains dirty on disk so
+    /// an unknown network outcome can be retried with the same idempotency key.
+    func resolveConflict(
+        _ conflict: SelectiveRemoteTeamVaultConflict,
+        resolvedPayload: Data,
+        teamID: UUID,
+        vaultID: UUID,
+        identity: SelectiveRemoteTeamDeviceIdentity
+    ) async throws -> SelectiveRemoteTeamVaultPushOutcome {
+        guard let current = try snapshots.load(
+            endpoint: endpoint,
+            teamID: teamID,
+            vaultID: vaultID
+        ) else { throw SelectiveRemoteTeamVaultSyncError.noLocalSnapshot }
+        guard current == conflict.local.snapshot,
+              current.deviceID == identity.deviceID
+        else { throw SelectiveRemoteTeamVaultSyncError.staleConflict }
+        try validateLocalCausality(current)
+        let currentLocal = try decryptedLocalVersion(
+            current,
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+        guard currentLocal.payload == conflict.local.payload else {
+            throw SelectiveRemoteTeamVaultSyncError.staleConflict
+        }
+
+        let remoteEnvelope = try await remote.sharedVault(
+            endpoint: endpoint,
+            teamID: teamID,
+            vaultID: vaultID
+        )
+        guard !remoteEnvelope.rotationRequired else {
+            throw SelectiveRemoteTeamVaultSyncError.rotationRequired
+        }
+        let latestRemote = try decryptedRemoteVersion(
+            remoteEnvelope,
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+        guard latestRemote.revision > current.serverRevision else {
+            throw SelectiveRemoteTeamVaultSyncError.invalidConflictResponse
+        }
+        guard latestRemote == conflict.remote else {
+            return .conflict(.init(local: currentLocal, remote: latestRemote))
+        }
+
+        let (nextLocalRevision, overflow) = current.localRevision.addingReportingOverflow(1)
+        guard !overflow else { throw SelectiveRemoteTeamVaultSyncError.invalidLocalSnapshot }
+        let vaultKey = try SelectiveRemoteTeamVaultCrypto.unwrapVaultKey(
+            latestRemote.wrapper,
+            with: identity,
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: latestRemote.keyGeneration
+        )
+        let resolvedEnvelope = try SelectiveRemoteTeamVaultCrypto.encryptPayload(
+            resolvedPayload,
+            vaultKey: vaultKey,
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: latestRemote.keyGeneration,
+            baseRevision: latestRemote.revision
+        )
+        let prepared = try SelectiveRemoteTeamVaultSnapshot(
+            teamID: teamID,
+            vaultID: vaultID,
+            deviceID: identity.deviceID,
+            keyGeneration: latestRemote.keyGeneration,
+            localRevision: nextLocalRevision,
+            serverRevision: latestRemote.revision,
+            syncedLocalRevision: current.syncedLocalRevision,
+            envelope: resolvedEnvelope,
+            wrapper: latestRemote.wrapper
+        )
+        try snapshots.save(prepared, endpoint: endpoint)
+        return try await push(teamID: teamID, vaultID: vaultID, identity: identity)
     }
 
     private func accept(

--- a/Sources/SelectiveRemote/CloudTeamVaultSyncCoordinator.swift
+++ b/Sources/SelectiveRemote/CloudTeamVaultSyncCoordinator.swift
@@ -316,6 +316,17 @@ actor SelectiveRemoteTeamVaultSyncCoordinator {
             return .conflict(.init(local: currentLocal, remote: latestRemote))
         }
 
+        // Actor methods are re-entrant across the remote fetch above. Refuse
+        // to replace a newer local edit that was staged while this resolution
+        // was waiting for the network.
+        guard let revalidated = try snapshots.load(
+            endpoint: endpoint,
+            teamID: teamID,
+            vaultID: vaultID
+        ), revalidated == current else {
+            throw SelectiveRemoteTeamVaultSyncError.staleConflict
+        }
+
         let (nextLocalRevision, overflow) = current.localRevision.addingReportingOverflow(1)
         guard !overflow else { throw SelectiveRemoteTeamVaultSyncError.invalidLocalSnapshot }
         let vaultKey = try SelectiveRemoteTeamVaultCrypto.unwrapVaultKey(

--- a/Sources/SelectiveRemote/CloudVaultConflictReviewView.swift
+++ b/Sources/SelectiveRemote/CloudVaultConflictReviewView.swift
@@ -1,0 +1,309 @@
+import SwiftUI
+
+struct SelectiveRemoteVaultConflictReviewView: View {
+    let mergedDocument: SelectiveRemoteVaultDocument
+    let conflicts: [SelectiveRemoteVaultConflict]
+    let onCancel: () -> Void
+    let onResolve: ([SelectiveRemoteVaultConflictResolution]) -> Void
+
+    @State private var choices: [UUID: SelectiveRemoteVaultConflictChoice] = [:]
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: 0) {
+                summary
+                Divider()
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 14) {
+                        ForEach(Array(conflicts.enumerated()), id: \.element.id) { entry in
+                            conflictCard(entry.element, number: entry.offset + 1)
+                        }
+                    }
+                    .padding(20)
+                }
+            }
+            .navigationTitle(UpdateLocalization.text(
+                ru: "Конфликты Team Vault",
+                en: "Team Vault Conflicts"
+            ))
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(UpdateLocalization.text(ru: "Отмена", en: "Cancel"), action: onCancel)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(UpdateLocalization.text(
+                        ru: "Разрешить и синхронизировать",
+                        en: "Resolve and Sync"
+                    )) {
+                        onResolve(resolutions)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!hasCompleteChoiceSet)
+                }
+            }
+        }
+        .frame(minWidth: 720, idealWidth: 780, minHeight: 520, idealHeight: 620)
+    }
+
+    private var summary: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label(
+                UpdateLocalization.text(
+                    ru: "Найдены параллельные изменения: \(conflicts.count)",
+                    en: "Concurrent changes found: \(conflicts.count)"
+                ),
+                systemImage: "arrow.triangle.branch"
+            )
+            .font(.headline)
+
+            Text(UpdateLocalization.text(
+                ru: "Выберите локальную или облачную версию для каждого элемента. Время изменения не выбирает победителя. Отправка доступна только после полного выбора.",
+                en: "Choose the local or cloud version for every item. Modification time never chooses the winner. Upload is available only after every choice is complete."
+            ))
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 16) {
+                Label(
+                    UpdateLocalization.text(
+                        ru: "Без конфликтов: \(mergedDocument.records.count) записей",
+                        en: "Conflict-free: \(mergedDocument.records.count) records"
+                    ),
+                    systemImage: "checkmark.circle"
+                )
+                Label(
+                    UpdateLocalization.text(
+                        ru: "Удалений: \(mergedDocument.tombstones.count)",
+                        en: "Deletions: \(mergedDocument.tombstones.count)"
+                    ),
+                    systemImage: "trash"
+                )
+            }
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+        }
+        .padding(20)
+    }
+
+    private func conflictCard(
+        _ conflict: SelectiveRemoteVaultConflict,
+        number: Int
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text(UpdateLocalization.text(
+                    ru: "Конфликт (number)",
+                    en: "Conflict (number)"
+                ))
+                .font(.headline)
+                Spacer()
+                Text(String(conflict.id.canonicalCloudString.prefix(8)))
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.tertiary)
+            }
+
+            HStack(alignment: .top, spacing: 12) {
+                choiceButton(
+                    conflict.local,
+                    choice: .local,
+                    title: UpdateLocalization.text(ru: "На этом Mac", en: "On This Mac"),
+                    conflictID: conflict.id
+                )
+                choiceButton(
+                    conflict.remote,
+                    choice: .remote,
+                    title: UpdateLocalization.text(ru: "В Cloud", en: "In Cloud"),
+                    conflictID: conflict.id
+                )
+            }
+        }
+        .padding(14)
+        .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: 13))
+    }
+
+    private func choiceButton(
+        _ entity: SelectiveRemoteVaultEntity,
+        choice: SelectiveRemoteVaultConflictChoice,
+        title: String,
+        conflictID: UUID
+    ) -> some View {
+        let presentation = SelectiveRemoteVaultConflictPresentation.side(entity)
+        let selected = choices[conflictID] == choice
+        return Button {
+            choices[conflictID] = choice
+        } label: {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Image(systemName: selected ? "checkmark.circle.fill" : "circle")
+                        .foregroundStyle(selected ? Color.accentColor : Color.secondary)
+                    Text(title).font(.subheadline.weight(.semibold))
+                    Spacer()
+                }
+                Label(presentation.title, systemImage: presentation.symbol)
+                    .font(.body.weight(.medium))
+                    .foregroundStyle(presentation.isDeletion ? Color.red : Color.primary)
+                    .lineLimit(2)
+                Text(presentation.metadata)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, minHeight: 116, alignment: .topLeading)
+            .contentShape(Rectangle())
+            .background(
+                selected ? Color.accentColor.opacity(0.10) : Color.clear,
+                in: RoundedRectangle(cornerRadius: 10)
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(selected ? Color.accentColor : Color.secondary.opacity(0.25), lineWidth: selected ? 2 : 1)
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(title), \(presentation.title), \(presentation.metadata)")
+        .accessibilityAddTraits(selected ? [.isSelected] : [])
+    }
+
+    private var hasCompleteChoiceSet: Bool {
+        !conflicts.isEmpty
+            && choices.count == conflicts.count
+            && conflicts.allSatisfy { choices[$0.id] != nil }
+    }
+
+    private var resolutions: [SelectiveRemoteVaultConflictResolution] {
+        conflicts.compactMap { conflict in
+            choices[conflict.id].map {
+                .init(id: conflict.id, choice: $0)
+            }
+        }
+    }
+}
+
+enum SelectiveRemoteVaultConflictPresentation {
+    struct Side: Equatable, Sendable {
+        let title: String
+        let metadata: String
+        let symbol: String
+        let isDeletion: Bool
+    }
+
+    static func side(_ entity: SelectiveRemoteVaultEntity) -> Side {
+        switch entity {
+        case let .record(record):
+            return .init(
+                title: boundedTitle(record.data),
+                metadata: "\(record.type.rawValue) · \(record.modifiedAt)",
+                symbol: symbol(record.type),
+                isDeletion: false
+            )
+        case let .tombstone(tombstone):
+            return .init(
+                title: UpdateLocalization.text(ru: "Удалено", en: "Deleted"),
+                metadata: tombstone.deletedAt,
+                symbol: "trash.fill",
+                isDeletion: true
+            )
+        }
+    }
+
+    private static func boundedTitle(_ data: SelectiveRemoteJSONValue) -> String {
+        guard case let .object(values) = data,
+              case let .string(rawTitle)? = values["title"]
+        else { return UpdateLocalization.text(ru: "Без названия", en: "Untitled") }
+        let title = rawTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty else {
+            return UpdateLocalization.text(ru: "Без названия", en: "Untitled")
+        }
+        return title.count > 120 ? String(title.prefix(117)) + "…" : title
+    }
+
+    private static func symbol(_ type: SelectiveRemoteVaultRecordType) -> String {
+        switch type {
+        case .host: "desktopcomputer"
+        case .credential: "key.fill"
+        case .snippet: "text.quote"
+        case .forwarding: "arrow.left.arrow.right"
+        }
+    }
+}
+
+struct SelectiveRemoteVaultConflictReviewScenario: Sendable {
+    let mergedDocument: SelectiveRemoteVaultDocument
+    let conflicts: [SelectiveRemoteVaultConflict]
+    let resolverDeviceID: UUID
+    let resolvedAt: String
+
+    static func synthetic() throws -> Self {
+        let deviceA = UUID(uuidString: "11111111-1111-4111-8111-111111111111")!
+        let deviceB = UUID(uuidString: "22222222-2222-4222-8222-222222222222")!
+        let resolver = UUID(uuidString: "33333333-3333-4333-8333-333333333333")!
+        let credentialID = UUID(uuidString: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")!
+        let snippetID = UUID(uuidString: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")!
+        let localTime = "2026-09-07T09:00:00.000Z"
+        let remoteTime = "2026-09-07T09:05:00.000Z"
+
+        let local = try SelectiveRemoteVaultDocument(records: [
+            .init(
+                id: credentialID,
+                type: .credential,
+                version: .init([deviceA: 2]),
+                modifiedAt: localTime,
+                data: .object([
+                    "title": .string("Production SSH"),
+                    "username": .string("must-not-render"),
+                    "secret": .string("must-not-render")
+                ])
+            ),
+            .init(
+                id: snippetID,
+                type: .snippet,
+                version: .init([deviceA: 2]),
+                modifiedAt: localTime,
+                data: .object([
+                    "title": .string("Service status"),
+                    "body": .string("must-not-render")
+                ])
+            )
+        ])
+        let remote = try SelectiveRemoteVaultDocument(
+            records: [
+                .init(
+                    id: credentialID,
+                    type: .credential,
+                    version: .init([deviceA: 1, deviceB: 1]),
+                    modifiedAt: remoteTime,
+                    data: .object([
+                        "title": .string("Production SSH — Cloud"),
+                        "username": .string("must-not-render"),
+                        "secret": .string("must-not-render")
+                    ])
+                )
+            ],
+            tombstones: [
+                .init(
+                    id: snippetID,
+                    version: .init([deviceA: 1, deviceB: 1]),
+                    deletedAt: remoteTime
+                )
+            ]
+        )
+        let merge = try local.merged(with: remote)
+        return .init(
+            mergedDocument: merge.document,
+            conflicts: merge.conflicts,
+            resolverDeviceID: resolver,
+            resolvedAt: "2026-09-07T09:10:00.000Z"
+        )
+    }
+
+    func resolve(_ resolutions: [SelectiveRemoteVaultConflictResolution]) throws -> SelectiveRemoteVaultDocument {
+        try mergedDocument.resolving(
+            conflicts,
+            with: resolutions,
+            deviceID: resolverDeviceID,
+            resolvedAt: resolvedAt
+        )
+    }
+}

--- a/Sources/SelectiveRemote/CloudVaultRecordModel.swift
+++ b/Sources/SelectiveRemote/CloudVaultRecordModel.swift
@@ -272,7 +272,7 @@ struct SelectiveRemoteVaultMerge: Equatable, Sendable {
     let conflicts: [SelectiveRemoteVaultConflict]
 }
 
-enum SelectiveRemoteVaultConflictChoice: String, Codable, Sendable {
+enum SelectiveRemoteVaultConflictChoice: String, Codable, Equatable, Hashable, Sendable {
     case local
     case remote
 }

--- a/Sources/SelectiveRemote/CloudVaultRecordModel.swift
+++ b/Sources/SelectiveRemote/CloudVaultRecordModel.swift
@@ -1,0 +1,609 @@
+import Foundation
+
+enum SelectiveRemoteVaultDocumentError: Error, Equatable {
+    case invalidVaultDocument
+    case invalidVaultSchemaVersion
+    case vaultTooLarge
+    case duplicateRecordID
+    case invalidVaultRecord
+    case invalidVaultTombstone
+    case invalidRecordType
+    case invalidRecordID
+    case invalidRecordVersion
+    case invalidModifiedAt
+    case invalidDeletedAt
+    case invalidRecordData
+    case invalidVaultConflict
+    case conflictRecordPresent
+    case invalidDevice
+    case incompleteConflictResolutions
+    case duplicateConflictResolution
+    case unknownConflictResolution
+}
+
+enum SelectiveRemoteVaultRecordType: String, Codable, CaseIterable, Sendable {
+    case host
+    case credential
+    case snippet
+    case forwarding
+}
+
+enum SelectiveRemoteJSONValue: Equatable, Sendable {
+    case null
+    case boolean(Bool)
+    case number(Double)
+    case string(String)
+    case array([SelectiveRemoteJSONValue])
+    case object([String: SelectiveRemoteJSONValue])
+}
+
+extension SelectiveRemoteJSONValue: Codable {
+    init(from decoder: Decoder) throws {
+        let values = try decoder.singleValueContainer()
+        if values.decodeNil() {
+            self = .null
+        } else if let value = try? values.decode(Bool.self) {
+            self = .boolean(value)
+        } else if let value = try? values.decode(Double.self) {
+            guard value.isFinite else {
+                throw SelectiveRemoteVaultDocumentError.invalidRecordData
+            }
+            self = .number(value)
+        } else if let value = try? values.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? values.decode([SelectiveRemoteJSONValue].self) {
+            self = .array(value)
+        } else if let value = try? values.decode([String: SelectiveRemoteJSONValue].self) {
+            self = .object(value)
+        } else {
+            throw SelectiveRemoteVaultDocumentError.invalidRecordData
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var values = encoder.singleValueContainer()
+        switch self {
+        case .null:
+            try values.encodeNil()
+        case let .boolean(value):
+            try values.encode(value)
+        case let .number(value):
+            guard value.isFinite else {
+                throw SelectiveRemoteVaultDocumentError.invalidRecordData
+            }
+            try values.encode(value)
+        case let .string(value):
+            try values.encode(value)
+        case let .array(value):
+            try values.encode(value)
+        case let .object(value):
+            try values.encode(value)
+        }
+    }
+}
+
+struct SelectiveRemoteVaultVersion: Equatable, Sendable {
+    static let maximumCounter = 9_007_199_254_740_991
+
+    let counters: [UUID: Int]
+
+    init(_ counters: [UUID: Int]) throws {
+        guard !counters.isEmpty, counters.count <= 128,
+              counters.values.allSatisfy({ (1 ... Self.maximumCounter).contains($0) })
+        else { throw SelectiveRemoteVaultDocumentError.invalidRecordVersion }
+        self.counters = counters
+    }
+
+    func incrementing(_ deviceID: UUID) throws -> Self {
+        var result = counters
+        let current = result[deviceID] ?? 0
+        guard current < Self.maximumCounter else {
+            throw SelectiveRemoteVaultDocumentError.invalidRecordVersion
+        }
+        result[deviceID] = current + 1
+        return try .init(result)
+    }
+
+    func joined(with other: Self, incrementing deviceID: UUID) throws -> Self {
+        var result = counters
+        for (key, value) in other.counters {
+            result[key] = max(result[key] ?? 0, value)
+        }
+        return try Self(result).incrementing(deviceID)
+    }
+}
+
+extension SelectiveRemoteVaultVersion: Codable {
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: SelectiveRemoteAnyCodingKey.self)
+        guard !values.allKeys.isEmpty, values.allKeys.count <= 128 else {
+            throw SelectiveRemoteVaultDocumentError.invalidRecordVersion
+        }
+        var result: [UUID: Int] = [:]
+        for key in values.allKeys.sorted(by: { $0.stringValue < $1.stringValue }) {
+            let deviceID = try SelectiveRemoteVaultValidation.uuid(
+                key.stringValue,
+                error: .invalidRecordVersion
+            )
+            let counter = try values.decode(Int.self, forKey: key)
+            guard (1 ... Self.maximumCounter).contains(counter) else {
+                throw SelectiveRemoteVaultDocumentError.invalidRecordVersion
+            }
+            result[deviceID] = counter
+        }
+        try self.init(result)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var values = encoder.container(keyedBy: SelectiveRemoteAnyCodingKey.self)
+        for (deviceID, counter) in counters.sorted(by: {
+            $0.key.canonicalCloudString < $1.key.canonicalCloudString
+        }) {
+            let key = SelectiveRemoteAnyCodingKey(stringValue: deviceID.canonicalCloudString)!
+            try values.encode(counter, forKey: key)
+        }
+    }
+}
+
+struct SelectiveRemoteVaultRecord: Equatable, Sendable, Codable {
+    let id: UUID
+    let type: SelectiveRemoteVaultRecordType
+    let version: SelectiveRemoteVaultVersion
+    let modifiedAt: String
+    let data: SelectiveRemoteJSONValue
+
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case id, type, version, modifiedAt, data
+    }
+
+    init(
+        id: UUID,
+        type: SelectiveRemoteVaultRecordType,
+        version: SelectiveRemoteVaultVersion,
+        modifiedAt: String,
+        data: SelectiveRemoteJSONValue
+    ) throws {
+        try SelectiveRemoteVaultValidation.timestamp(modifiedAt, error: .invalidModifiedAt)
+        self.id = id
+        self.type = type
+        self.version = version
+        self.modifiedAt = modifiedAt
+        self.data = data
+    }
+
+    init(from decoder: Decoder) throws {
+        try SelectiveRemoteVaultValidation.exactKeys(
+            decoder,
+            expected: CodingKeys.allCases.map(\.rawValue),
+            error: .invalidVaultRecord
+        )
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        let rawID = try values.decode(String.self, forKey: .id)
+        guard let type = try? values.decode(SelectiveRemoteVaultRecordType.self, forKey: .type) else {
+            throw SelectiveRemoteVaultDocumentError.invalidRecordType
+        }
+        try self.init(
+            id: SelectiveRemoteVaultValidation.uuid(rawID, error: .invalidRecordID),
+            type: type,
+            version: values.decode(SelectiveRemoteVaultVersion.self, forKey: .version),
+            modifiedAt: values.decode(String.self, forKey: .modifiedAt),
+            data: values.decode(SelectiveRemoteJSONValue.self, forKey: .data)
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var values = encoder.container(keyedBy: CodingKeys.self)
+        try values.encode(id.canonicalCloudString, forKey: .id)
+        try values.encode(type, forKey: .type)
+        try values.encode(version, forKey: .version)
+        try values.encode(modifiedAt, forKey: .modifiedAt)
+        try values.encode(data, forKey: .data)
+    }
+}
+
+struct SelectiveRemoteVaultTombstone: Equatable, Sendable, Codable {
+    let id: UUID
+    let version: SelectiveRemoteVaultVersion
+    let deletedAt: String
+
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case id, version, deletedAt
+    }
+
+    init(id: UUID, version: SelectiveRemoteVaultVersion, deletedAt: String) throws {
+        try SelectiveRemoteVaultValidation.timestamp(deletedAt, error: .invalidDeletedAt)
+        self.id = id
+        self.version = version
+        self.deletedAt = deletedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        try SelectiveRemoteVaultValidation.exactKeys(
+            decoder,
+            expected: CodingKeys.allCases.map(\.rawValue),
+            error: .invalidVaultTombstone
+        )
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(
+            id: SelectiveRemoteVaultValidation.uuid(
+                values.decode(String.self, forKey: .id),
+                error: .invalidRecordID
+            ),
+            version: values.decode(SelectiveRemoteVaultVersion.self, forKey: .version),
+            deletedAt: values.decode(String.self, forKey: .deletedAt)
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var values = encoder.container(keyedBy: CodingKeys.self)
+        try values.encode(id.canonicalCloudString, forKey: .id)
+        try values.encode(version, forKey: .version)
+        try values.encode(deletedAt, forKey: .deletedAt)
+    }
+}
+
+enum SelectiveRemoteVaultEntity: Equatable, Sendable {
+    case record(SelectiveRemoteVaultRecord)
+    case tombstone(SelectiveRemoteVaultTombstone)
+
+    var id: UUID {
+        switch self {
+        case let .record(value): value.id
+        case let .tombstone(value): value.id
+        }
+    }
+
+    var version: SelectiveRemoteVaultVersion {
+        switch self {
+        case let .record(value): value.version
+        case let .tombstone(value): value.version
+        }
+    }
+}
+
+struct SelectiveRemoteVaultConflict: Equatable, Sendable {
+    let id: UUID
+    let local: SelectiveRemoteVaultEntity
+    let remote: SelectiveRemoteVaultEntity
+}
+
+struct SelectiveRemoteVaultMerge: Equatable, Sendable {
+    let document: SelectiveRemoteVaultDocument
+    let conflicts: [SelectiveRemoteVaultConflict]
+}
+
+enum SelectiveRemoteVaultConflictChoice: String, Codable, Sendable {
+    case local
+    case remote
+}
+
+struct SelectiveRemoteVaultConflictResolution: Equatable, Sendable {
+    let id: UUID
+    let choice: SelectiveRemoteVaultConflictChoice
+}
+
+struct SelectiveRemoteVaultDocument: Equatable, Sendable, Codable {
+    static let schemaVersion = 1
+    private static let maximumBytes = 24 * 1024 * 1024
+    private static let maximumEntities = 10_000
+
+    let records: [SelectiveRemoteVaultRecord]
+    let tombstones: [SelectiveRemoteVaultTombstone]
+
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case schemaVersion, records, tombstones
+    }
+
+    init(
+        records: [SelectiveRemoteVaultRecord] = [],
+        tombstones: [SelectiveRemoteVaultTombstone] = []
+    ) throws {
+        guard records.count + tombstones.count <= Self.maximumEntities else {
+            throw SelectiveRemoteVaultDocumentError.vaultTooLarge
+        }
+        let allIDs = records.map(\.id) + tombstones.map(\.id)
+        guard Set(allIDs).count == allIDs.count else {
+            throw SelectiveRemoteVaultDocumentError.duplicateRecordID
+        }
+        var budget = 100_000
+        for record in records {
+            try SelectiveRemoteVaultValidation.json(record.data, depth: 0, budget: &budget)
+        }
+        self.records = records.sorted { $0.id.canonicalCloudString < $1.id.canonicalCloudString }
+        self.tombstones = tombstones.sorted { $0.id.canonicalCloudString < $1.id.canonicalCloudString }
+        guard try encoded().count <= Self.maximumBytes else {
+            throw SelectiveRemoteVaultDocumentError.vaultTooLarge
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        try SelectiveRemoteVaultValidation.exactKeys(
+            decoder,
+            expected: CodingKeys.allCases.map(\.rawValue),
+            error: .invalidVaultDocument
+        )
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        guard try values.decode(Int.self, forKey: .schemaVersion) == Self.schemaVersion else {
+            throw SelectiveRemoteVaultDocumentError.invalidVaultSchemaVersion
+        }
+        try self.init(
+            records: values.decode([SelectiveRemoteVaultRecord].self, forKey: .records),
+            tombstones: values.decode([SelectiveRemoteVaultTombstone].self, forKey: .tombstones)
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var values = encoder.container(keyedBy: CodingKeys.self)
+        try values.encode(Self.schemaVersion, forKey: .schemaVersion)
+        try values.encode(records, forKey: .records)
+        try values.encode(tombstones, forKey: .tombstones)
+    }
+
+    static func decode(_ data: Data) throws -> Self {
+        do {
+            return try JSONDecoder().decode(Self.self, from: data)
+        } catch let error as SelectiveRemoteVaultDocumentError {
+            throw error
+        } catch {
+            throw SelectiveRemoteVaultDocumentError.invalidVaultDocument
+        }
+    }
+
+    func encoded() throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        return try encoder.encode(self)
+    }
+
+    func merged(with remote: Self) throws -> SelectiveRemoteVaultMerge {
+        let localEntities = entityMap
+        let remoteEntities = remote.entityMap
+        var records: [SelectiveRemoteVaultRecord] = []
+        var tombstones: [SelectiveRemoteVaultTombstone] = []
+        var conflicts: [SelectiveRemoteVaultConflict] = []
+        let ids = Set(localEntities.keys).union(remoteEntities.keys).sorted {
+            $0.canonicalCloudString < $1.canonicalCloudString
+        }
+
+        for id in ids {
+            let local = localEntities[id]
+            let remote = remoteEntities[id]
+            var selected = local ?? remote
+            if let local, let remote {
+                switch SelectiveRemoteVaultValidation.relation(local.version, remote.version) {
+                case .left:
+                    selected = local
+                case .right:
+                    selected = remote
+                case .equal:
+                    if local == remote {
+                        selected = local
+                    } else {
+                        selected = nil
+                        conflicts.append(.init(id: id, local: local, remote: remote))
+                    }
+                case .concurrent:
+                    selected = nil
+                    conflicts.append(.init(id: id, local: local, remote: remote))
+                }
+            }
+            switch selected {
+            case let .some(.record(value)): records.append(value)
+            case let .some(.tombstone(value)): tombstones.append(value)
+            case .none: break
+            }
+        }
+        return try .init(document: .init(records: records, tombstones: tombstones), conflicts: conflicts)
+    }
+
+    func resolving(
+        _ conflicts: [SelectiveRemoteVaultConflict],
+        with resolutions: [SelectiveRemoteVaultConflictResolution],
+        deviceID: UUID,
+        resolvedAt: String
+    ) throws -> Self {
+        let conflictIDs = Set(conflicts.map(\.id))
+        guard conflictIDs.count == conflicts.count else {
+            throw SelectiveRemoteVaultDocumentError.invalidVaultConflict
+        }
+        var choices: [UUID: SelectiveRemoteVaultConflictChoice] = [:]
+        for resolution in resolutions {
+            guard choices[resolution.id] == nil else {
+                throw SelectiveRemoteVaultDocumentError.duplicateConflictResolution
+            }
+            guard conflictIDs.contains(resolution.id) else {
+                throw SelectiveRemoteVaultDocumentError.unknownConflictResolution
+            }
+            choices[resolution.id] = resolution.choice
+        }
+        guard choices.count == conflicts.count else {
+            throw SelectiveRemoteVaultDocumentError.incompleteConflictResolutions
+        }
+
+        var records = self.records
+        var tombstones = self.tombstones
+        let presentIDs = Set(entityMap.keys)
+        for conflict in conflicts.sorted(by: { $0.id.canonicalCloudString < $1.id.canonicalCloudString }) {
+            guard conflict.local.id == conflict.id,
+                  conflict.remote.id == conflict.id,
+                  let choice = choices[conflict.id]
+            else { throw SelectiveRemoteVaultDocumentError.invalidVaultConflict }
+            guard !presentIDs.contains(conflict.id) else {
+                throw SelectiveRemoteVaultDocumentError.conflictRecordPresent
+            }
+            let selected = choice == .local ? conflict.local : conflict.remote
+            let version = try conflict.local.version.joined(
+                with: conflict.remote.version,
+                incrementing: deviceID
+            )
+            switch selected {
+            case let .record(value):
+                records.append(try .init(
+                    id: value.id,
+                    type: value.type,
+                    version: version,
+                    modifiedAt: resolvedAt,
+                    data: value.data
+                ))
+            case let .tombstone(value):
+                tombstones.append(try .init(id: value.id, version: version, deletedAt: resolvedAt))
+            }
+        }
+        return try .init(records: records, tombstones: tombstones)
+    }
+
+    private var entityMap: [UUID: SelectiveRemoteVaultEntity] {
+        var result: [UUID: SelectiveRemoteVaultEntity] = Dictionary(
+            uniqueKeysWithValues: records.map { ($0.id, .record($0)) }
+        )
+        for tombstone in tombstones { result[tombstone.id] = .tombstone(tombstone) }
+        return result
+    }
+}
+
+struct SelectiveRemoteTeamVaultRecordConflict: Equatable, Sendable {
+    let transport: SelectiveRemoteTeamVaultConflict
+    let mergedDocument: SelectiveRemoteVaultDocument
+    let recordConflicts: [SelectiveRemoteVaultConflict]
+}
+
+enum SelectiveRemoteTeamVaultRecordPushOutcome: Equatable, Sendable {
+    case uploaded(SelectiveRemoteTeamVaultDecryptedSnapshot, SelectiveRemoteVaultDocument)
+    case conflict(SelectiveRemoteTeamVaultRecordConflict)
+}
+
+extension SelectiveRemoteTeamVaultSyncCoordinator {
+    func prepareRecordConflict(
+        _ conflict: SelectiveRemoteTeamVaultConflict
+    ) throws -> SelectiveRemoteTeamVaultRecordConflict {
+        let local = try SelectiveRemoteVaultDocument.decode(conflict.local.payload)
+        let remote = try SelectiveRemoteVaultDocument.decode(conflict.remote.payload)
+        let merge = try local.merged(with: remote)
+        return .init(
+            transport: conflict,
+            mergedDocument: merge.document,
+            recordConflicts: merge.conflicts
+        )
+    }
+
+    func resolveRecordConflicts(
+        _ conflict: SelectiveRemoteTeamVaultRecordConflict,
+        resolutions: [SelectiveRemoteVaultConflictResolution],
+        resolvedAt: String,
+        teamID: UUID,
+        vaultID: UUID,
+        identity: SelectiveRemoteTeamDeviceIdentity
+    ) async throws -> SelectiveRemoteTeamVaultRecordPushOutcome {
+        let resolved = try conflict.mergedDocument.resolving(
+            conflict.recordConflicts,
+            with: resolutions,
+            deviceID: identity.deviceID,
+            resolvedAt: resolvedAt
+        )
+        let outcome = try await resolveConflict(
+            conflict.transport,
+            resolvedPayload: resolved.encoded(),
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+        switch outcome {
+        case let .uploaded(snapshot):
+            return .uploaded(snapshot, try SelectiveRemoteVaultDocument.decode(snapshot.payload))
+        case let .conflict(updated):
+            return .conflict(try prepareRecordConflict(updated))
+        }
+    }
+}
+
+private enum SelectiveRemoteVaultVectorRelation {
+    case left, right, equal, concurrent
+}
+
+private enum SelectiveRemoteVaultValidation {
+    private static let forbiddenKeys: Set<String> = ["__proto__", "constructor", "prototype"]
+
+    static func exactKeys(
+        _ decoder: Decoder,
+        expected: [String],
+        error: SelectiveRemoteVaultDocumentError
+    ) throws {
+        let values = try decoder.container(keyedBy: SelectiveRemoteAnyCodingKey.self)
+        guard Set(values.allKeys.map(\.stringValue)) == Set(expected),
+              values.allKeys.count == expected.count
+        else { throw error }
+    }
+
+    static func uuid(
+        _ value: String,
+        error: SelectiveRemoteVaultDocumentError
+    ) throws -> UUID {
+        let normalized = value.lowercased()
+        guard normalized.range(
+            of: #"^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"#,
+            options: .regularExpression
+        ) != nil, let result = UUID(uuidString: normalized)
+        else { throw error }
+        return result
+    }
+
+    static func timestamp(
+        _ value: String,
+        error: SelectiveRemoteVaultDocumentError
+    ) throws {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        guard let date = formatter.date(from: value), formatter.string(from: date) == value else {
+            throw error
+        }
+    }
+
+    static func json(
+        _ value: SelectiveRemoteJSONValue,
+        depth: Int,
+        budget: inout Int
+    ) throws {
+        budget -= 1
+        guard budget >= 0, depth <= 32 else {
+            throw SelectiveRemoteVaultDocumentError.invalidRecordData
+        }
+        switch value {
+        case .null, .boolean, .string:
+            return
+        case let .number(number):
+            guard number.isFinite else {
+                throw SelectiveRemoteVaultDocumentError.invalidRecordData
+            }
+        case let .array(values):
+            guard values.count <= 10_000 else {
+                throw SelectiveRemoteVaultDocumentError.invalidRecordData
+            }
+            for value in values { try json(value, depth: depth + 1, budget: &budget) }
+        case let .object(values):
+            guard values.count <= 1_000,
+                  values.keys.allSatisfy({ !forbiddenKeys.contains($0) })
+            else { throw SelectiveRemoteVaultDocumentError.invalidRecordData }
+            for key in values.keys.sorted() {
+                try json(values[key]!, depth: depth + 1, budget: &budget)
+            }
+        }
+    }
+
+    static func relation(
+        _ left: SelectiveRemoteVaultVersion,
+        _ right: SelectiveRemoteVaultVersion
+    ) -> SelectiveRemoteVaultVectorRelation {
+        var leftAhead = false
+        var rightAhead = false
+        for deviceID in Set(left.counters.keys).union(right.counters.keys) {
+            let comparison = (left.counters[deviceID] ?? 0) - (right.counters[deviceID] ?? 0)
+            if comparison > 0 { leftAhead = true }
+            if comparison < 0 { rightAhead = true }
+        }
+        if leftAhead, rightAhead { return .concurrent }
+        if leftAhead { return .left }
+        if rightAhead { return .right }
+        return .equal
+    }
+
+}

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -639,6 +639,129 @@ struct CloudMacOSFoundationTests {
         #expect(writes.count == 1)
     }
 
+    @Test("Team Vault record workflow requires a complete causal choice before upload")
+    func teamVaultRecordConflictWorkflow() async throws {
+        let fixture = try Self.fixture()
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized("https://cloud.example.invalid")
+        let teamID = try fixture.wrapper.teamID.uuid
+        let vaultID = try fixture.wrapper.vaultID.uuid
+        let identity = try SelectiveRemoteTeamDeviceIdentity(
+            deviceID: try fixture.wrapper.deviceID.uuid,
+            privateKeyRepresentation: try fixture.keyWrap.recipientPrivateScalar.base64URLData
+        )
+        let wrapper = try Self.fixtureWrapper(fixture, identity: identity)
+        let remote = TeamVaultRemoteStub(
+            envelope: Self.remoteEnvelope(fixture, wrapper: wrapper),
+            writeResult: .init(conflict: true, revision: 6, keyGeneration: 7, rotationCompleted: nil)
+        )
+        let storage = SelectiveRemoteTeamVaultMemorySnapshotStore()
+        let coordinator = try SelectiveRemoteTeamVaultSyncCoordinator(
+            endpoint: endpoint,
+            remote: remote,
+            snapshots: storage
+        )
+        _ = try await coordinator.refresh(teamID: teamID, vaultID: vaultID, identity: identity)
+
+        let deviceA = try #require(UUID(uuidString: "11111111-1111-4111-8111-111111111111"))
+        let deviceB = try #require(UUID(uuidString: "22222222-2222-4222-8222-222222222222"))
+        let recordID = try #require(UUID(uuidString: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"))
+        let localRecord = try SelectiveRemoteVaultRecord(
+            id: recordID,
+            type: .host,
+            version: .init([deviceA: 2]),
+            modifiedAt: "2026-09-07T01:00:00.000Z",
+            data: .object(["title": .string("Local")])
+        )
+        let remoteRecord = try SelectiveRemoteVaultRecord(
+            id: recordID,
+            type: .host,
+            version: .init([deviceA: 1, deviceB: 1]),
+            modifiedAt: "2026-09-07T02:00:00.000Z",
+            data: .object(["title": .string("Remote")])
+        )
+        let localDocument = try SelectiveRemoteVaultDocument(records: [localRecord])
+        let remoteDocument = try SelectiveRemoteVaultDocument(records: [remoteRecord])
+        _ = try await coordinator.stage(
+            localDocument.encoded(),
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+        let remoteCiphertext = try SelectiveRemoteTeamVaultCrypto.encryptPayload(
+            remoteDocument.encoded(),
+            vaultKey: try fixture.keyWrap.vaultKey.base64URLData,
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: fixture.payload.keyGeneration,
+            baseRevision: 5,
+            nonce: Data(repeating: 0x27, count: 12)
+        )
+        await remote.setEnvelope(.init(
+            id: vaultID,
+            teamID: teamID,
+            name: "Operations",
+            revision: 6,
+            keyGeneration: fixture.payload.keyGeneration,
+            rotationRequired: false,
+            envelopeVersion: remoteCiphertext.envelopeVersion,
+            ciphertext: remoteCiphertext.ciphertext,
+            nonce: remoteCiphertext.nonce,
+            authTag: remoteCiphertext.authTag,
+            contentHash: remoteCiphertext.contentHash,
+            wrapper: wrapper,
+            createdAt: "2026-09-06T00:00:00.000Z",
+            updatedAt: "2026-09-07T02:00:00.000Z"
+        ))
+
+        let pushed = try await coordinator.push(teamID: teamID, vaultID: vaultID, identity: identity)
+        guard case let .conflict(transportConflict) = pushed else {
+            Issue.record("Expected a transport conflict")
+            return
+        }
+        let prepared = try await coordinator.prepareRecordConflict(transportConflict)
+        #expect(prepared.mergedDocument.records.isEmpty)
+        #expect(prepared.recordConflicts.map(\.id) == [recordID])
+        await #expect(throws: SelectiveRemoteVaultDocumentError.incompleteConflictResolutions) {
+            try await coordinator.resolveRecordConflicts(
+                prepared,
+                resolutions: [],
+                resolvedAt: "2026-09-07T03:00:00.000Z",
+                teamID: teamID,
+                vaultID: vaultID,
+                identity: identity
+            )
+        }
+
+        await remote.setWriteResult(.init(
+            conflict: false,
+            revision: 7,
+            keyGeneration: fixture.payload.keyGeneration,
+            rotationCompleted: false
+        ))
+        let resolved = try await coordinator.resolveRecordConflicts(
+            prepared,
+            resolutions: [.init(id: recordID, choice: .remote)],
+            resolvedAt: "2026-09-07T03:00:00.000Z",
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+        guard case let .uploaded(snapshot, document) = resolved else {
+            Issue.record("Expected a resolved record upload")
+            return
+        }
+        #expect(snapshot.snapshot.serverRevision == 7)
+        #expect(document.records[0].data == .object(["title": .string("Remote")]))
+        #expect(document.records[0].version.counters == [
+            deviceA: 2,
+            deviceB: 1,
+            identity.deviceID: 1
+        ])
+        let writes = await remote.recordedWrites()
+        #expect(writes.count == 2)
+        #expect(writes.last?.upload.envelope.baseRevision == 6)
+    }
+
     @Test("Team Vault coordinator fails closed while key rotation is required")
     func teamVaultSyncRotationGate() async throws {
         let fixture = try Self.fixture()

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -512,9 +512,12 @@ struct CloudMacOSFoundationTests {
                 identity: identity
             )
         }
-        let pendingResolution = try #require(
-            storage.load(endpoint: endpoint, teamID: teamID, vaultID: vaultID)
+        let storedPendingResolution = try storage.load(
+            endpoint: endpoint,
+            teamID: teamID,
+            vaultID: vaultID
         )
+        let pendingResolution = try #require(storedPendingResolution)
         #expect(pendingResolution.envelope.baseRevision == 7)
         #expect(pendingResolution.localRevision > pendingResolution.syncedLocalRevision)
 

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -61,6 +61,8 @@ struct CloudMacOSFoundationTests {
         )
         #expect(user == SelectiveRemoteCloudUser(id: userID, email: "user@example.invalid", displayName: "User"))
         #expect(try store.token(for: endpoint) == token)
+        let hasStoredSession = await client.hasStoredSession(endpoint: endpoint)
+        #expect(hasStoredSession)
         #expect(try await client.currentUser(endpoint: endpoint) == user)
         let teams = try await client.teams(endpoint: endpoint)
         #expect(teams.count == 1)
@@ -68,6 +70,51 @@ struct CloudMacOSFoundationTests {
         #expect(teams[0].membershipEpoch == 3)
         try await client.logout(endpoint: endpoint)
         #expect(try store.token(for: endpoint) == nil)
+    }
+
+    @Test("macOS account inventory rejects extended user and Team responses")
+    func accountInventoryRejectsExtendedResponses() async throws {
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized("https://cloud.example.invalid")
+        let token = String(repeating: "t", count: 43)
+        let userID = try #require(UUID(uuidString: "66666666-6666-4666-8666-666666666666"))
+        let membershipID = try #require(UUID(uuidString: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"))
+        let teamID = try #require(UUID(uuidString: "11111111-1111-4111-8111-111111111111"))
+        let store = SelectiveRemoteCloudMemoryTokenStore()
+        try store.saveToken(token, for: endpoint)
+        let client = SelectiveRemoteCloudAPIClient(
+            tokenStore: store,
+            dataLoader: { request in
+                switch request.url?.path {
+                case "/v1/me":
+                    Self.response(request, status: 200, json: [
+                        "id": userID.canonicalCloudString,
+                        "email": "user@example.invalid",
+                        "displayName": "User",
+                        "unexpected": true
+                    ])
+                case "/v1/teams":
+                    Self.response(request, status: 200, json: ["teams": [[
+                        "id": teamID.canonicalCloudString,
+                        "name": "Platform",
+                        "membershipID": membershipID.canonicalCloudString,
+                        "role": "owner",
+                        "membershipEpoch": 3,
+                        "createdAt": "2026-09-07T00:00:00.000Z",
+                        "updatedAt": "2026-09-07T00:00:00.000Z",
+                        "unexpected": true
+                    ]]])
+                default:
+                    Self.response(request, status: 500, json: ["error": "unexpected_request"])
+                }
+            }
+        )
+
+        await #expect(throws: SelectiveRemoteCloudError.invalidResponse) {
+            try await client.currentUser(endpoint: endpoint)
+        }
+        await #expect(throws: SelectiveRemoteCloudError.invalidResponse) {
+            try await client.teams(endpoint: endpoint)
+        }
     }
 
     @Test("a 401 response deletes the stored macOS Cloud session")

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -548,6 +548,97 @@ struct CloudMacOSFoundationTests {
         #expect(resolutionWrites.last?.idempotencyKey != resolutionWrites.first?.idempotencyKey)
     }
 
+    @Test("Team Vault conflict resolution preserves an edit staged during remote revalidation")
+    func teamVaultConflictResolutionReentrancy() async throws {
+        let fixture = try Self.fixture()
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized("https://cloud.example.invalid")
+        let teamID = try fixture.wrapper.teamID.uuid
+        let vaultID = try fixture.wrapper.vaultID.uuid
+        let identity = try SelectiveRemoteTeamDeviceIdentity(
+            deviceID: try fixture.wrapper.deviceID.uuid,
+            privateKeyRepresentation: try fixture.keyWrap.recipientPrivateScalar.base64URLData
+        )
+        let wrapper = try Self.fixtureWrapper(fixture, identity: identity)
+        let remote = TeamVaultRemoteStub(
+            envelope: Self.remoteEnvelope(fixture, wrapper: wrapper),
+            writeResult: .init(conflict: true, revision: 6, keyGeneration: 7, rotationCompleted: nil)
+        )
+        let storage = SelectiveRemoteTeamVaultMemorySnapshotStore()
+        let coordinator = try SelectiveRemoteTeamVaultSyncCoordinator(
+            endpoint: endpoint,
+            remote: remote,
+            snapshots: storage
+        )
+        _ = try await coordinator.refresh(teamID: teamID, vaultID: vaultID, identity: identity)
+        _ = try await coordinator.stage(
+            Data("synthetic original local conflict".utf8),
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+
+        let remotePayload = Data("synthetic remote conflict".utf8)
+        let remoteCiphertext = try SelectiveRemoteTeamVaultCrypto.encryptPayload(
+            remotePayload,
+            vaultKey: try fixture.keyWrap.vaultKey.base64URLData,
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: fixture.payload.keyGeneration,
+            baseRevision: 5,
+            nonce: Data(repeating: 0x26, count: 12)
+        )
+        await remote.setEnvelope(.init(
+            id: vaultID,
+            teamID: teamID,
+            name: "Operations",
+            revision: 6,
+            keyGeneration: fixture.payload.keyGeneration,
+            rotationRequired: false,
+            envelopeVersion: remoteCiphertext.envelopeVersion,
+            ciphertext: remoteCiphertext.ciphertext,
+            nonce: remoteCiphertext.nonce,
+            authTag: remoteCiphertext.authTag,
+            contentHash: remoteCiphertext.contentHash,
+            wrapper: wrapper,
+            createdAt: "2026-09-06T00:00:00.000Z",
+            updatedAt: "2026-09-07T00:00:00.000Z"
+        ))
+        let pushed = try await coordinator.push(teamID: teamID, vaultID: vaultID, identity: identity)
+        guard case let .conflict(conflict) = pushed else {
+            Issue.record("Expected an explicit conflict")
+            return
+        }
+
+        let barrier = TeamVaultReadBarrier()
+        await remote.setReadBarrier(barrier)
+        let resolving = Task {
+            try await coordinator.resolveConflict(
+                conflict,
+                resolvedPayload: Data("must not replace racing edit".utf8),
+                teamID: teamID,
+                vaultID: vaultID,
+                identity: identity
+            )
+        }
+        await barrier.waitUntilSuspended()
+        let racingPayload = Data("synthetic racing local edit".utf8)
+        let racing = try await coordinator.stage(
+            racingPayload,
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+        await barrier.resume()
+
+        await #expect(throws: SelectiveRemoteTeamVaultSyncError.staleConflict) {
+            try await resolving.value
+        }
+        let preserved = try storage.load(endpoint: endpoint, teamID: teamID, vaultID: vaultID)
+        #expect(preserved == racing.snapshot)
+        let writes = await remote.recordedWrites()
+        #expect(writes.count == 1)
+    }
+
     @Test("Team Vault coordinator fails closed while key rotation is required")
     func teamVaultSyncRotationGate() async throws {
         let fixture = try Self.fixture()
@@ -723,6 +814,29 @@ private enum TeamVaultRemoteStubFailure: Error, Equatable, Sendable {
     case unknownOutcome
 }
 
+private actor TeamVaultReadBarrier {
+    private var suspended = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func suspend() async {
+        suspended = true
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func waitUntilSuspended() async {
+        while !suspended {
+            await Task.yield()
+        }
+    }
+
+    func resume() {
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
 private actor TeamVaultRemoteStub: SelectiveRemoteTeamVaultRemote {
     struct RecordedWrite: Equatable, Sendable {
         let upload: SelectiveRemoteCloudTeamVaultUpload
@@ -732,6 +846,7 @@ private actor TeamVaultRemoteStub: SelectiveRemoteTeamVaultRemote {
     private var envelope: SelectiveRemoteCloudSharedVaultEnvelope
     private var writeResult: SelectiveRemoteCloudTeamVaultWriteResult
     private var writeFailure: TeamVaultRemoteStubFailure?
+    private var readBarrier: TeamVaultReadBarrier?
     private var writes: [RecordedWrite] = []
 
     init(
@@ -749,6 +864,10 @@ private actor TeamVaultRemoteStub: SelectiveRemoteTeamVaultRemote {
     ) async throws -> SelectiveRemoteCloudSharedVaultEnvelope {
         #expect(envelope.teamID == teamID)
         #expect(envelope.id == vaultID)
+        if let readBarrier {
+            self.readBarrier = nil
+            await readBarrier.suspend()
+        }
         return envelope
     }
 
@@ -778,6 +897,10 @@ private actor TeamVaultRemoteStub: SelectiveRemoteTeamVaultRemote {
 
     func setWriteFailure(_ value: TeamVaultRemoteStubFailure?) {
         writeFailure = value
+    }
+
+    func setReadBarrier(_ value: TeamVaultReadBarrier?) {
+        readBarrier = value
     }
 
     func recordedWrites() -> [RecordedWrite] {

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -457,6 +457,92 @@ struct CloudMacOSFoundationTests {
         #expect(conflict.local.snapshot.envelope == staged.snapshot.envelope)
         let preserved = try storage.load(endpoint: endpoint, teamID: teamID, vaultID: vaultID)
         #expect(preserved == staged.snapshot)
+
+        let newerRemotePayload = Data("synthetic newer remote conflict".utf8)
+        let newerRemoteCiphertext = try SelectiveRemoteTeamVaultCrypto.encryptPayload(
+            newerRemotePayload,
+            vaultKey: try fixture.keyWrap.vaultKey.base64URLData,
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: fixture.payload.keyGeneration,
+            baseRevision: 6,
+            nonce: Data(repeating: 0x24, count: 12)
+        )
+        await remote.setEnvelope(.init(
+            id: vaultID,
+            teamID: teamID,
+            name: "Operations",
+            revision: 7,
+            keyGeneration: fixture.payload.keyGeneration,
+            rotationRequired: false,
+            envelopeVersion: newerRemoteCiphertext.envelopeVersion,
+            ciphertext: newerRemoteCiphertext.ciphertext,
+            nonce: newerRemoteCiphertext.nonce,
+            authTag: newerRemoteCiphertext.authTag,
+            contentHash: newerRemoteCiphertext.contentHash,
+            wrapper: wrapper,
+            createdAt: "2026-09-06T00:00:00.000Z",
+            updatedAt: "2026-09-07T01:00:00.000Z"
+        ))
+        let staleResolution = try await coordinator.resolveConflict(
+            conflict,
+            resolvedPayload: Data("must not upload".utf8),
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+        guard case let .conflict(updatedConflict) = staleResolution else {
+            Issue.record("Expected a changed remote version to return a new conflict")
+            return
+        }
+        #expect(updatedConflict.remote.revision == 7)
+        #expect(updatedConflict.remote.payload == newerRemotePayload)
+        #expect(try storage.load(endpoint: endpoint, teamID: teamID, vaultID: vaultID) == staged.snapshot)
+        let staleResolutionWrites = await remote.recordedWrites()
+        #expect(staleResolutionWrites.count == 1)
+
+        let resolvedPayload = Data("synthetic joined conflict resolution".utf8)
+        await remote.setWriteFailure(.unknownOutcome)
+        await #expect(throws: TeamVaultRemoteStubFailure.unknownOutcome) {
+            try await coordinator.resolveConflict(
+                updatedConflict,
+                resolvedPayload: resolvedPayload,
+                teamID: teamID,
+                vaultID: vaultID,
+                identity: identity
+            )
+        }
+        let pendingResolution = try #require(
+            storage.load(endpoint: endpoint, teamID: teamID, vaultID: vaultID)
+        )
+        #expect(pendingResolution.envelope.baseRevision == 7)
+        #expect(pendingResolution.localRevision > pendingResolution.syncedLocalRevision)
+
+        await remote.setWriteFailure(nil)
+        await remote.setWriteResult(.init(
+            conflict: false,
+            revision: 8,
+            keyGeneration: fixture.payload.keyGeneration,
+            rotationCompleted: false
+        ))
+        let resolution = try await coordinator.push(
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+        guard case let .uploaded(uploaded) = resolution else {
+            Issue.record("Expected the explicit conflict resolution to upload")
+            return
+        }
+        #expect(uploaded.payload == resolvedPayload)
+        #expect(uploaded.snapshot.serverRevision == 8)
+        #expect(uploaded.snapshot.envelope.baseRevision == 7)
+        #expect(uploaded.snapshot.localRevision == uploaded.snapshot.syncedLocalRevision)
+        let resolutionWrites = await remote.recordedWrites()
+        #expect(resolutionWrites.count == 3)
+        #expect(resolutionWrites.last?.upload.envelope.baseRevision == 7)
+        #expect(resolutionWrites[1].idempotencyKey == resolutionWrites[2].idempotencyKey)
+        #expect(resolutionWrites.last?.idempotencyKey != resolutionWrites.first?.idempotencyKey)
     }
 
     @Test("Team Vault coordinator fails closed while key rotation is required")
@@ -630,6 +716,10 @@ private final class CloudHTTPStub: @unchecked Sendable {
     }
 }
 
+private enum TeamVaultRemoteStubFailure: Error, Equatable, Sendable {
+    case unknownOutcome
+}
+
 private actor TeamVaultRemoteStub: SelectiveRemoteTeamVaultRemote {
     struct RecordedWrite: Equatable, Sendable {
         let upload: SelectiveRemoteCloudTeamVaultUpload
@@ -638,6 +728,7 @@ private actor TeamVaultRemoteStub: SelectiveRemoteTeamVaultRemote {
 
     private var envelope: SelectiveRemoteCloudSharedVaultEnvelope
     private var writeResult: SelectiveRemoteCloudTeamVaultWriteResult
+    private var writeFailure: TeamVaultRemoteStubFailure?
     private var writes: [RecordedWrite] = []
 
     init(
@@ -668,11 +759,22 @@ private actor TeamVaultRemoteStub: SelectiveRemoteTeamVaultRemote {
         #expect(envelope.teamID == teamID)
         #expect(envelope.id == vaultID)
         writes.append(.init(upload: upload, idempotencyKey: idempotencyKey))
+        if let writeFailure {
+            throw writeFailure
+        }
         return writeResult
     }
 
     func setEnvelope(_ value: SelectiveRemoteCloudSharedVaultEnvelope) {
         envelope = value
+    }
+
+    func setWriteResult(_ value: SelectiveRemoteCloudTeamVaultWriteResult) {
+        writeResult = value
+    }
+
+    func setWriteFailure(_ value: TeamVaultRemoteStubFailure?) {
+        writeFailure = value
     }
 
     func recordedWrites() -> [RecordedWrite] {

--- a/Tests/SelectiveRemoteTests/CloudVaultConflictReviewTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudVaultConflictReviewTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+@testable import SelectiveRemote
+
+@Suite("macOS Team Vault conflict review")
+struct CloudVaultConflictReviewTests {
+    @Test("review summaries expose bounded metadata but no credential or snippet contents")
+    func redactedSummaries() throws {
+        let scenario = try SelectiveRemoteVaultConflictReviewScenario.synthetic()
+        #expect(scenario.conflicts.count == 2)
+
+        let summaries = scenario.conflicts.flatMap { conflict in
+            [
+                SelectiveRemoteVaultConflictPresentation.side(conflict.local),
+                SelectiveRemoteVaultConflictPresentation.side(conflict.remote)
+            ]
+        }
+        let rendered = summaries.map { "\($0.title) \($0.metadata)" }.joined(separator: " ")
+        #expect(rendered.contains("Production SSH"))
+        #expect(rendered.contains("credential"))
+        #expect(rendered.contains("must-not-render") == false)
+        #expect(summaries.contains { $0.isDeletion })
+    }
+
+    @Test("manual review stays blocked until every synthetic conflict has one choice")
+    func completeChoiceSet() throws {
+        let scenario = try SelectiveRemoteVaultConflictReviewScenario.synthetic()
+        let first = try #require(scenario.conflicts.first)
+        #expect(throws: SelectiveRemoteVaultDocumentError.incompleteConflictResolutions) {
+            try scenario.resolve([.init(id: first.id, choice: .local)])
+        }
+
+        let choices = scenario.conflicts.map { conflict in
+            SelectiveRemoteVaultConflictResolution(
+                id: conflict.id,
+                choice: conflict.id == first.id ? .remote : .local
+            )
+        }
+        let resolved = try scenario.resolve(choices)
+        #expect(resolved.records.count == 2)
+        #expect(resolved.tombstones.isEmpty)
+        #expect(resolved.records.allSatisfy {
+            $0.version.counters[scenario.resolverDeviceID] == 1
+        })
+    }
+
+    @Test("choosing the remote deletion produces one joined tombstone")
+    func deletionChoice() throws {
+        let scenario = try SelectiveRemoteVaultConflictReviewScenario.synthetic()
+        let choices = scenario.conflicts.map { conflict in
+            SelectiveRemoteVaultConflictResolution(
+                id: conflict.id,
+                choice: SelectiveRemoteVaultConflictPresentation.side(conflict.remote).isDeletion
+                    ? .remote
+                    : .local
+            )
+        }
+        let resolved = try scenario.resolve(choices)
+        #expect(resolved.records.count == 1)
+        #expect(resolved.tombstones.count == 1)
+        #expect(resolved.tombstones[0].version.counters[scenario.resolverDeviceID] == 1)
+    }
+}

--- a/Tests/SelectiveRemoteTests/CloudVaultRecordModelTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudVaultRecordModelTests.swift
@@ -131,6 +131,25 @@ struct CloudVaultRecordModelTests {
                 resolvedAt: secondTime
             )
         }
+        #expect(throws: SelectiveRemoteVaultDocumentError.duplicateConflictResolution) {
+            try merge.document.resolving(
+                merge.conflicts,
+                with: [
+                    .init(id: recordB, choice: .local),
+                    .init(id: recordB, choice: .remote)
+                ],
+                deviceID: deviceC,
+                resolvedAt: secondTime
+            )
+        }
+        #expect(throws: SelectiveRemoteVaultDocumentError.unknownConflictResolution) {
+            try merge.document.resolving(
+                merge.conflicts,
+                with: [.init(id: recordC, choice: .local)],
+                deviceID: deviceC,
+                resolvedAt: secondTime
+            )
+        }
         let resolved = try merge.document.resolving(
             merge.conflicts,
             with: [.init(id: recordB, choice: .local)],

--- a/Tests/SelectiveRemoteTests/CloudVaultRecordModelTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudVaultRecordModelTests.swift
@@ -143,6 +143,37 @@ struct CloudVaultRecordModelTests {
         #expect(resolved.records[0].modifiedAt == secondTime)
     }
 
+    @Test("A concurrent edit and deletion remain a conflict and can resolve to a tombstone")
+    func editDeletionResolution() throws {
+        let edited = try record(
+            id: recordA,
+            version: [deviceA: 2],
+            value: "edited-offline",
+            modifiedAt: secondTime
+        )
+        let deleted = try SelectiveRemoteVaultTombstone(
+            id: recordA,
+            version: .init([deviceA: 1, deviceB: 1]),
+            deletedAt: secondTime
+        )
+        let merge = try SelectiveRemoteVaultDocument(records: [edited]).merged(
+            with: SelectiveRemoteVaultDocument(tombstones: [deleted])
+        )
+
+        #expect(merge.conflicts.count == 1)
+        #expect(merge.conflicts[0].local == .record(edited))
+        #expect(merge.conflicts[0].remote == .tombstone(deleted))
+        let resolved = try merge.document.resolving(
+            merge.conflicts,
+            with: [.init(id: recordA, choice: .remote)],
+            deviceID: deviceC,
+            resolvedAt: secondTime
+        )
+        #expect(resolved.records.isEmpty)
+        #expect(resolved.tombstones[0].version.counters == [deviceA: 2, deviceB: 1, deviceC: 1])
+        #expect(resolved.tombstones[0].deletedAt == secondTime)
+    }
+
     private func record(
         id: UUID,
         version: [UUID: Int],

--- a/Tests/SelectiveRemoteTests/CloudVaultRecordModelTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudVaultRecordModelTests.swift
@@ -1,0 +1,160 @@
+import Foundation
+import Testing
+@testable import SelectiveRemote
+
+@Suite("macOS Cloud Vault causal record model")
+struct CloudVaultRecordModelTests {
+    private let deviceA = UUID(uuidString: "11111111-1111-4111-8111-111111111111")!
+    private let deviceB = UUID(uuidString: "22222222-2222-4222-8222-222222222222")!
+    private let deviceC = UUID(uuidString: "33333333-3333-4333-8333-333333333333")!
+    private let recordA = UUID(uuidString: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")!
+    private let recordB = UUID(uuidString: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")!
+    private let recordC = UUID(uuidString: "cccccccc-cccc-4ccc-8ccc-cccccccccccc")!
+    private let firstTime = "2026-09-06T00:00:00.000Z"
+    private let secondTime = "2026-09-07T00:00:00.000Z"
+
+    @Test("Swift decodes and canonically re-encodes the browser Vault schema")
+    func browserSchemaRoundTrip() throws {
+        let source = Data(#"""
+        {
+          "schemaVersion": 1,
+          "records": [{
+            "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            "type": "credential",
+            "version": {"22222222-2222-4222-8222-222222222222": 1, "11111111-1111-4111-8111-111111111111": 2},
+            "modifiedAt": "2026-09-06T00:00:00.000Z",
+            "data": {"username": "operator", "secret": "synthetic", "metadata": [true, null, 3]}
+          }],
+          "tombstones": []
+        }
+        """#.utf8)
+
+        let document = try SelectiveRemoteVaultDocument.decode(source)
+        #expect(document.records.map(\.id) == [recordA])
+        #expect(document.records[0].version.counters == [deviceA: 2, deviceB: 1])
+        let encoded = String(decoding: try document.encoded(), as: UTF8.self)
+        #expect(encoded.hasPrefix(#"{"records":[{"data":{"metadata":[true,null,3]"#))
+        #expect(try SelectiveRemoteVaultDocument.decode(Data(encoded.utf8)) == document)
+    }
+
+    @Test("Vault validation rejects unknown structure and unsafe record data")
+    func strictValidation() {
+        let unknownField = Data(#"""
+        {
+          "schemaVersion": 1,
+          "records": [],
+          "tombstones": [],
+          "plaintext": "must fail"
+        }
+        """#.utf8)
+        #expect(throws: SelectiveRemoteVaultDocumentError.invalidVaultDocument) {
+            try SelectiveRemoteVaultDocument.decode(unknownField)
+        }
+
+        let forbiddenData = Data(#"""
+        {
+          "schemaVersion": 1,
+          "records": [{
+            "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            "type": "host",
+            "version": {"11111111-1111-4111-8111-111111111111": 1},
+            "modifiedAt": "2026-09-06T00:00:00.000Z",
+            "data": {"constructor": "must fail"}
+          }],
+          "tombstones": []
+        }
+        """#.utf8)
+        #expect(throws: SelectiveRemoteVaultDocumentError.invalidRecordData) {
+            try SelectiveRemoteVaultDocument.decode(forbiddenData)
+        }
+    }
+
+    @Test("Causal dominance merges automatically and concurrency remains explicit")
+    func causalMerge() throws {
+        let localDominant = try record(
+            id: recordA,
+            version: [deviceA: 2],
+            value: "local-newer",
+            modifiedAt: secondTime
+        )
+        let remoteOlder = try record(
+            id: recordA,
+            version: [deviceA: 1],
+            value: "remote-older",
+            modifiedAt: firstTime
+        )
+        let localConcurrent = try record(
+            id: recordB,
+            version: [deviceA: 1],
+            value: "local-choice",
+            modifiedAt: firstTime
+        )
+        let remoteConcurrent = try record(
+            id: recordB,
+            version: [deviceB: 1],
+            value: "remote-choice",
+            modifiedAt: secondTime
+        )
+        let remoteOnly = try SelectiveRemoteVaultTombstone(
+            id: recordC,
+            version: .init([deviceB: 1]),
+            deletedAt: secondTime
+        )
+
+        let local = try SelectiveRemoteVaultDocument(records: [localConcurrent, localDominant])
+        let remote = try SelectiveRemoteVaultDocument(
+            records: [remoteOlder, remoteConcurrent],
+            tombstones: [remoteOnly]
+        )
+        let merge = try local.merged(with: remote)
+
+        #expect(merge.document.records == [localDominant])
+        #expect(merge.document.tombstones == [remoteOnly])
+        #expect(merge.conflicts.map(\.id) == [recordB])
+        #expect(merge.conflicts[0].local == .record(localConcurrent))
+        #expect(merge.conflicts[0].remote == .record(remoteConcurrent))
+    }
+
+    @Test("A complete manual choice joins both histories and records the resolver event")
+    func completeResolution() throws {
+        let local = try record(id: recordB, version: [deviceA: 2], value: "local", modifiedAt: firstTime)
+        let remote = try record(id: recordB, version: [deviceB: 1], value: "remote", modifiedAt: secondTime)
+        let merge = try SelectiveRemoteVaultDocument(records: [local]).merged(
+            with: SelectiveRemoteVaultDocument(records: [remote])
+        )
+
+        #expect(throws: SelectiveRemoteVaultDocumentError.incompleteConflictResolutions) {
+            try merge.document.resolving(
+                merge.conflicts,
+                with: [],
+                deviceID: deviceC,
+                resolvedAt: secondTime
+            )
+        }
+        let resolved = try merge.document.resolving(
+            merge.conflicts,
+            with: [.init(id: recordB, choice: .local)],
+            deviceID: deviceC,
+            resolvedAt: secondTime
+        )
+        #expect(resolved.records.count == 1)
+        #expect(resolved.records[0].data == .object(["value": .string("local")]))
+        #expect(resolved.records[0].version.counters == [deviceA: 2, deviceB: 1, deviceC: 1])
+        #expect(resolved.records[0].modifiedAt == secondTime)
+    }
+
+    private func record(
+        id: UUID,
+        version: [UUID: Int],
+        value: String,
+        modifiedAt: String
+    ) throws -> SelectiveRemoteVaultRecord {
+        try .init(
+            id: id,
+            type: .host,
+            version: .init(version),
+            modifiedAt: modifiedAt,
+            data: .object(["value": .string(value)])
+        )
+    }
+}

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -33,9 +33,12 @@ produced exactly by Swift and decrypted by the browser tests. The bounded sync
 coordinator accepts clean remote revisions, stages encrypted offline edits with
 deterministic retry identity, rejects rollback or same-revision divergence,
 fails closed during rotation and preserves both decrypted versions plus the
-dirty ciphertext snapshot on a 409. Personal-Vault recovery wrapping, sync UI,
-explicit conflict-resolution writes and end-to-end service acceptance remain
-pending.
+dirty ciphertext snapshot on a 409. An explicit caller-provided resolution is
+accepted only while both the dirty local snapshot and observed remote version
+still match; it is re-encrypted from the observed remote revision and stays
+dirty until the exact conditional upload acknowledgement. Personal-Vault
+recovery wrapping, record-level conflict UI and end-to-end service acceptance
+remain pending.
 
 The browser portal can create and unlock a client-encrypted personal Vault,
 perform local CRUD, sign in with an existing verified account and manually

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -67,4 +67,8 @@ test("macOS Team Vault coordinator preserves causal dirty and conflict state", a
   assert.match(coordinator, /macos:team-vault:/);
   assert.match(coordinator, /try snapshots\.save\(staged, endpoint: endpoint\)/);
   assert.match(coordinator, /write\.revision == expectedServerRevision/);
+  assert.match(coordinator, /func resolveConflict\(/);
+  assert.match(coordinator, /latestRemote == conflict\.remote/);
+  assert.match(coordinator, /baseRevision: latestRemote\.revision/);
+  assert.match(coordinator, /return try await push\(teamID: teamID, vaultID: vaultID, identity: identity\)/);
 });

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -101,3 +101,26 @@ test("macOS exposes a complete-choice conflict review without rendering secrets"
   assert.match(settings, /Open Test Conflict/);
   assert.match(settings, /sends nothing to Cloud/);
 });
+
+test("macOS Cloud settings expose real device-bound sign-in and read-only Team inventory", async () => {
+  const [settings, accountViews, client, sessions] = await Promise.all([
+    readFile(new URL("CloudSettingsView.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudAccountViews.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudAPIClient.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudSessionStore.swift", sourceRoot), "utf8"),
+  ]);
+  assert.match(accountViews, /SecureField/);
+  assert.doesNotMatch(accountViews, /@AppStorage/);
+  assert.match(settings, /identityManager\.identity/);
+  assert.match(settings, /publicKey: identity\.publicKey/);
+  assert.match(settings, /restoreStoredSession/);
+  assert.match(settings, /client\.currentUser/);
+  assert.match(settings, /client\.teams/);
+  assert.match(settings, /client\.sharedVaults/);
+  assert.match(settings, /client\.logout/);
+  assert.match(accountViews, /Teams & Shared Vaults/);
+  assert.match(client, /validLoginJSON/);
+  assert.match(client, /validTeamsJSON/);
+  assert.match(sessions, /kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly/);
+  assert.doesNotMatch(sessions, /UserDefaults/);
+});

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -73,3 +73,16 @@ test("macOS Team Vault coordinator preserves causal dirty and conflict state", a
   assert.match(coordinator, /return try await push\(teamID: teamID, vaultID: vaultID, identity: identity\)/);
   assert.match(coordinator, /revalidated == current/);
 });
+
+test("macOS Team Vault record workflow mirrors the bounded browser causal model", async () => {
+  const model = await readFile(new URL("CloudVaultRecordModel.swift", sourceRoot), "utf8");
+  assert.match(model, /static let schemaVersion = 1/);
+  assert.match(model, /case host[\s\S]*case credential[\s\S]*case snippet[\s\S]*case forwarding/);
+  assert.match(model, /maximumBytes = 24 \* 1024 \* 1024/);
+  assert.match(model, /maximumEntities = 10_000/);
+  assert.match(model, /case left, right, equal, concurrent/);
+  assert.match(model, /incompleteConflictResolutions/);
+  assert.match(model, /func prepareRecordConflict\(/);
+  assert.match(model, /func resolveRecordConflicts\(/);
+  assert.match(model, /resolvedPayload: resolved\.encoded\(\)/);
+});

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -71,4 +71,5 @@ test("macOS Team Vault coordinator preserves causal dirty and conflict state", a
   assert.match(coordinator, /latestRemote == conflict\.remote/);
   assert.match(coordinator, /baseRevision: latestRemote\.revision/);
   assert.match(coordinator, /return try await push\(teamID: teamID, vaultID: vaultID, identity: identity\)/);
+  assert.match(coordinator, /revalidated == current/);
 });

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -86,3 +86,18 @@ test("macOS Team Vault record workflow mirrors the bounded browser causal model"
   assert.match(model, /func resolveRecordConflicts\(/);
   assert.match(model, /resolvedPayload: resolved\.encoded\(\)/);
 });
+
+test("macOS exposes a complete-choice conflict review without rendering secrets", async () => {
+  const [review, settings] = await Promise.all([
+    readFile(new URL("CloudVaultConflictReviewView.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudSettingsView.swift", sourceRoot), "utf8"),
+  ]);
+  assert.match(review, /Resolve and Sync/);
+  assert.match(review, /choices\.count == conflicts\.count/);
+  assert.match(review, /conflicts\.allSatisfy \{ choices\[\$0\.id\] != nil \}/);
+  assert.match(review, /values\["title"\]/);
+  assert.doesNotMatch(review, /values\["(?:secret|body|username)"\]/);
+  assert.match(review, /must-not-render/);
+  assert.match(settings, /Open Test Conflict/);
+  assert.match(settings, /sends nothing to Cloud/);
+});

--- a/docs/cloud-v0.32-team-threat-model.md
+++ b/docs/cloud-v0.32-team-threat-model.md
@@ -190,6 +190,10 @@ or wrappers.
   timestamps never choose a winner.
 - Conflict resolution joins both histories, creates a new local causal event
   and uploads conditionally. The server never sees the selected plaintext.
+- The macOS coordinator revalidates the exact dirty local snapshot and observed
+  remote version before preparing a caller-resolved payload. A changed remote
+  version returns a new conflict without writing; an unknown upload outcome
+  leaves the resolution dirty for deterministic-idempotency retry.
 - Role changes and rotation cannot be smuggled inside an encrypted record
   revision; they use separate authorized endpoints and durable transactions.
 


### PR DESCRIPTION
## Summary
- enable real macOS Cloud sign-in instead of the disabled placeholder
- generate/reuse the device-bound P-256 identity and register only its public key
- restore endpoint-scoped bearer sessions from this-device-only Keychain storage
- display the authenticated user plus read-only Team/shared-Vault inventory with refresh and sign-out
- reject extended or unbounded user/Team API responses before rendering them

## Stack
This PR is stacked on #55 (`feature/macos-team-vault-conflict-ui`). CI and Test DMG were enqueued for the exact head before restoring the stacked base.

## Security boundary
- the account password exists only in the in-memory SecureField and is never persisted
- session token and device private key remain in device-only Keychain entries
- the server receives the device public key, never its private key
- inventory renders names, roles, revision/generation and rotation status; it never fetches or renders Vault plaintext
- a 401 removes the stored session and returns the UI to signed-out state

## Validation
- `node --test cloud/tests/macos-cloud-source.test.mjs` — 7/7 passed
- `node --test cloud/tests/*.test.mjs` — 235 passed, 1 skipped (real PostgreSQL not configured), 0 failed
- `npm audit --omit=dev --offline` — 0 vulnerabilities
- `git diff --check`
- exact-head CI 34157312457 (#508) — success, including Swift 6/macOS, PostgreSQL 16, Cloud/browser tests and release build
- exact-head Test DMG 34157312518 (#198) — success
- artifact `SelectiveRemote-test-56-arm64`, id 10031561005, digest `sha256:2f83509ff65dde7b43834a3bcc39151cf27f87e41abd7a32f50db253a69484fd`

## Manual-test boundary
PR #55’s exact Test DMG passed Owner hands-on validation for both synthetic keep/delete outcomes. This PR prepares real account/session/inventory UI, but live Team inventory still requires a compatible deployed server and a controlled staging update. Public `main` and staging are unchanged.