### PR TITLE
Cloud: keep inactive authentication forms hidden

### DIFF
--- a/cloud/public/styles.css
+++ b/cloud/public/styles.css
@@ -1,5 +1,6 @@
 :root { color-scheme: dark; --bg:#08100e; --panel:#0e1916; --line:#244138; --ink:#f2f7f4; --muted:#9bb0a9; --accent:#75e0b4; --accent2:#c8ff78; }
 * { box-sizing:border-box; }
+[hidden] { display:none !important; }
 body { margin:0; min-height:100vh; background:radial-gradient(circle at 70% 15%,#183b2e 0,transparent 32%),linear-gradient(145deg,#07100d,#0a1412 58%,#101a14); color:var(--ink); font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
 .shell { width:min(1180px,calc(100% - 40px)); margin:0 auto; padding:38px 0 60px; }
 .brand { display:flex; align-items:center; gap:14px; border-bottom:1px solid var(--line); padding-bottom:24px; }

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -81,8 +81,9 @@ test("conflict choices expose only bounded metadata and never record secrets or 
 });
 
 test("portal exposes memory-only login and explicit manual synchronization controls", async () => {
-  const [html, application, synchronization, teamSynchronization] = await Promise.all([
+  const [html, styles, application, synchronization, teamSynchronization] = await Promise.all([
     readFile(new URL("../public/index.html", import.meta.url), "utf8"),
+    readFile(new URL("../public/styles.css", import.meta.url), "utf8"),
     readFile(new URL("../public/app.js", import.meta.url), "utf8"),
     readFile(new URL("../public/vault-sync.js", import.meta.url), "utf8"),
     readFile(new URL("../public/team-vault-sync.js", import.meta.url), "utf8"),
@@ -107,6 +108,7 @@ test("portal exposes memory-only login and explicit manual synchronization contr
   assert.match(html, /id="team-vault-rotate"[^>]*hidden/u);
   assert.match(html, /id="team-vault-record-form"/u);
   assert.match(html, /id="team-vault-conflicts-form"/u);
+  assert.match(styles, /\[hidden\]\s*\{\s*display:\s*none\s*!important;\s*\}/u);
   assert.match(application, /createAuthenticatedVaultClient/u);
   assert.match(application, /synchronizeVault/u);
   assert.match(application, /ensureTeamDeviceIdentity/u);


### PR DESCRIPTION
## Причина

В Safari авторское правило `.auth-form { display: grid; }` переопределяет отображение элементов с HTML-атрибутом `hidden`. Из-за этого одновременно видны формы входа, регистрации и восстановления пароля, и поле восстановления легко принять за регистрацию.

## Изменение

- добавлено явное глобальное `[hidden] { display: none !important; }`;
- добавлена регрессия, требующая это правило для интерфейсов, которыми управляет JavaScript.

## Проверка

- Cloud tests: 239 passed, 0 failed, 1 PostgreSQL integration skipped (`TEST_DATABASE_URL` отсутствует);
- `git diff --check`: success.

Этот PR не включает staging-операции и не меняет публичный `main` до отдельного разрешения владельца.