### PR TITLE
feat: add macOS Cloud registration and verification UX

### DIFF
--- a/Sources/SelectiveRemote/CloudAPIClient.swift
+++ b/Sources/SelectiveRemote/CloudAPIClient.swift
@@ -37,10 +37,33 @@ enum SelectiveRemoteCloudError: LocalizedError, Equatable {
                 en: "Cloud returned an invalid response."
             )
         case let .serviceError(status, code):
-            UpdateLocalization.text(
-                ru: "Cloud недоступен (HTTP \(status)\(code.map { ": \($0)" } ?? "")).",
-                en: "Cloud is unavailable (HTTP \(status)\(code.map { ": \($0)" } ?? ""))."
-            )
+            switch code {
+            case "invalid_credentials":
+                UpdateLocalization.text(
+                    ru: "Неверная электронная почта или пароль.",
+                    en: "The email or password is incorrect."
+                )
+            case "email_not_verified":
+                UpdateLocalization.text(
+                    ru: "Сначала подтвердите электронную почту по ссылке из письма.",
+                    en: "Verify your email using the link in the message first."
+                )
+            case "registration_disabled":
+                UpdateLocalization.text(
+                    ru: "Регистрация новых аккаунтов отключена на этом сервере.",
+                    en: "New-account registration is disabled on this server."
+                )
+            case "smtp_not_configured":
+                UpdateLocalization.text(
+                    ru: "Сервер ещё не настроен для отправки письма подтверждения.",
+                    en: "The server is not configured to send verification email yet."
+                )
+            default:
+                UpdateLocalization.text(
+                    ru: "Cloud недоступен (HTTP \(status)\(code.map { ": \($0)" } ?? "")).",
+                    en: "Cloud is unavailable (HTTP \(status)\(code.map { ": \($0)" } ?? ""))."
+                )
+            }
         case let .incompatibleAPI(version):
             UpdateLocalization.text(
                 ru: "Версия Cloud API \(version) пока не поддерживается.",
@@ -308,6 +331,55 @@ actor SelectiveRemoteCloudAPIClient {
         else { throw SelectiveRemoteCloudError.invalidResponse }
         try tokenStore.saveToken(result.token, for: endpoint)
         return result.user
+    }
+
+    func register(
+        endpoint: URL,
+        displayName: String,
+        email: String,
+        password: String,
+        device: SelectiveRemoteCloudDeviceRegistration
+    ) async throws {
+        let normalizedDisplayName = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedDeviceName = device.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedDisplayName.isEmpty, normalizedDisplayName.count <= 120,
+              !normalizedEmail.isEmpty, normalizedEmail.count <= 254,
+              password.count >= 12, password.count <= 1_024,
+              !normalizedDeviceName.isEmpty, normalizedDeviceName.count <= 120,
+              !device.platform.isEmpty, device.platform.count <= 80,
+              device.appVersion.count <= 40
+        else { throw SelectiveRemoteCloudError.invalidRequest }
+
+        let body = RegistrationRequest(
+            email: normalizedEmail,
+            password: password,
+            displayName: normalizedDisplayName,
+            device: .init(
+                id: device.id,
+                name: normalizedDeviceName,
+                platform: device.platform,
+                appVersion: device.appVersion,
+                publicKey: device.publicKey
+            )
+        )
+        let request = JSONRequest(
+            url: endpoint.appending(path: "v1/auth/register"),
+            method: "POST",
+            body: try encoder.encode(body)
+        ).value
+        let (data, response) = try await dataLoader(request)
+        let http = try httpResponse(response)
+        guard http.statusCode == 201 else {
+            throw serviceError(status: http.statusCode, data: data)
+        }
+        guard Self.exactKeys(
+            try? JSONSerialization.jsonObject(with: data),
+            expected: ["verificationRequired"]
+        ),
+        let result = try? decoder.decode(RegistrationResponse.self, from: data),
+        result.verificationRequired
+        else { throw SelectiveRemoteCloudError.invalidResponse }
     }
 
     func currentUser(endpoint: URL) async throws -> SelectiveRemoteCloudUser {
@@ -697,6 +769,17 @@ private struct LoginRequest: Encodable {
     var email: String
     var password: String
     var device: SelectiveRemoteCloudDeviceRegistration
+}
+
+private struct RegistrationRequest: Encodable {
+    var email: String
+    var password: String
+    var displayName: String
+    var device: SelectiveRemoteCloudDeviceRegistration
+}
+
+private struct RegistrationResponse: Decodable {
+    var verificationRequired: Bool
 }
 
 private struct LoginResponse: Decodable {

--- a/Sources/SelectiveRemote/CloudAccountViews.swift
+++ b/Sources/SelectiveRemote/CloudAccountViews.swift
@@ -2,9 +2,11 @@ import SwiftUI
 
 struct SelectiveRemoteCloudSignInView: View {
     let endpoint: URL
+    let registrationEnabled: Bool?
     let isSigningIn: Bool
     let errorMessage: String?
     let onCancel: () -> Void
+    let onCreateAccount: () -> Void
     let onSignIn: (String, String) -> Void
 
     @State private var email = ""
@@ -41,6 +43,37 @@ struct SelectiveRemoteCloudSignInView: View {
                     .foregroundStyle(.secondary)
                 }
 
+                Section {
+                    if registrationEnabled == true {
+                        Button(
+                            UpdateLocalization.text(ru: "Создать новый аккаунт…", en: "Create New Account…"),
+                            systemImage: "person.crop.circle.badge.plus",
+                            action: onCreateAccount
+                        )
+                        .disabled(isSigningIn)
+                    } else if registrationEnabled == false {
+                        Label(
+                            UpdateLocalization.text(
+                                ru: "Регистрация на этом сервере пока отключена. Для входа нужен уже созданный и подтверждённый аккаунт.",
+                                en: "Registration is currently disabled on this server. Sign-in requires an existing verified account."
+                            ),
+                            systemImage: "person.crop.circle.badge.exclamationmark"
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    } else {
+                        Label(
+                            UpdateLocalization.text(
+                                ru: "Сначала проверьте соединение, чтобы узнать, разрешена ли регистрация.",
+                                en: "Check the connection first to learn whether registration is available."
+                            ),
+                            systemImage: "network"
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
+                }
+
                 if let errorMessage {
                     Section {
                         Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
@@ -74,6 +107,136 @@ struct SelectiveRemoteCloudSignInView: View {
     private func submit() {
         guard canSubmit, !isSigningIn else { return }
         onSignIn(email, password)
+    }
+}
+
+struct SelectiveRemoteCloudRegistrationView: View {
+    let endpoint: URL
+    let isRegistering: Bool
+    let errorMessage: String?
+    let onBack: () -> Void
+    let onCancel: () -> Void
+    let onRegister: (String, String, String) -> Void
+
+    @State private var displayName = ""
+    @State private var email = ""
+    @State private var password = ""
+    @State private var confirmation = ""
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField(UpdateLocalization.text(ru: "Имя", en: "Display Name"), text: $displayName)
+                        .textContentType(.name)
+                        .disabled(isRegistering)
+                    TextField(UpdateLocalization.text(ru: "Электронная почта", en: "Email"), text: $email)
+                        .textContentType(.emailAddress)
+                        .disabled(isRegistering)
+                    SecureField(UpdateLocalization.text(ru: "Новый пароль", en: "New Password"), text: $password)
+                        .textContentType(.newPassword)
+                        .disabled(isRegistering)
+                    SecureField(UpdateLocalization.text(ru: "Повторите пароль", en: "Confirm Password"), text: $confirmation)
+                        .textContentType(.newPassword)
+                        .disabled(isRegistering)
+                        .onSubmit(submit)
+                }
+
+                Section {
+                    LabeledContent(UpdateLocalization.text(ru: "Сервер", en: "Server")) {
+                        Text(endpoint.host ?? endpoint.absoluteString)
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                    }
+                    Label(
+                        UpdateLocalization.text(
+                            ru: "Используйте свою доступную почту и придумайте новый пароль минимум из 12 символов. После регистрации откройте письмо и подтвердите адрес.",
+                            en: "Use an email address you can access and create a new password of at least 12 characters. Then open the message and verify the address."
+                        ),
+                        systemImage: "envelope.badge.shield.half.filled"
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+
+                if !confirmation.isEmpty, password != confirmation {
+                    Section {
+                        Label(
+                            UpdateLocalization.text(ru: "Пароли не совпадают.", en: "Passwords do not match."),
+                            systemImage: "exclamationmark.triangle.fill"
+                        )
+                        .foregroundStyle(.orange)
+                    }
+                }
+
+                if let errorMessage {
+                    Section {
+                        Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+            .formStyle(.grouped)
+            .navigationTitle(UpdateLocalization.text(ru: "Регистрация в Cloud", en: "Create Cloud Account"))
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(UpdateLocalization.text(ru: "Назад", en: "Back"), action: onBack)
+                        .disabled(isRegistering)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(UpdateLocalization.text(ru: "Зарегистрироваться", en: "Register"), action: submit)
+                        .buttonStyle(.borderedProminent)
+                        .disabled(!canSubmit || isRegistering)
+                }
+                ToolbarItem(placement: .automatic) {
+                    Button(UpdateLocalization.text(ru: "Отмена", en: "Cancel"), action: onCancel)
+                        .disabled(isRegistering)
+                }
+            }
+        }
+        .frame(width: 540, height: 520)
+    }
+
+    private var canSubmit: Bool {
+        let name = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let mail = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !name.isEmpty && name.count <= 120
+            && !mail.isEmpty && mail.count <= 254
+            && (12...1_024).contains(password.count)
+            && password == confirmation
+    }
+
+    private func submit() {
+        guard canSubmit, !isRegistering else { return }
+        onRegister(displayName, email, password)
+    }
+}
+
+struct SelectiveRemoteCloudRegistrationConfirmationView: View {
+    let email: String
+    let onDone: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            ContentUnavailableView {
+                Label(
+                    UpdateLocalization.text(ru: "Подтвердите почту", en: "Verify Your Email"),
+                    systemImage: "envelope.badge"
+                )
+            } description: {
+                Text(UpdateLocalization.text(
+                    ru: "Мы отправили одноразовую ссылку на \(email). Откройте её, затем вернитесь в приложение и войдите с созданным паролем.",
+                    en: "We sent a one-time link to \(email). Open it, then return to the app and sign in with the password you created."
+                ))
+            } actions: {
+                Button(UpdateLocalization.text(ru: "Готово", en: "Done"), action: onDone)
+                    .buttonStyle(.borderedProminent)
+            }
+            .padding(36)
+            .navigationTitle(UpdateLocalization.text(ru: "Аккаунт создан", en: "Account Created"))
+        }
+        .frame(width: 540, height: 360)
     }
 }
 

--- a/Sources/SelectiveRemote/CloudSettingsView.swift
+++ b/Sources/SelectiveRemote/CloudSettingsView.swift
@@ -14,9 +14,12 @@ struct CloudSettingsView: View {
     @State private var teams: [SelectiveRemoteCloudTeam] = []
     @State private var vaultsByTeam: [UUID: [SelectiveRemoteCloudSharedVault]] = [:]
     @State private var accountErrorMessage: String?
+    @State private var registrationErrorMessage: String?
+    @State private var registeredEmail: String?
     @State private var inventoryErrorMessage: String?
     @State private var accountEndpoint: String?
-    @State private var showsSignIn = false
+    @State private var showsAccountSheet = false
+    @State private var accountSheetMode = AccountSheetMode.signIn
     @State private var showsConflictReview = false
     @State private var conflictReviewMessage: String?
 
@@ -108,10 +111,36 @@ struct CloudSettingsView: View {
                         systemImage: "person.crop.circle.badge.checkmark"
                     ) {
                         accountErrorMessage = nil
-                        showsSignIn = true
+                        registrationErrorMessage = nil
+                        registeredEmail = nil
+                        accountSheetMode = .signIn
+                        showsAccountSheet = true
                     }
                     .buttonStyle(.borderedProminent)
                     .disabled(accountPhase.isBusy)
+
+                    if metadata?.registrationEnabled == true {
+                        Button(
+                            UpdateLocalization.text(ru: "Создать аккаунт…", en: "Create Account…"),
+                            systemImage: "person.crop.circle.badge.plus"
+                        ) {
+                            registrationErrorMessage = nil
+                            registeredEmail = nil
+                            accountSheetMode = .registration
+                            showsAccountSheet = true
+                        }
+                        .disabled(accountPhase.isBusy)
+                    } else if metadata?.registrationEnabled == false {
+                        Label(
+                            UpdateLocalization.text(
+                                ru: "Регистрация новых аккаунтов на этом сервере отключена. Войти можно только с уже созданным и подтверждённым аккаунтом.",
+                                en: "New-account registration is disabled on this server. You can only sign in with an existing verified account."
+                            ),
+                            systemImage: "person.crop.circle.badge.exclamationmark"
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
                 }
 
                 if let accountErrorMessage {
@@ -186,10 +215,10 @@ struct CloudSettingsView: View {
         }
         .formStyle(.grouped)
         .task {
-            await restoreStoredSessionIfNeeded()
+            await loadCloudStateIfNeeded()
         }
-        .sheet(isPresented: $showsSignIn) {
-            signInSheet
+        .sheet(isPresented: $showsAccountSheet) {
+            accountSheet
         }
         .sheet(isPresented: $showsConflictReview) {
             conflictReviewSheet
@@ -212,6 +241,12 @@ struct CloudSettingsView: View {
             HStack(spacing: 7) {
                 ProgressView().controlSize(.small)
                 Text(UpdateLocalization.text(ru: "Вход…", en: "Signing in…"))
+            }
+            .foregroundStyle(.secondary)
+        case .registering:
+            HStack(spacing: 7) {
+                ProgressView().controlSize(.small)
+                Text(UpdateLocalization.text(ru: "Создание аккаунта…", en: "Creating account…"))
             }
             .foregroundStyle(.secondary)
         case .signedIn:
@@ -249,39 +284,82 @@ struct CloudSettingsView: View {
     }
 
     private func checkConnection() {
+        Task { @MainActor in
+            await loadCloudState(force: true)
+        }
+    }
+
+    @MainActor
+    private func loadCloudStateIfNeeded() async {
+        guard phase == .idle else { return }
+        await loadCloudState(force: false)
+    }
+
+    @MainActor
+    private func loadCloudState(force: Bool) async {
         phase = .checking
         metadata = nil
         errorMessage = nil
-        Task { @MainActor in
-            do {
-                let url = try SelectiveRemoteCloudEndpoint.normalized(endpoint)
-                endpoint = url.absoluteString
-                metadata = try await client.metadata(endpoint: url)
-                phase = .available
-                await restoreStoredSession(at: url, force: true)
-            } catch {
-                errorMessage = error.localizedDescription
-                phase = .failed
-            }
+        do {
+            let url = try SelectiveRemoteCloudEndpoint.normalized(endpoint)
+            endpoint = url.absoluteString
+            metadata = try await client.metadata(endpoint: url)
+            phase = .available
+            await restoreStoredSession(at: url, force: force)
+        } catch {
+            errorMessage = error.localizedDescription
+            phase = .failed
         }
     }
 
     @ViewBuilder
-    private var signInSheet: some View {
+    private var accountSheet: some View {
         if let url = try? SelectiveRemoteCloudEndpoint.normalized(endpoint) {
-            SelectiveRemoteCloudSignInView(
-                endpoint: url,
-                isSigningIn: accountPhase == .signingIn,
-                errorMessage: accountErrorMessage,
-                onCancel: {
-                    guard accountPhase != .signingIn else { return }
-                    showsSignIn = false
-                    accountErrorMessage = nil
-                },
-                onSignIn: { email, password in
-                    signIn(email: email, password: password, endpoint: url)
+            switch accountSheetMode {
+            case .signIn:
+                SelectiveRemoteCloudSignInView(
+                    endpoint: url,
+                    registrationEnabled: metadata?.registrationEnabled,
+                    isSigningIn: accountPhase == .signingIn,
+                    errorMessage: accountErrorMessage,
+                    onCancel: closeAccountSheet,
+                    onCreateAccount: {
+                        registrationErrorMessage = nil
+                        registeredEmail = nil
+                        accountSheetMode = .registration
+                    },
+                    onSignIn: { email, password in
+                        signIn(email: email, password: password, endpoint: url)
+                    }
+                )
+            case .registration:
+                if let registeredEmail {
+                    SelectiveRemoteCloudRegistrationConfirmationView(
+                        email: registeredEmail,
+                        onDone: closeAccountSheet
+                    )
+                } else {
+                    SelectiveRemoteCloudRegistrationView(
+                        endpoint: url,
+                        isRegistering: accountPhase == .registering,
+                        errorMessage: registrationErrorMessage,
+                        onBack: {
+                            guard accountPhase != .registering else { return }
+                            registrationErrorMessage = nil
+                            accountSheetMode = .signIn
+                        },
+                        onCancel: closeAccountSheet,
+                        onRegister: { displayName, email, password in
+                            register(
+                                displayName: displayName,
+                                email: email,
+                                password: password,
+                                endpoint: url
+                            )
+                        }
+                    )
                 }
-            )
+            }
         } else {
             ContentUnavailableView(
                 UpdateLocalization.text(ru: "Некорректный адрес Cloud", en: "Invalid Cloud Address"),
@@ -291,9 +369,12 @@ struct CloudSettingsView: View {
         }
     }
 
-    private func restoreStoredSessionIfNeeded() async {
-        guard let url = try? SelectiveRemoteCloudEndpoint.normalized(endpoint) else { return }
-        await restoreStoredSession(at: url, force: false)
+    private func closeAccountSheet() {
+        guard !accountPhase.isBusy else { return }
+        showsAccountSheet = false
+        accountErrorMessage = nil
+        registrationErrorMessage = nil
+        registeredEmail = nil
     }
 
     @MainActor
@@ -328,11 +409,41 @@ struct CloudSettingsView: View {
                 )
                 accountEndpoint = url.absoluteString
                 accountPhase = .signedIn
-                showsSignIn = false
+                showsAccountSheet = false
                 await loadInventory(endpoint: url)
             } catch {
                 accountPhase = .signedOut
                 accountErrorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func register(displayName: String, email: String, password: String, endpoint url: URL) {
+        guard metadata?.registrationEnabled == true else {
+            registrationErrorMessage = UpdateLocalization.text(
+                ru: "Регистрация новых аккаунтов отключена на этом сервере.",
+                en: "New-account registration is disabled on this server."
+            )
+            return
+        }
+        accountPhase = .registering
+        registrationErrorMessage = nil
+        Task { @MainActor in
+            do {
+                let deviceID = resolvedDeviceID()
+                let identity = try await identityManager.identity(endpoint: url, deviceID: deviceID)
+                try await client.register(
+                    endpoint: url,
+                    displayName: displayName,
+                    email: email,
+                    password: password,
+                    device: .thisMac(id: deviceID, publicKey: identity.publicKey)
+                )
+                registeredEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
+                accountPhase = .signedOut
+            } catch {
+                accountPhase = .signedOut
+                registrationErrorMessage = error.localizedDescription
             }
         }
     }
@@ -455,17 +566,23 @@ struct CloudSettingsView: View {
         case failed
     }
 
+    private enum AccountSheetMode {
+        case signIn
+        case registration
+    }
+
     private enum AccountPhase: Equatable {
         case signedOut
         case restoring
         case signingIn
+        case registering
         case signedIn
         case refreshing
         case signingOut
 
         var isBusy: Bool {
             switch self {
-            case .restoring, .signingIn, .refreshing, .signingOut: true
+            case .restoring, .signingIn, .registering, .refreshing, .signingOut: true
             case .signedOut, .signedIn: false
             }
         }

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -72,6 +72,76 @@ struct CloudMacOSFoundationTests {
         #expect(try store.token(for: endpoint) == nil)
     }
 
+    @Test("registration sends the device public identity and requires exact verification response")
+    func registrationFoundation() async throws {
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized("https://cloud.example.invalid")
+        let deviceID = try #require(UUID(uuidString: "44444444-4444-4444-8444-444444444444"))
+        let store = SelectiveRemoteCloudMemoryTokenStore()
+        let stub = CloudHTTPStub { request in
+            #expect(request.httpMethod == "POST")
+            #expect(request.url?.path == "/v1/auth/register")
+            let body = try #require(request.httpBody)
+            let object = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            #expect(Set(object.keys) == ["email", "password", "displayName", "device"])
+            #expect(object["email"] as? String == "user@example.invalid")
+            #expect(object["password"] as? String == "synthetic-password")
+            #expect(object["displayName"] as? String == "User")
+            let device = try #require(object["device"] as? [String: Any])
+            #expect(device["id"] as? String == deviceID.canonicalCloudString)
+            #expect(device["name"] as? String == "Synthetic Mac")
+            #expect(device["platform"] as? String == "macos")
+            return Self.response(request, status: 201, json: ["verificationRequired": true])
+        }
+        let client = SelectiveRemoteCloudAPIClient(
+            tokenStore: store,
+            dataLoader: { request in try stub.data(for: request) }
+        )
+
+        try await client.register(
+            endpoint: endpoint,
+            displayName: " User ",
+            email: " user@example.invalid ",
+            password: "synthetic-password",
+            device: .thisMac(id: deviceID, name: "Synthetic Mac")
+        )
+        #expect(try store.token(for: endpoint) == nil)
+    }
+
+    @Test("registration rejects an extended or false verification response")
+    func registrationRejectsInvalidResponses() async throws {
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized("https://cloud.example.invalid")
+        let deviceID = try #require(UUID(uuidString: "44444444-4444-4444-8444-444444444444"))
+        let invalidResponses: [[String: Any]] = [
+            ["verificationRequired": false],
+            ["verificationRequired": true, "unexpected": true]
+        ]
+        for json in invalidResponses {
+            let payload = try JSONSerialization.data(withJSONObject: json)
+            let client = SelectiveRemoteCloudAPIClient(
+                tokenStore: SelectiveRemoteCloudMemoryTokenStore(),
+                dataLoader: { request in
+                    let url = try #require(request.url)
+                    let response = try #require(HTTPURLResponse(
+                        url: url,
+                        statusCode: 201,
+                        httpVersion: nil,
+                        headerFields: ["Content-Type": "application/json"]
+                    ))
+                    return (payload, response)
+                }
+            )
+            await #expect(throws: SelectiveRemoteCloudError.invalidResponse) {
+                try await client.register(
+                    endpoint: endpoint,
+                    displayName: "User",
+                    email: "user@example.invalid",
+                    password: "synthetic-password",
+                    device: .thisMac(id: deviceID, name: "Synthetic Mac")
+                )
+            }
+        }
+    }
+
     @Test("macOS account inventory rejects extended user and Team responses")
     func accountInventoryRejectsExtendedResponses() async throws {
         let endpoint = try SelectiveRemoteCloudEndpoint.normalized("https://cloud.example.invalid")

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -111,6 +111,10 @@ test("macOS Cloud settings expose real device-bound sign-in and read-only Team i
   ]);
   assert.match(accountViews, /SecureField/);
   assert.doesNotMatch(accountViews, /@AppStorage/);
+  assert.match(accountViews, /Create New Account/);
+  assert.match(accountViews, /Registration is currently disabled on this server/);
+  assert.match(accountViews, /Confirm Password/);
+  assert.match(accountViews, /Verify Your Email/);
   assert.match(settings, /identityManager\.identity/);
   assert.match(settings, /publicKey: identity\.publicKey/);
   assert.match(settings, /restoreStoredSession/);
@@ -118,7 +122,11 @@ test("macOS Cloud settings expose real device-bound sign-in and read-only Team i
   assert.match(settings, /client\.teams/);
   assert.match(settings, /client\.sharedVaults/);
   assert.match(settings, /client\.logout/);
+  assert.match(settings, /client\.register/);
+  assert.match(settings, /metadata\?\.registrationEnabled == true/);
   assert.match(accountViews, /Teams & Shared Vaults/);
+  assert.match(client, /v1\/auth\/register/);
+  assert.match(client, /verificationRequired/);
   assert.match(client, /validLoginJSON/);
   assert.match(client, /validTeamsJSON/);
   assert.match(sessions, /kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly/);


### PR DESCRIPTION
## Summary
- automatically fetch Cloud metadata when the settings page opens
- show an explicit explanation when the selected server has registration disabled
- expose a real macOS registration form when `registrationEnabled` is true
- collect display name, reachable email, new password, and password confirmation
- register the same device-bound P-256 public identity used for sign-in
- keep the password only in transient `SecureField` state and issue no session before email verification
- show a dedicated confirmation screen instructing the user to open the one-time email link
- map common authentication and registration server errors to actionable localized messages

## Validation
- `node --test cloud/tests/macos-cloud-source.test.mjs` — 7/7 passed
- `npm test --prefix cloud` — 235 passed, 1 skipped (real PostgreSQL not configured), 0 failed
- `git diff --check`
- exact local tree `e258474ce5423aeea3b498d5adcb249020b9aa39`

## Live-test boundary
This removes the dead-end UI, but a real registration/login test still requires a compatible staging deployment with complete SMTP configuration and registration explicitly enabled. No staging or production configuration is changed by this PR.