### PR TITLE
Cloud: redesign sign-in and add browser registration UX

### DIFF
--- a/Sources/SelectiveRemote/CloudAccountViews.swift
+++ b/Sources/SelectiveRemote/CloudAccountViews.swift
@@ -11,79 +11,122 @@ struct SelectiveRemoteCloudSignInView: View {
 
     @State private var email = ""
     @State private var password = ""
+    @State private var revealsPassword = false
 
     var body: some View {
         NavigationStack {
-            Form {
-                Section {
-                    TextField(UpdateLocalization.text(ru: "Электронная почта", en: "Email"), text: $email)
-                        .textContentType(.username)
-                        .disabled(isSigningIn)
-                    SecureField(UpdateLocalization.text(ru: "Пароль", en: "Password"), text: $password)
-                        .textContentType(.password)
-                        .disabled(isSigningIn)
-                        .onSubmit(submit)
-                }
-
-                Section {
-                    LabeledContent(UpdateLocalization.text(ru: "Сервер", en: "Server")) {
-                        Text(endpoint.host ?? endpoint.absoluteString)
-                            .foregroundStyle(.secondary)
-                            .textSelection(.enabled)
-                    }
-
-                    Label(
-                        UpdateLocalization.text(
-                            ru: "Сессия хранится в Keychain только на этом Mac. Пароль существует только в этой форме и не становится ключом Vault.",
-                            en: "The session is stored in Keychain on this Mac only. The password exists only in this form and never becomes a Vault key."
-                        ),
-                        systemImage: "lock.shield"
-                    )
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                }
-
-                Section {
-                    if registrationEnabled == true {
-                        Button(
-                            UpdateLocalization.text(ru: "Создать новый аккаунт…", en: "Create New Account…"),
-                            systemImage: "person.crop.circle.badge.plus",
-                            action: onCreateAccount
-                        )
-                        .disabled(isSigningIn)
-                    } else if registrationEnabled == false {
-                        Label(
-                            UpdateLocalization.text(
-                                ru: "Регистрация на этом сервере пока отключена. Для входа нужен уже созданный и подтверждённый аккаунт.",
-                                en: "Registration is currently disabled on this server. Sign-in requires an existing verified account."
-                            ),
-                            systemImage: "person.crop.circle.badge.exclamationmark"
-                        )
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    } else {
-                        Label(
-                            UpdateLocalization.text(
-                                ru: "Сначала проверьте соединение, чтобы узнать, разрешена ли регистрация.",
-                                en: "Check the connection first to learn whether registration is available."
-                            ),
-                            systemImage: "network"
-                        )
-                        .font(.caption)
+            VStack(spacing: 0) {
+                HStack(spacing: 14) {
+                    Image(systemName: "cloud.fill")
+                        .font(.title2.weight(.semibold))
+                        .foregroundStyle(.white)
+                        .frame(width: 48, height: 48)
+                        .background(.blue.gradient, in: RoundedRectangle(cornerRadius: 14))
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(UpdateLocalization.text(ru: "Selective Remote Cloud", en: "Selective Remote Cloud"))
+                            .font(.title3.weight(.semibold))
+                        Text(UpdateLocalization.text(
+                            ru: "Войдите для защищённой синхронизации между устройствами",
+                            en: "Sign in for protected synchronization across devices"
+                        ))
+                        .font(.callout)
                         .foregroundStyle(.secondary)
                     }
+                    Spacer()
                 }
+                .padding(22)
 
-                if let errorMessage {
+                Divider()
+
+                Form {
                     Section {
-                        Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
-                            .foregroundStyle(.orange)
-                            .fixedSize(horizontal: false, vertical: true)
+                        TextField(UpdateLocalization.text(ru: "Электронная почта", en: "Email"), text: $email)
+                            .textContentType(.username)
+                            .disabled(isSigningIn)
+                        HStack {
+                            Group {
+                                if revealsPassword {
+                                    TextField(UpdateLocalization.text(ru: "Пароль Selective Remote", en: "Selective Remote Password"), text: $password)
+                                } else {
+                                    SecureField(UpdateLocalization.text(ru: "Пароль Selective Remote", en: "Selective Remote Password"), text: $password)
+                                }
+                            }
+                            .textContentType(.password)
+                            .disabled(isSigningIn)
+                            .onSubmit(submit)
+                            Button {
+                                revealsPassword.toggle()
+                            } label: {
+                                Image(systemName: revealsPassword ? "eye.slash" : "eye")
+                            }
+                            .buttonStyle(.plain)
+                            .foregroundStyle(.secondary)
+                            .accessibilityLabel(UpdateLocalization.text(ru: "Показать или скрыть пароль", en: "Show or hide password"))
+                        }
+                    }
+
+                    Section {
+                        LabeledContent(UpdateLocalization.text(ru: "Сервер", en: "Server")) {
+                            Text(endpoint.host ?? endpoint.absoluteString)
+                                .foregroundStyle(.secondary)
+                                .textSelection(.enabled)
+                        }
+
+                        Label(
+                            UpdateLocalization.text(
+                                ru: "Сессия хранится в Keychain только на этом Mac. Пароль существует только в этой форме и не становится ключом Vault.",
+                                en: "The session is stored in Keychain on this Mac only. The password exists only in this form and never becomes a Vault key."
+                            ),
+                            systemImage: "lock.shield"
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
+
+                    Section {
+                        if registrationEnabled == true {
+                            Button(
+                                UpdateLocalization.text(ru: "Создать новый аккаунт…", en: "Create New Account…"),
+                                systemImage: "person.crop.circle.badge.plus",
+                                action: onCreateAccount
+                            )
+                            .buttonStyle(.bordered)
+                            .controlSize(.large)
+                            .disabled(isSigningIn)
+                        } else if registrationEnabled == false {
+                            Label(
+                                UpdateLocalization.text(
+                                    ru: "Регистрация на этом сервере пока отключена. Для входа нужен уже созданный и подтверждённый аккаунт.",
+                                    en: "Registration is currently disabled on this server. Sign-in requires an existing verified account."
+                                ),
+                                systemImage: "person.crop.circle.badge.exclamationmark"
+                            )
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        } else {
+                            Label(
+                                UpdateLocalization.text(
+                                    ru: "Сначала проверьте соединение, чтобы узнать, разрешена ли регистрация.",
+                                    en: "Check the connection first to learn whether registration is available."
+                                ),
+                                systemImage: "network"
+                            )
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    if let errorMessage {
+                        Section {
+                            Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                                .foregroundStyle(.orange)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
                     }
                 }
+                .formStyle(.grouped)
             }
-            .formStyle(.grouped)
-            .navigationTitle(UpdateLocalization.text(ru: "Вход в Cloud", en: "Cloud Sign In"))
+            .navigationTitle(UpdateLocalization.text(ru: "Вход", en: "Sign In"))
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button(UpdateLocalization.text(ru: "Отмена", en: "Cancel"), action: onCancel)
@@ -96,7 +139,7 @@ struct SelectiveRemoteCloudSignInView: View {
                 }
             }
         }
-        .frame(width: 500, height: 390)
+        .frame(width: 540, height: 470)
     }
 
     private var canSubmit: Bool {

--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -1041,11 +1041,22 @@ export async function initializeCloudAccount({
   documentValue = document,
   vaultUI,
   fetchValue = fetch,
+  metadata = null,
 } = {}) {
   const vault = vaultUI?.controller;
   const section = documentValue.querySelector("#cloud-account");
   if (!section || !vault) return null;
   const form = documentValue.querySelector("#cloud-login-form");
+  const registrationForm = documentValue.querySelector("#cloud-registration-form");
+  const recoveryFormAccount = documentValue.querySelector("#cloud-recovery-form");
+  const loginTab = documentValue.querySelector("#cloud-login-tab");
+  const registrationTab = documentValue.querySelector("#cloud-register-tab");
+  const tabs = documentValue.querySelector(".auth-tabs");
+  const registrationSuccess = documentValue.querySelector("#cloud-registration-success");
+  const registrationSuccessMessage = documentValue.querySelector("#cloud-registration-success-message");
+  const registrationDone = documentValue.querySelector("#cloud-registration-done");
+  const showRecovery = documentValue.querySelector("#cloud-show-recovery");
+  const hideRecovery = documentValue.querySelector("#cloud-hide-recovery");
   const signedIn = documentValue.querySelector("#cloud-signed-in");
   const accountName = documentValue.querySelector("#cloud-account-name");
   const message = documentValue.querySelector("#cloud-account-message");
@@ -1066,6 +1077,34 @@ export async function initializeCloudAccount({
     activeConflicts = null;
     conflictApply.disabled = true;
   });
+
+  function setAccountMessage(value, tone = null) {
+    setText(message, value);
+    message.classList.toggle("error", tone === "error");
+    message.classList.toggle("success", tone === "success");
+  }
+
+  function setAuthMode(mode) {
+    const registrationAvailable = metadata?.registrationEnabled === true;
+    form.hidden = mode !== "login";
+    registrationForm.hidden = mode !== "registration";
+    recoveryFormAccount.hidden = mode !== "recovery";
+    registrationSuccess.hidden = true;
+    loginTab.setAttribute("aria-selected", String(mode === "login"));
+    registrationTab.setAttribute("aria-selected", String(mode === "registration"));
+    for (const control of registrationForm.querySelectorAll("input, button")) {
+      control.disabled = mode === "registration" && !registrationAvailable;
+    }
+    if (mode === "registration") {
+      setAccountMessage(registrationAvailable
+        ? "Создайте пароль Selective Remote — на почту придёт только одноразовая ссылка подтверждения."
+        : "Регистрация временно закрыта. Уже подтверждённые аккаунты могут войти.", registrationAvailable ? null : "error");
+    } else if (mode === "recovery") {
+      setAccountMessage("Мы отправим одноразовую ссылку для смены пароля, если аккаунт существует.");
+    } else {
+      setAccountMessage("Сессионный токен хранится только в памяти этой вкладки.");
+    }
+  }
 
   function hideConflicts() {
     activeConflicts = null;
@@ -1110,11 +1149,81 @@ export async function initializeCloudAccount({
   }
 
   function showSession(user) {
+    tabs.hidden = Boolean(user);
     form.hidden = Boolean(user);
+    registrationForm.hidden = true;
+    recoveryFormAccount.hidden = true;
+    registrationSuccess.hidden = true;
     signedIn.hidden = !user;
     syncButton.disabled = !user;
     setText(accountName, user ? `${user.displayName || user.email} · ${user.email}` : "");
   }
+
+  loginTab.addEventListener("click", () => setAuthMode("login"));
+  registrationTab.addEventListener("click", () => setAuthMode("registration"));
+  showRecovery.addEventListener("click", () => setAuthMode("recovery"));
+  hideRecovery.addEventListener("click", () => setAuthMode("login"));
+  registrationDone.addEventListener("click", () => setAuthMode("login"));
+
+  registrationForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    if (metadata?.registrationEnabled !== true) {
+      setAccountMessage("Регистрация временно закрыта. Обновите страницу после открытия регистрационного окна.", "error");
+      return;
+    }
+    const button = registrationForm.querySelector('button[type="submit"]');
+    const password = registrationForm.elements.password.value;
+    if (password !== registrationForm.elements.confirmation.value) {
+      setAccountMessage("Пароли не совпадают.", "error");
+      return;
+    }
+    button.disabled = true;
+    try {
+      const deviceID = await vault.deviceID();
+      let identity = null;
+      try { identity = await ensureTeamDeviceIdentity({ repository: teamDeviceRepository, deviceID }); } catch {}
+      await client.register({
+        displayName: registrationForm.elements.displayName.value,
+        email: registrationForm.elements.email.value,
+        password,
+        deviceID,
+        publicKey: identity?.publicKey ?? null,
+      });
+      const email = registrationForm.elements.email.value.trim();
+      registrationForm.reset();
+      registrationForm.hidden = true;
+      registrationSuccess.hidden = false;
+      setText(registrationSuccessMessage, `Одноразовая ссылка отправлена на ${email}. Подтвердите адрес, затем войдите с созданным паролем.`);
+      setAccountMessage("Аккаунт создан. Пароль не отправлялся по почте и не был сохранён в браузере.", "success");
+    } catch (error) {
+      const code = String(error?.message ?? "");
+      const messages = {
+        registration_disabled: "Регистрационное окно уже закрыто. Обновите страницу позже.",
+        rate_limited: "Слишком много попыток. Повторите позже.",
+        smtp_not_configured: "Почтовый сервис временно не настроен.",
+      };
+      setAccountMessage(messages[code] ?? "Не удалось создать аккаунт. Проверьте поля и повторите попытку.", "error");
+    } finally {
+      registrationForm.elements.password.value = "";
+      registrationForm.elements.confirmation.value = "";
+      button.disabled = false;
+    }
+  });
+
+  recoveryFormAccount.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const button = recoveryFormAccount.querySelector('button[type="submit"]');
+    button.disabled = true;
+    try {
+      await client.requestPasswordReset(recoveryFormAccount.elements.email.value);
+      recoveryFormAccount.reset();
+      setAccountMessage("Если аккаунт существует, ссылка для смены пароля уже отправлена.", "success");
+    } catch {
+      setAccountMessage("Не удалось запросить восстановление. Повторите позже.", "error");
+    } finally {
+      button.disabled = false;
+    }
+  });
 
   form.addEventListener("submit", async (event) => {
     event.preventDefault();
@@ -1158,8 +1267,14 @@ export async function initializeCloudAccount({
           setText(message, "Вход выполнен. Team-раздел временно недоступен; личный Vault и сессия продолжают работать.");
         }
       }
-    } catch {
-      setText(message, "Не удалось войти. Проверьте email, пароль и подтверждение аккаунта.");
+    } catch (error) {
+      const code = String(error?.message ?? "");
+      const messages = {
+        invalid_credentials: "Неверная электронная почта или пароль.",
+        email_not_verified: "Сначала подтвердите почту по ссылке из письма.",
+        rate_limited: "Слишком много попыток входа. Повторите позже.",
+      };
+      setAccountMessage(messages[code] ?? "Не удалось войти. Проверьте соединение и повторите попытку.", "error");
     } finally {
       button.disabled = false;
     }
@@ -1267,6 +1382,7 @@ export async function initializeCloudAccount({
   });
 
   showSession(null);
+  setAuthMode("login");
   return client;
 }
 
@@ -1281,8 +1397,10 @@ async function updateServiceStatus(documentValue, fetchValue) {
     const meta = await response.json();
     status.textContent = `API v${meta.apiVersion} · сервис доступен`;
     status.classList.add("ok");
+    return meta;
   } catch {
     status.textContent = "Сервис недоступен";
+    return null;
   }
 }
 
@@ -1354,9 +1472,9 @@ export async function initializePortal({
       });
     }
   }
+  const metadata = await updateServiceStatus(documentValue, fetchValue);
   const vaultUI = await initializeLocalVault({ documentValue });
-  await initializeCloudAccount({ documentValue, vaultUI, fetchValue });
-  await updateServiceStatus(documentValue, fetchValue);
+  await initializeCloudAccount({ documentValue, vaultUI, fetchValue, metadata });
 }
 
 if (typeof document !== "undefined") await initializePortal();

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -39,42 +39,81 @@
       <a href="/" id="password-reset-home" hidden>Вернуться на главную</a>
     </section>
 
-    <section class="hero">
-      <div>
+    <section class="hero hero-with-auth">
+      <div class="hero-copy">
         <p class="kicker">Ваши подключения — на ваших устройствах</p>
         <h2>Синхронизация без доступа сервера к данным.</h2>
         <p class="lead">Профили, Snippets и секреты шифруются на Mac до отправки. Cloud хранит только зашифрованные ревизии.</p>
+        <div class="trust-row" aria-label="Свойства безопасности">
+          <span>Локальное шифрование</span>
+          <span>Сессия только в памяти</span>
+          <span>HTTPS</span>
+        </div>
       </div>
-      <div class="vault-visual" aria-label="Схема защищённого хранилища">
-        <div class="orbit orbit-one"></div>
-        <div class="orbit orbit-two"></div>
-        <div class="vault-core"><span>256</span><small>AES-GCM</small></div>
-      </div>
+
+      <section class="auth-card" id="cloud-account" aria-labelledby="cloud-account-title">
+        <div class="auth-card-heading">
+          <div class="auth-icon" aria-hidden="true">SR</div>
+          <div>
+            <p class="eyebrow">SELECTIVE REMOTE CLOUD</p>
+            <h2 id="cloud-account-title">Добро пожаловать</h2>
+          </div>
+        </div>
+
+        <div class="auth-tabs" role="tablist" aria-label="Аккаунт Cloud">
+          <button type="button" role="tab" id="cloud-login-tab" aria-controls="cloud-login-form" aria-selected="true">Войти</button>
+          <button type="button" role="tab" id="cloud-register-tab" aria-controls="cloud-registration-form" aria-selected="false">Регистрация</button>
+        </div>
+
+        <p class="auth-message" id="cloud-account-message" aria-live="polite">Проверяем доступность Cloud…</p>
+
+        <form class="auth-form" id="cloud-login-form" method="post" action="/v1/auth/login">
+          <label for="cloud-email">Электронная почта</label>
+          <input id="cloud-email" name="email" type="email" maxlength="254" autocomplete="username" placeholder="name@example.com" required>
+          <label for="cloud-password">Пароль Selective Remote</label>
+          <input id="cloud-password" name="password" type="password" minlength="12" maxlength="1024" autocomplete="current-password" placeholder="Минимум 12 символов" required>
+          <button type="submit">Войти в Cloud</button>
+          <button type="button" class="text-button" id="cloud-show-recovery">Не удаётся войти?</button>
+        </form>
+
+        <form class="auth-form" id="cloud-registration-form" method="post" action="/v1/auth/register" hidden>
+          <label for="cloud-registration-name">Ваше имя</label>
+          <input id="cloud-registration-name" name="displayName" maxlength="120" autocomplete="name" placeholder="Как к вам обращаться" required>
+          <label for="cloud-registration-email">Электронная почта</label>
+          <input id="cloud-registration-email" name="email" type="email" maxlength="254" autocomplete="email" placeholder="На неё придёт подтверждение" required>
+          <label for="cloud-registration-password">Новый пароль Selective Remote</label>
+          <input id="cloud-registration-password" name="password" type="password" minlength="12" maxlength="1024" autocomplete="new-password" placeholder="Минимум 12 символов" required>
+          <label for="cloud-registration-confirmation">Повторите пароль</label>
+          <input id="cloud-registration-confirmation" name="confirmation" type="password" minlength="12" maxlength="1024" autocomplete="new-password" required>
+          <button type="submit">Создать аккаунт</button>
+          <p class="auth-note">Мы отправим одноразовую ссылку подтверждения. Пароли по почте не отправляются и не сохраняются в браузере.</p>
+        </form>
+
+        <form class="auth-form compact" id="cloud-recovery-form" method="post" action="/v1/auth/request-password-reset" hidden>
+          <label for="cloud-recovery-email">Электронная почта аккаунта</label>
+          <input id="cloud-recovery-email" name="email" type="email" maxlength="254" autocomplete="email" required>
+          <button type="submit">Отправить ссылку для смены пароля</button>
+          <button type="button" class="text-button" id="cloud-hide-recovery">Вернуться ко входу</button>
+        </form>
+
+        <div class="auth-success" id="cloud-registration-success" hidden>
+          <div class="auth-success-icon" aria-hidden="true">✓</div>
+          <h3>Проверьте почту</h3>
+          <p id="cloud-registration-success-message"></p>
+          <button type="button" class="secondary" id="cloud-registration-done">Вернуться ко входу</button>
+        </div>
+
+        <div id="cloud-signed-in" hidden>
+          <p id="cloud-account-name"></p>
+          <button type="button" class="secondary" id="cloud-logout">Выйти и удалить токен из памяти</button>
+        </div>
+      </section>
     </section>
 
     <section class="grid" aria-label="Возможности первой версии">
       <article><span>01</span><h3>Личный Vault</h3><p>Одна зашифрованная библиотека с историей ревизий и защитой от перезаписи.</p></article>
       <article><span>02</span><h3>Ваши устройства</h3><p>Список активных Mac, дата последнего доступа и мгновенный отзыв сессии.</p></article>
       <article><span>03</span><h3>Локальный режим</h3><p>Аккаунт необязателен: приложение продолжает полноценно работать автономно.</p></article>
-    </section>
-
-    <section class="cloud-account" id="cloud-account" aria-labelledby="cloud-account-title">
-      <div>
-        <p class="eyebrow">CLOUD SESSION · MEMORY ONLY</p>
-        <h2 id="cloud-account-title">Вход для зашифрованной синхронизации</h2>
-        <p id="cloud-account-message" aria-live="polite">Токен не сохраняется в localStorage, sessionStorage или IndexedDB.</p>
-      </div>
-      <form id="cloud-login-form" method="post" action="/v1/auth/login">
-        <label for="cloud-email">Email</label>
-        <input id="cloud-email" name="email" type="email" maxlength="254" autocomplete="username" required>
-        <label for="cloud-password">Пароль аккаунта</label>
-        <input id="cloud-password" name="password" type="password" minlength="12" maxlength="1024" autocomplete="current-password" required>
-        <button type="submit">Войти</button>
-      </form>
-      <div id="cloud-signed-in" hidden>
-        <p id="cloud-account-name"></p>
-        <button type="button" class="secondary" id="cloud-logout">Выйти и удалить токен из памяти</button>
-      </div>
     </section>
 
     <section class="local-vault" id="local-vault" aria-labelledby="local-vault-title">
@@ -307,8 +346,8 @@
     </section>
 
     <section class="access">
-      <div><p class="eyebrow">V0.32 FOUNDATION</p><h2>Портал готовится к первому входу</h2></div>
-      <p>Регистрация будет открыта после завершения сброса пароля, ограничения запросов, защиты от злоупотреблений и ручной проверки безопасности.</p>
+      <div><p class="eyebrow">V0.32 FOUNDATION</p><h2>Cloud управляется вами</h2></div>
+      <p>Регистрация доступна только во время контролируемого окна. Вход, подтверждение почты и восстановление пароля остаются доступны для существующего аккаунта.</p>
     </section>
   </main>
   <script type="module" src="/app.js"></script>

--- a/cloud/public/styles.css
+++ b/cloud/public/styles.css
@@ -13,21 +13,41 @@ body { margin:0; min-height:100vh; background:radial-gradient(circle at 70% 15%,
 .verification input { width:100%; border:1px solid var(--line); border-radius:10px; padding:12px 14px; background:#07100d; color:var(--ink); font:inherit; }
 .verification button { justify-self:start; margin:8px 0 16px; border:0; border-radius:10px; padding:12px 18px; background:var(--accent); color:#082016; font:inherit; font-weight:750; cursor:pointer; }
 .verification button:disabled { opacity:.6; cursor:wait; }
-.hero { min-height:460px; display:grid; grid-template-columns:1.35fr .65fr; align-items:center; gap:60px; border-bottom:1px solid var(--line); }
+.hero { min-height:560px; display:grid; grid-template-columns:minmax(0,1.08fr) minmax(380px,.72fr); align-items:center; gap:64px; border-bottom:1px solid var(--line); padding:54px 0; }
 .kicker { color:var(--accent2); font-weight:650; }.hero h2 { font-size:clamp(42px,6vw,78px); line-height:.98; letter-spacing:-.055em; max-width:850px; margin:18px 0 24px; }
 .lead { max-width:660px; color:var(--muted); line-height:1.65; font-size:18px; }
+.trust-row { display:flex; flex-wrap:wrap; gap:9px; margin-top:28px; }
+.trust-row span { padding:8px 11px; border:1px solid var(--line); border-radius:999px; color:#bdd0c9; background:#0c1714b8; font-size:12px; }
 .vault-visual { width:min(320px,75vw); aspect-ratio:1; position:relative; display:grid; place-items:center; margin:auto; }
 .orbit { position:absolute; inset:10%; border:1px solid #4a7a67; border-radius:42% 58% 63% 37%; animation:spin 18s linear infinite; }.orbit-two { inset:22%; border-color:#75e0b477; animation-direction:reverse; animation-duration:12s; }
 .vault-core { width:120px; height:120px; display:grid; place-content:center; text-align:center; border-radius:28px; background:linear-gradient(145deg,#a9ffc9,#78dcaa); color:#082016; box-shadow:0 0 70px #75e0b438; transform:rotate(-5deg); }
 .vault-core span { font-size:38px; font-weight:800; line-height:1; }.vault-core small { font-size:10px; letter-spacing:.12em; margin-top:6px; }
 .grid { display:grid; grid-template-columns:repeat(3,1fr); gap:1px; background:var(--line); border:1px solid var(--line); margin:50px 0; }
 .grid article { background:var(--panel); padding:30px; min-height:210px; }.grid span { color:var(--accent); font-family:ui-monospace,monospace; }.grid h3 { margin:38px 0 12px; font-size:20px; }.grid p,.access p { color:var(--muted); line-height:1.55; }
-.cloud-account { margin:50px 0; padding:34px; display:grid; grid-template-columns:minmax(0,1fr) minmax(300px,.8fr); gap:34px; border:1px solid var(--line); border-radius:22px; background:#0c1714e8; }
-.cloud-account h2 { margin:8px 0 12px; }.cloud-account p { color:var(--muted); line-height:1.55; }
-.cloud-account form { display:grid; gap:10px; }.cloud-account label { color:var(--muted); font-size:13px; }
-.cloud-account input { width:100%; border:1px solid var(--line); border-radius:10px; padding:12px 14px; background:#07100d; color:var(--ink); font:inherit; }
-.cloud-account button { justify-self:start; border:0; border-radius:10px; padding:12px 18px; background:var(--accent); color:#082016; font:inherit; font-weight:750; cursor:pointer; }
-.cloud-account button.secondary { background:transparent; border:1px solid var(--line); color:var(--ink); }.cloud-account button:disabled { opacity:.6; cursor:wait; }
+.auth-card { position:relative; overflow:hidden; padding:28px; border:1px solid #75e0b452; border-radius:24px; background:linear-gradient(150deg,#12221de8,#09120ff5); box-shadow:0 28px 80px #0007,0 0 0 1px #ffffff08 inset; }
+.auth-card::before { content:""; position:absolute; width:180px; height:180px; right:-70px; top:-90px; border-radius:50%; background:#75e0b41f; filter:blur(8px); pointer-events:none; }
+.auth-card-heading { display:flex; align-items:center; gap:14px; position:relative; }
+.auth-card-heading h2 { margin:5px 0 0; font-size:25px; letter-spacing:-.025em; }
+.auth-icon { width:44px; height:44px; display:grid; place-items:center; border-radius:14px; background:linear-gradient(145deg,var(--accent),#a7ffc9); color:#082016; font-weight:850; box-shadow:0 10px 30px #75e0b42b; }
+.auth-tabs { display:grid; grid-template-columns:1fr 1fr; gap:4px; margin:25px 0 18px; padding:4px; border:1px solid var(--line); border-radius:13px; background:#06100c; }
+.auth-tabs button { border:0; border-radius:9px; padding:10px 12px; background:transparent; color:var(--muted); font:inherit; font-weight:700; cursor:pointer; }
+.auth-tabs button[aria-selected="true"] { color:#092018; background:var(--accent); box-shadow:0 6px 18px #75e0b426; }
+.auth-tabs button:disabled { cursor:not-allowed; opacity:.55; }
+.auth-message { min-height:40px; margin:0 0 16px; color:var(--muted); line-height:1.45; font-size:14px; }
+.auth-message.error { color:#ffb4a6; }.auth-message.success { color:var(--accent2); }
+.auth-form { display:grid; gap:9px; }.auth-form.compact { padding-top:5px; }
+.auth-form label { color:#bdd0c9; font-size:12px; font-weight:650; margin-top:3px; }
+.auth-form input { width:100%; border:1px solid #315347; border-radius:11px; padding:12px 13px; background:#050c0a; color:var(--ink); font:inherit; outline:none; transition:border-color .15s,box-shadow .15s; }
+.auth-form input:focus { border-color:var(--accent); box-shadow:0 0 0 3px #75e0b41c; }
+.auth-form input::placeholder { color:#657a73; }
+.auth-form button,.auth-card button.secondary { border:0; border-radius:11px; padding:12px 16px; background:var(--accent); color:#082016; font:inherit; font-weight:750; cursor:pointer; margin-top:8px; }
+.auth-form button:disabled { opacity:.55; cursor:wait; }
+.auth-form .text-button { justify-self:start; padding:5px 0; margin:1px 0 0; color:var(--accent); background:transparent; font-size:13px; }
+.auth-note { margin:6px 0 0; color:var(--muted); font-size:12px; line-height:1.45; }
+.auth-success { text-align:center; padding:18px 8px 8px; }.auth-success h3 { margin:12px 0 8px; }.auth-success p { color:var(--muted); line-height:1.5; }
+.auth-success-icon { width:54px; height:54px; display:grid; place-items:center; margin:auto; border-radius:50%; background:#75e0b424; color:var(--accent); font-size:27px; }
+.auth-card button.secondary { background:transparent; border:1px solid var(--line); color:var(--ink); }
+#cloud-signed-in { padding-top:10px; } #cloud-signed-in p { color:var(--ink); font-weight:700; }
 .local-vault { margin:50px 0; padding:34px; border:1px solid var(--line); border-radius:22px; background:#0c1714e8; }
 .team-vault { margin:50px 0; padding:34px; border:1px solid #75e0b45c; border-radius:22px; background:linear-gradient(145deg,#0c1714f2,#102019e8); }
 .team-onboarding,.team-columns { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:18px; margin-top:26px; }
@@ -85,5 +105,5 @@ body { margin:0; min-height:100vh; background:radial-gradient(circle at 70% 15%,
 .vault-conflicts button:disabled { opacity:.6; cursor:not-allowed; }
 .access { display:flex; justify-content:space-between; gap:40px; align-items:end; padding:34px; border:1px solid var(--line); border-radius:18px; background:#0c1714cc; }.access h2 { margin:8px 0 0; }.access>p { max-width:500px; margin:0; }
 @keyframes spin { to { transform:rotate(360deg); } }
-@media (max-width:760px) { .shell{width:min(100% - 24px,1180px);padding-top:18px}.hero{grid-template-columns:1fr;padding:64px 0;gap:30px}.vault-visual{width:230px}.grid,.cloud-account,.team-onboarding,.team-columns,.team-lifecycle-forms{grid-template-columns:1fr}.vault-heading,.vault-toolbar,.access,.team-summary,.team-devices-heading{align-items:start;flex-direction:column}.vault-actions{justify-content:flex-start}.vault-panel form,.record-form{grid-template-columns:1fr}.vault-panel button,.record-form button{grid-column:1}.vault-records{grid-template-columns:1fr}.team-picker,.team-picker.compact{grid-template-columns:1fr}.team-members article,.team-devices article{grid-template-columns:1fr}.team-members strong,.team-members small,.team-members select,.team-members button,.team-members button.danger,.team-devices strong,.team-devices small,.team-device-fingerprint,.team-devices button,.team-devices button.danger{grid-column:1;grid-row:auto}.status{font-size:0}.status::after{content:"●";font-size:16px} }
+@media (max-width:880px) { .shell{width:min(100% - 24px,1180px);padding-top:18px}.hero{grid-template-columns:1fr;padding:48px 0;gap:36px}.hero h2{font-size:clamp(40px,11vw,68px)}.auth-card{width:100%;max-width:560px}.vault-visual{width:230px}.grid,.team-onboarding,.team-columns,.team-lifecycle-forms{grid-template-columns:1fr}.vault-heading,.vault-toolbar,.access,.team-summary,.team-devices-heading{align-items:start;flex-direction:column}.vault-actions{justify-content:flex-start}.vault-panel form,.record-form{grid-template-columns:1fr}.vault-panel button,.record-form button{grid-column:1}.vault-records{grid-template-columns:1fr}.team-picker,.team-picker.compact{grid-template-columns:1fr}.team-members article,.team-devices article{grid-template-columns:1fr}.team-members strong,.team-members small,.team-members select,.team-members button,.team-members button.danger,.team-devices strong,.team-devices small,.team-device-fingerprint,.team-devices button,.team-devices button.danger{grid-column:1;grid-row:auto}.status{font-size:0}.status::after{content:"●";font-size:16px} }
 @media (prefers-reduced-motion:reduce) { .orbit{animation:none} }

--- a/cloud/public/vault-sync.js
+++ b/cloud/public/vault-sync.js
@@ -371,6 +371,57 @@ export function createAuthenticatedVaultClient({ fetchValue = globalThis.fetch }
   }
 
   return {
+    async register({ displayName, email, password, deviceID, publicKey = null }) {
+      const normalizedDeviceID = String(deviceID ?? "").toLowerCase();
+      if (!uuidPattern.test(normalizedDeviceID)) throw new Error("invalid_device");
+      const normalizedName = String(displayName ?? "").trim();
+      if (!normalizedName || normalizedName.length > 120) throw new Error("invalid_display_name");
+      const normalizedPublicKey = publicKey === null ? null : normalizeTeamDevicePublicKey(publicKey);
+      const response = await fetchValue("/v1/auth/register", {
+        method: "POST",
+        headers: { Accept: "application/json", "Content-Type": "application/json" },
+        body: JSON.stringify({
+          displayName: normalizedName,
+          email: String(email ?? "").trim(),
+          password: normalizedPassword(password),
+          device: {
+            id: normalizedDeviceID,
+            name: "Web browser",
+            platform: "web",
+            appVersion: "0.32",
+            publicKey: normalizedPublicKey,
+          },
+        }),
+        cache: "no-store",
+        credentials: "omit",
+        referrerPolicy: "no-referrer",
+      });
+      const result = await responseJSON(response, "registration_failed");
+      if (!response.ok) {
+        const code = ["registration_disabled", "rate_limited", "smtp_not_configured"].includes(result.error)
+          ? result.error : "registration_failed";
+        throw new Error(code);
+      }
+      if (result.verificationRequired !== true || Object.keys(result).length !== 1) {
+        throw new Error("registration_failed");
+      }
+      return { verificationRequired: true };
+    },
+
+    async requestPasswordReset(email) {
+      const response = await fetchValue("/v1/auth/request-password-reset", {
+        method: "POST",
+        headers: { Accept: "application/json", "Content-Type": "application/json" },
+        body: JSON.stringify({ email: String(email ?? "").trim() }),
+        cache: "no-store",
+        credentials: "omit",
+        referrerPolicy: "no-referrer",
+      });
+      const result = await responseJSON(response, "recovery_failed");
+      if (!response.ok || result.accepted !== true) throw new Error("recovery_failed");
+      return { accepted: true };
+    },
+
     async login({ email, password, deviceID, publicKey = null }) {
       const normalizedDeviceID = String(deviceID ?? "").toLowerCase();
       if (!uuidPattern.test(normalizedDeviceID)) throw new Error("invalid_device");
@@ -393,8 +444,12 @@ export function createAuthenticatedVaultClient({ fetchValue = globalThis.fetch }
         credentials: "omit",
         referrerPolicy: "no-referrer",
       });
-      if (!response.ok) throw new Error("login_failed");
       const result = await responseJSON(response, "login_failed");
+      if (!response.ok) {
+        const code = ["invalid_credentials", "email_not_verified", "rate_limited"].includes(result.error)
+          ? result.error : "login_failed";
+        throw new Error(code);
+      }
       if (typeof result.token !== "string" || result.token.length < 32 || result.token.length > 256) {
         throw new Error("login_failed");
       }

--- a/cloud/src/server.mjs
+++ b/cloud/src/server.mjs
@@ -431,7 +431,7 @@ async function serveStatic(pathname, response, head) {
     const types = { ".html": "text/html; charset=utf-8", ".css": "text/css; charset=utf-8", ".js": "text/javascript; charset=utf-8", ".svg": "image/svg+xml" };
     response.writeHead(200, {
       "Content-Type": types[extname(relative)] ?? "application/octet-stream",
-      "Cache-Control": relative === "index.html" ? "no-cache" : "public, max-age=3600",
+      "Cache-Control": [".html", ".js", ".css"].includes(extname(relative)) ? "no-cache" : "public, max-age=3600",
       "Content-Security-Policy": "default-src 'self'; style-src 'self'; script-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'",
     });
     response.end(head ? undefined : data);

--- a/cloud/tests/public-auth.test.mjs
+++ b/cloud/tests/public-auth.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { createAuthenticatedVaultClient } from "../public/vault-sync.js";
+
+const deviceID = "84f6c860-0d26-4ef5-8652-27cb8b991b70";
+
+test("browser registration sends JSON without persisting or returning a password", async () => {
+  let request;
+  const client = createAuthenticatedVaultClient({
+    async fetchValue(...values) {
+      request = values;
+      return { ok: true, status: 201, async json() { return { verificationRequired: true }; } };
+    },
+  });
+
+  const result = await client.register({
+    displayName: "Leonid",
+    email: "owner@example.com",
+    password: "a sufficiently long password",
+    deviceID,
+  });
+  assert.deepEqual(result, { verificationRequired: true });
+  assert.equal(request[0], "/v1/auth/register");
+  assert.equal(request[1].method, "POST");
+  assert.equal(request[1].headers["Content-Type"], "application/json");
+  assert.equal(request[1].cache, "no-store");
+  const body = JSON.parse(request[1].body);
+  assert.equal(body.email, "owner@example.com");
+  assert.equal(body.device.id, deviceID);
+  assert.equal("password" in result, false);
+});
+
+test("browser surfaces bounded registration and login errors", async () => {
+  const registrationClient = createAuthenticatedVaultClient({
+    fetchValue: async () => ({ ok: false, status: 403, async json() { return { error: "registration_disabled" }; } }),
+  });
+  await assert.rejects(
+    registrationClient.register({ displayName: "Owner", email: "owner@example.com", password: "a sufficiently long password", deviceID }),
+    /registration_disabled/,
+  );
+
+  const loginClient = createAuthenticatedVaultClient({
+    fetchValue: async () => ({ ok: false, status: 403, async json() { return { error: "email_not_verified" }; } }),
+  });
+  await assert.rejects(
+    loginClient.login({ email: "owner@example.com", password: "a sufficiently long password", deviceID }),
+    /email_not_verified/,
+  );
+});
+
+test("password recovery uses a generic no-store response", async () => {
+  let request;
+  const client = createAuthenticatedVaultClient({
+    fetchValue: async (...values) => {
+      request = values;
+      return { ok: true, status: 202, async json() { return { accepted: true }; } };
+    },
+  });
+  assert.deepEqual(await client.requestPasswordReset("owner@example.com"), { accepted: true });
+  assert.equal(request[0], "/v1/auth/request-password-reset");
+  assert.equal(request[1].cache, "no-store");
+  assert.deepEqual(JSON.parse(request[1].body), { email: "owner@example.com" });
+});
+
+test("portal exposes visible login and registration modes and never promises emailed passwords", async () => {
+  const [html, server] = await Promise.all([
+    readFile(new URL("../public/index.html", import.meta.url), "utf8"),
+    readFile(new URL("../src/server.mjs", import.meta.url), "utf8"),
+  ]);
+  assert.match(html, /id="cloud-login-tab"/u);
+  assert.match(html, /id="cloud-register-tab"/u);
+  assert.match(html, /id="cloud-registration-form"/u);
+  assert.match(html, /id="cloud-recovery-form"/u);
+  assert.match(html, /Пароли по почте не отправляются/u);
+  assert.doesNotMatch(html, /отправим[^<]*(?:логин|пароль)/iu);
+  assert.match(server, /\["\.html", "\.js", "\.css"\][^\n]*"no-cache"/u);
+});


### PR DESCRIPTION
## Summary

- move Cloud authentication into a polished above-the-fold card with explicit sign-in and registration modes
- add browser registration, email verification guidance, and password-reset request UX
- improve bounded authentication errors in the browser and refresh the macOS sign-in sheet
- revalidate HTML, JavaScript, and CSS to prevent a stale-script/new-form mismatch that surfaced as `invalid_content_type`

Passwords are created by the user and are never emailed. Registration sends only a one-time email-verification link.

## Root cause

`index.html` was revalidated while JavaScript and CSS could remain cached for one hour. After an upgrade, Safari could therefore render new native forms with old JavaScript; the form posted URL-encoded data to the JSON API and received `invalid_content_type`.

## Verification

- `node --test cloud/tests/*.test.mjs` — 239 passed, 1 skipped because `TEST_DATABASE_URL` is not configured
- `node --check cloud/public/app.js`
- `node --check cloud/public/vault-sync.js`
- `git diff --check`

The local source commit authorized for publication was `806ad1b085d37d2beeabb44a2ed783294d1aee8e`; the GitHub commit has the identical tree `00f636de9c20f5b8b174d9a3db6fd0192b98045b`.