### PR TITLE
Cloud: separate authentication from the workspace

### DIFF
--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -129,8 +129,10 @@ export async function initializeLocalVault({
   const conflictPanel = documentValue.querySelector("#local-vault-conflicts");
   const conflictForm = documentValue.querySelector("#local-vault-conflicts-form");
   const conflictList = documentValue.querySelector("#local-vault-conflicts-list");
+  const filterButtons = [...documentValue.querySelectorAll("#personal-vault-filters [data-record-filter]")];
   const controller = createLocalVaultController({ repository });
   let conflictResetListener = () => {};
+  let activeRecordFilter = "all";
 
   function clearConflictUI() {
     conflictPanel.hidden = true;
@@ -173,15 +175,27 @@ export async function initializeLocalVault({
 
   function render() {
     const current = controller.document();
+    const counts = { host: 0, credential: 0, snippet: 0, forwarding: 0 };
+    for (const record of current.records) {
+      if (Object.hasOwn(counts, record.type)) counts[record.type] += 1;
+    }
+    for (const [recordType, count] of Object.entries(counts)) {
+      setText(documentValue.querySelector(`#workspace-${recordType}-count`), String(count));
+    }
+    const visibleRecords = activeRecordFilter === "all"
+      ? current.records
+      : current.records.filter((record) => record.type === activeRecordFilter);
     records.replaceChildren();
-    if (current.records.length === 0) {
+    if (visibleRecords.length === 0) {
       const empty = documentValue.createElement("p");
       empty.className = "vault-empty";
-      empty.textContent = "Vault пока пуст.";
+      empty.textContent = current.records.length === 0
+        ? "Personal Vault пока пуст. Данные появятся после первой синхронизации с Mac или ручного добавления."
+        : "Записей этого типа пока нет.";
       records.append(empty);
       return;
     }
-    for (const record of current.records) {
+    for (const record of visibleRecords) {
       const card = documentValue.createElement("article");
       const heading = documentValue.createElement("h4");
       const summary = documentValue.createElement("p");
@@ -275,6 +289,15 @@ export async function initializeLocalVault({
   });
 
   type.addEventListener("change", updateLabels);
+  for (const button of filterButtons) {
+    button.addEventListener("click", () => {
+      activeRecordFilter = button.dataset.recordFilter || "all";
+      for (const candidate of filterButtons) {
+        candidate.classList.toggle("active", candidate === button);
+      }
+      if (!workspace.hidden) render();
+    });
+  }
   lockButton.addEventListener("click", () => {
     controller.lock();
     hideRecovery();
@@ -300,6 +323,13 @@ export async function initializeLocalVault({
     render,
     clearConflictUI,
     setConflictMode,
+    setFilter(value) {
+      activeRecordFilter = ["all", "host", "credential", "snippet", "forwarding"].includes(value) ? value : "all";
+      for (const button of filterButtons) {
+        button.classList.toggle("active", button.dataset.recordFilter === activeRecordFilter);
+      }
+      if (!workspace.hidden) render();
+    },
     setConflictResetListener(listener) {
       conflictResetListener = typeof listener === "function" ? listener : () => {};
     },
@@ -1018,7 +1048,6 @@ export function initializeTeamWorkspace({
   return {
     async activate(nextIdentity) {
       identity = nextIdentity;
-      section.hidden = false;
       await Promise.all([loadDevices(), loadTeams()]);
     },
     deactivate() {
@@ -1032,7 +1061,6 @@ export function initializeTeamWorkspace({
       devices.replaceChildren();
       members.replaceChildren();
       selectedPanel.hidden = true;
-      section.hidden = true;
     },
   };
 }
@@ -1042,6 +1070,7 @@ export async function initializeCloudAccount({
   vaultUI,
   fetchValue = fetch,
   metadata = null,
+  onSessionChange = () => {},
 } = {}) {
   const vault = vaultUI?.controller;
   const section = documentValue.querySelector("#cloud-account");
@@ -1157,6 +1186,7 @@ export async function initializeCloudAccount({
     signedIn.hidden = !user;
     syncButton.disabled = !user;
     setText(accountName, user ? `${user.displayName || user.email} · ${user.email}` : "");
+    onSessionChange(user);
   }
 
   loginTab.addEventListener("click", () => setAuthMode("login"));
@@ -1383,7 +1413,131 @@ export async function initializeCloudAccount({
 
   showSession(null);
   setAuthMode("login");
-  return client;
+  return { client, showAuth: setAuthMode };
+}
+
+export function initializePortalNavigation({
+  documentValue = document,
+  locationValue = location,
+  historyValue = history,
+  vaultUI = null,
+  showAuthMode = () => {},
+} = {}) {
+  const brand = documentValue.querySelector("#site-brand");
+  const publicActions = documentValue.querySelector("#public-actions");
+  const hero = documentValue.querySelector("#public-hero");
+  const heroCopy = documentValue.querySelector("#public-hero-copy");
+  const heroPreview = documentValue.querySelector("#cloud-hero-preview");
+  const auth = documentValue.querySelector("#cloud-account");
+  const authBack = documentValue.querySelector("#cloud-auth-back");
+  const publicGrid = documentValue.querySelector("#public-grid");
+  const publicAccess = documentValue.querySelector("#public-access");
+  const workspace = documentValue.querySelector("#cloud-workspace");
+  const workspaceTitle = documentValue.querySelector("#workspace-title");
+  const workspacePanels = [...documentValue.querySelectorAll(".workspace-panel")];
+  const workspaceButtons = [...documentValue.querySelectorAll("[data-workspace-target]")];
+  const sidebarButtons = [...documentValue.querySelectorAll(".workspace-sidebar [data-workspace-target]")];
+  const titles = {
+    "workspace-overview": "Обзор",
+    "local-vault": "Personal Vault",
+    "team-vault": "Teams и Vaults",
+    "workspace-devices": "Устройства",
+  };
+  let sessionActive = false;
+
+  function setPath(path, replace = false) {
+    if (locationValue.pathname === path) return;
+    const method = replace ? "replaceState" : "pushState";
+    historyValue[method]?.({}, "", path);
+  }
+
+  function selectWorkspacePanel(target, recordFilter = null) {
+    const panelID = Object.hasOwn(titles, target) ? target : "workspace-overview";
+    for (const panel of workspacePanels) panel.hidden = panel.id !== panelID;
+    for (const button of sidebarButtons) button.classList.toggle("active", button.dataset.workspaceTarget === panelID);
+    setText(workspaceTitle, titles[panelID]);
+    if (recordFilter) vaultUI?.setFilter(recordFilter);
+  }
+
+  function showLanding({ replace = false } = {}) {
+    brand.hidden = false;
+    publicActions.hidden = false;
+    hero.hidden = false;
+    hero.classList.remove("auth-active");
+    heroCopy.hidden = false;
+    heroPreview.hidden = false;
+    auth.hidden = true;
+    publicGrid.hidden = false;
+    publicAccess.hidden = false;
+    workspace.hidden = true;
+    setPath("/", replace);
+  }
+
+  function showAuthentication(mode = "login", { replace = false } = {}) {
+    brand.hidden = false;
+    publicActions.hidden = true;
+    hero.hidden = false;
+    hero.classList.add("auth-active");
+    heroCopy.hidden = true;
+    heroPreview.hidden = true;
+    auth.hidden = false;
+    publicGrid.hidden = true;
+    publicAccess.hidden = true;
+    workspace.hidden = true;
+    showAuthMode(mode);
+    setPath("/login", replace);
+    documentValue.querySelector(mode === "registration" ? "#cloud-registration-name" : "#cloud-email")?.focus();
+  }
+
+  function showWorkspace({ replace = false } = {}) {
+    brand.hidden = true;
+    hero.hidden = true;
+    publicGrid.hidden = true;
+    publicAccess.hidden = true;
+    workspace.hidden = false;
+    selectWorkspacePanel("workspace-overview");
+    setPath("/app", replace);
+  }
+
+  for (const button of documentValue.querySelectorAll("[data-open-auth]")) {
+    button.addEventListener("click", () => showAuthentication(button.dataset.openAuth || "login"));
+  }
+  authBack.addEventListener("click", () => showLanding());
+  for (const button of workspaceButtons) {
+    button.addEventListener("click", () => selectWorkspacePanel(
+      button.dataset.workspaceTarget,
+      button.dataset.recordFilter || null,
+    ));
+  }
+
+  const view = {
+    sessionChanged(user) {
+      if (user) {
+        sessionActive = true;
+        showWorkspace();
+      } else if (sessionActive) {
+        sessionActive = false;
+        showAuthentication("login", { replace: true });
+      }
+    },
+    showAuthentication,
+    showLanding,
+    showWorkspace,
+    selectWorkspacePanel,
+  };
+
+  const initialPath = String(locationValue.pathname || "/");
+  if (initialPath === "/login" || initialPath === "/app") {
+    showAuthentication("login", { replace: initialPath === "/app" });
+  } else {
+    showLanding({ replace: initialPath !== "/" });
+  }
+  documentValue.defaultView?.addEventListener("popstate", () => {
+    if (sessionActive && locationValue.pathname === "/app") showWorkspace({ replace: true });
+    else if (locationValue.pathname === "/login") showAuthentication("login", { replace: true });
+    else showLanding({ replace: true });
+  });
+  return view;
 }
 
 async function updateServiceStatus(documentValue, fetchValue) {
@@ -1474,7 +1628,21 @@ export async function initializePortal({
   }
   const metadata = await updateServiceStatus(documentValue, fetchValue);
   const vaultUI = await initializeLocalVault({ documentValue });
-  await initializeCloudAccount({ documentValue, vaultUI, fetchValue, metadata });
+  let navigation = null;
+  const account = await initializeCloudAccount({
+    documentValue,
+    vaultUI,
+    fetchValue,
+    metadata,
+    onSessionChange: (user) => navigation?.sessionChanged(user),
+  });
+  navigation = initializePortalNavigation({
+    documentValue,
+    locationValue,
+    historyValue,
+    vaultUI,
+    showAuthMode: account?.showAuth,
+  });
 }
 
 if (typeof document !== "undefined") await initializePortal();

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -9,12 +9,16 @@
 </head>
 <body>
   <main class="shell">
-    <header class="brand">
+    <header class="brand" id="site-brand">
       <div class="mark" aria-hidden="true">SR</div>
       <div>
         <p class="eyebrow">SELECTIVE REMOTE</p>
         <h1>Cloud</h1>
       </div>
+      <nav class="brand-actions" id="public-actions" aria-label="Аккаунт">
+        <button type="button" class="secondary" data-open-auth="login">Войти</button>
+        <button type="button" data-open-auth="registration">Создать аккаунт</button>
+      </nav>
       <span class="status" id="service-status">Проверка сервиса…</span>
     </header>
 
@@ -39,8 +43,8 @@
       <a href="/" id="password-reset-home" hidden>Вернуться на главную</a>
     </section>
 
-    <section class="hero hero-with-auth">
-      <div class="hero-copy">
+    <section class="hero hero-with-auth" id="public-hero">
+      <div class="hero-copy" id="public-hero-copy">
         <p class="kicker">Ваши подключения — на ваших устройствах</p>
         <h2>Синхронизация без доступа сервера к данным.</h2>
         <p class="lead">Профили, Snippets и секреты шифруются на Mac до отправки. Cloud хранит только зашифрованные ревизии.</p>
@@ -49,9 +53,25 @@
           <span>Сессия только в памяти</span>
           <span>HTTPS</span>
         </div>
+        <div class="hero-actions">
+          <button type="button" data-open-auth="login">Войти в Cloud</button>
+          <button type="button" class="secondary" data-open-auth="registration">Создать аккаунт</button>
+        </div>
       </div>
 
-      <section class="auth-card" id="cloud-account" aria-labelledby="cloud-account-title">
+      <aside class="hero-preview" id="cloud-hero-preview" aria-label="Возможности Cloud">
+        <p class="eyebrow">CLOUD WORKSPACE</p>
+        <h3>Одна рабочая область для всех подключений</h3>
+        <div class="hero-preview-grid">
+          <span><strong>Hosts</strong><small>RDP и SSH</small></span>
+          <span><strong>Vault</strong><small>Личный и Team</small></span>
+          <span><strong>Snippets</strong><small>Команды</small></span>
+          <span><strong>Devices</strong><small>Контроль доступа</small></span>
+        </div>
+      </aside>
+
+      <section class="auth-card" id="cloud-account" aria-labelledby="cloud-account-title" hidden>
+        <button type="button" class="auth-back" id="cloud-auth-back">← На главную</button>
         <div class="auth-card-heading">
           <div class="auth-icon" aria-hidden="true">SR</div>
           <div>
@@ -103,24 +123,58 @@
           <button type="button" class="secondary" id="cloud-registration-done">Вернуться ко входу</button>
         </div>
 
-        <div id="cloud-signed-in" hidden>
-          <p id="cloud-account-name"></p>
-          <button type="button" class="secondary" id="cloud-logout">Выйти и удалить токен из памяти</button>
-        </div>
       </section>
     </section>
 
-    <section class="grid" aria-label="Возможности первой версии">
+    <section class="grid" id="public-grid" aria-label="Возможности первой версии">
       <article><span>01</span><h3>Личный Vault</h3><p>Одна зашифрованная библиотека с историей ревизий и защитой от перезаписи.</p></article>
       <article><span>02</span><h3>Ваши устройства</h3><p>Список активных Mac, дата последнего доступа и мгновенный отзыв сессии.</p></article>
       <article><span>03</span><h3>Локальный режим</h3><p>Аккаунт необязателен: приложение продолжает полноценно работать автономно.</p></article>
     </section>
 
-    <section class="local-vault" id="local-vault" aria-labelledby="local-vault-title">
+    <section class="workspace-layout" id="cloud-workspace" hidden>
+      <aside class="workspace-sidebar">
+        <div class="workspace-logo"><span>SR</span><strong>Cloud</strong></div>
+        <nav aria-label="Разделы Cloud">
+          <button type="button" class="active" data-workspace-target="workspace-overview">Обзор</button>
+          <button type="button" data-workspace-target="local-vault">Personal Vault</button>
+          <button type="button" data-workspace-target="team-vault">Teams и Vaults</button>
+          <button type="button" data-workspace-target="workspace-devices">Устройства</button>
+        </nav>
+        <div class="workspace-security"><span>●</span> E2EE включено</div>
+      </aside>
+
+      <div class="workspace-main">
+        <header class="workspace-header">
+          <div><p class="eyebrow">SELECTIVE REMOTE CLOUD</p><h2 id="workspace-title">Обзор</h2></div>
+          <div id="cloud-signed-in" hidden>
+            <p id="cloud-account-name"></p>
+            <button type="button" class="secondary" id="cloud-logout">Выйти</button>
+          </div>
+        </header>
+
+        <section class="workspace-panel workspace-overview" id="workspace-overview">
+          <div class="workspace-welcome">
+            <div><p class="eyebrow">ВАША РАБОЧАЯ ОБЛАСТЬ</p><h2>Подключения и Vaults</h2></div>
+            <button type="button" data-workspace-target="local-vault">Открыть Personal Vault</button>
+          </div>
+          <div class="workspace-stats">
+            <button type="button" data-workspace-target="local-vault" data-record-filter="host"><span id="workspace-host-count">0</span><strong>Hosts</strong><small>RDP и SSH подключения</small></button>
+            <button type="button" data-workspace-target="local-vault" data-record-filter="credential"><span id="workspace-credential-count">0</span><strong>Credentials</strong><small>Секреты и учётные записи</small></button>
+            <button type="button" data-workspace-target="local-vault" data-record-filter="snippet"><span id="workspace-snippet-count">0</span><strong>Snippets</strong><small>Сохранённые команды</small></button>
+            <button type="button" data-workspace-target="local-vault" data-record-filter="forwarding"><span id="workspace-forwarding-count">0</span><strong>Forwarding</strong><small>Туннели и правила</small></button>
+          </div>
+          <div class="workspace-notice">
+            <strong>Ожидается первая синхронизация с Mac</strong>
+            <p>Локальные подключения из установленного приложения появятся здесь после отправки Personal Vault с Mac. Текущая версия macOS-клиента ещё не выполняет этот импорт автоматически.</p>
+          </div>
+        </section>
+
+    <section class="local-vault workspace-panel" id="local-vault" aria-labelledby="local-vault-title" hidden>
       <div class="vault-heading">
         <div>
-          <p class="eyebrow">PERSONAL VAULT · LOCAL PREVIEW</p>
-          <h2 id="local-vault-title">Зашифрованное хранилище в браузере</h2>
+          <p class="eyebrow">PERSONAL VAULT · E2EE</p>
+          <h2 id="local-vault-title">Личный Vault</h2>
         </div>
         <p id="local-vault-message" aria-live="polite">Проверяем локальное хранилище…</p>
       </div>
@@ -168,6 +222,13 @@
             <button type="button" class="secondary" id="local-vault-lock">Заблокировать</button>
           </div>
         </div>
+        <nav class="record-filters" id="personal-vault-filters" aria-label="Типы записей">
+          <button type="button" class="active" data-record-filter="all">Все</button>
+          <button type="button" data-record-filter="host">Hosts</button>
+          <button type="button" data-record-filter="credential">Credentials</button>
+          <button type="button" data-record-filter="snippet">Snippets</button>
+          <button type="button" data-record-filter="forwarding">Forwarding</button>
+        </nav>
         <form class="record-form" id="local-vault-record-form">
           <label for="local-record-type">Тип записи</label>
           <select id="local-record-type" name="type">
@@ -196,24 +257,27 @@
       </div>
     </section>
 
-    <section class="team-vault" id="team-vault" aria-labelledby="team-vault-title" hidden>
+    <section class="workspace-panel workspace-devices" id="workspace-devices" hidden>
+      <div class="vault-heading">
+        <div><p class="eyebrow">ACCOUNT DEVICES</p><h2>Устройства доступа</h2></div>
+        <p>Одобряйте только свои устройства и сравнивайте SHA-256 отпечаток на обоих экранах.</p>
+      </div>
+      <div class="team-devices-panel">
+        <div class="team-devices-heading">
+          <div><h3>Mac и браузеры</h3><p>Отзыв устройства немедленно завершает связанные сессии. Для Shared Vaults после отзыва потребуется ротация ключа.</p></div>
+          <button type="button" class="secondary" id="team-devices-refresh">Обновить устройства</button>
+        </div>
+        <div class="team-devices" id="team-devices"></div>
+      </div>
+    </section>
+
+    <section class="team-vault workspace-panel" id="team-vault" aria-labelledby="team-vault-title" hidden>
       <div class="vault-heading">
         <div>
           <p class="eyebrow">TEAM VAULTS · CLIENT-SIDE E2EE</p>
           <h2 id="team-vault-title">Командные хранилища</h2>
         </div>
         <p id="team-vault-message" aria-live="polite">Загрузка Teams…</p>
-      </div>
-
-      <div class="team-devices-panel">
-        <div class="team-devices-heading">
-          <div>
-            <h3>Устройства Team-доступа</h3>
-            <p>Перед одобрением сравните SHA-256 отпечаток на обоих устройствах. Отозванное устройство немедленно теряет сессии, а Shared Vaults требуют ротации.</p>
-          </div>
-          <button type="button" class="secondary" id="team-devices-refresh">Обновить устройства</button>
-        </div>
-        <div class="team-devices" id="team-devices"></div>
       </div>
 
       <div class="team-onboarding">
@@ -345,7 +409,10 @@
       </div>
     </section>
 
-    <section class="access">
+      </div>
+    </section>
+
+    <section class="access" id="public-access">
       <div><p class="eyebrow">V0.32 FOUNDATION</p><h2>Cloud управляется вами</h2></div>
       <p>Регистрация доступна только во время контролируемого окна. Вход, подтверждение почты и восстановление пароля остаются доступны для существующего аккаунта.</p>
     </section>

--- a/cloud/public/styles.css
+++ b/cloud/public/styles.css
@@ -6,7 +6,10 @@ body { margin:0; min-height:100vh; background:radial-gradient(circle at 70% 15%,
 .brand { display:flex; align-items:center; gap:14px; border-bottom:1px solid var(--line); padding-bottom:24px; }
 .mark { width:46px; height:46px; display:grid; place-items:center; border:1px solid var(--accent); color:var(--accent); border-radius:13px; font-weight:750; }
 .brand h1,.brand p { margin:0; }.brand h1 { font-size:22px; }.eyebrow { color:var(--accent); letter-spacing:.16em; font-size:11px; font-weight:750; }
-.status { margin-left:auto; color:var(--muted); font-size:13px; }.status.ok { color:var(--accent2); }
+.brand-actions { display:flex; gap:9px; margin-left:auto; }
+.brand-actions button,.hero-actions button,.workspace-welcome button { border:0; border-radius:11px; padding:11px 16px; background:var(--accent); color:#082016; font:inherit; font-weight:750; cursor:pointer; }
+.brand-actions button.secondary,.hero-actions button.secondary { border:1px solid var(--line); background:transparent; color:var(--ink); }
+.status { color:var(--muted); font-size:13px; }.status.ok { color:var(--accent2); }
 .verification { margin:32px 0 0; padding:30px; border:1px solid var(--line); border-radius:18px; background:#0c1714e8; }
 .verification h2 { margin:8px 0 10px; }.verification p:last-of-type { color:var(--muted); margin-bottom:20px; }
 .verification a { color:var(--accent2); font-weight:650; }.verification.success { border-color:#75e0b477; }.verification.error { border-color:#ff8f7a88; }
@@ -19,6 +22,13 @@ body { margin:0; min-height:100vh; background:radial-gradient(circle at 70% 15%,
 .lead { max-width:660px; color:var(--muted); line-height:1.65; font-size:18px; }
 .trust-row { display:flex; flex-wrap:wrap; gap:9px; margin-top:28px; }
 .trust-row span { padding:8px 11px; border:1px solid var(--line); border-radius:999px; color:#bdd0c9; background:#0c1714b8; font-size:12px; }
+.hero-actions { display:flex; flex-wrap:wrap; gap:10px; margin-top:24px; }
+.hero-preview { padding:30px; border:1px solid #75e0b452; border-radius:28px; background:linear-gradient(150deg,#11221ce8,#09120ff5); box-shadow:0 28px 80px #0006; }
+.hero-preview h3 { margin:9px 0 28px; font-size:28px; line-height:1.12; letter-spacing:-.035em; }
+.hero-preview-grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:10px; }
+.hero-preview-grid span { display:grid; gap:5px; min-height:96px; align-content:end; padding:16px; border:1px solid var(--line); border-radius:14px; background:#07100dbd; }
+.hero-preview-grid strong { font-size:17px; }.hero-preview-grid small { color:var(--muted); }
+.hero.auth-active { grid-template-columns:minmax(320px,560px); justify-content:center; min-height:680px; border-bottom:0; }
 .vault-visual { width:min(320px,75vw); aspect-ratio:1; position:relative; display:grid; place-items:center; margin:auto; }
 .orbit { position:absolute; inset:10%; border:1px solid #4a7a67; border-radius:42% 58% 63% 37%; animation:spin 18s linear infinite; }.orbit-two { inset:22%; border-color:#75e0b477; animation-direction:reverse; animation-duration:12s; }
 .vault-core { width:120px; height:120px; display:grid; place-content:center; text-align:center; border-radius:28px; background:linear-gradient(145deg,#a9ffc9,#78dcaa); color:#082016; box-shadow:0 0 70px #75e0b438; transform:rotate(-5deg); }
@@ -26,6 +36,7 @@ body { margin:0; min-height:100vh; background:radial-gradient(circle at 70% 15%,
 .grid { display:grid; grid-template-columns:repeat(3,1fr); gap:1px; background:var(--line); border:1px solid var(--line); margin:50px 0; }
 .grid article { background:var(--panel); padding:30px; min-height:210px; }.grid span { color:var(--accent); font-family:ui-monospace,monospace; }.grid h3 { margin:38px 0 12px; font-size:20px; }.grid p,.access p { color:var(--muted); line-height:1.55; }
 .auth-card { position:relative; overflow:hidden; padding:28px; border:1px solid #75e0b452; border-radius:24px; background:linear-gradient(150deg,#12221de8,#09120ff5); box-shadow:0 28px 80px #0007,0 0 0 1px #ffffff08 inset; }
+.auth-back { margin:0 0 22px; padding:0; border:0; background:transparent; color:var(--accent); font:inherit; font-weight:700; cursor:pointer; }
 .auth-card::before { content:""; position:absolute; width:180px; height:180px; right:-70px; top:-90px; border-radius:50%; background:#75e0b41f; filter:blur(8px); pointer-events:none; }
 .auth-card-heading { display:flex; align-items:center; gap:14px; position:relative; }
 .auth-card-heading h2 { margin:5px 0 0; font-size:25px; letter-spacing:-.025em; }
@@ -48,7 +59,20 @@ body { margin:0; min-height:100vh; background:radial-gradient(circle at 70% 15%,
 .auth-success { text-align:center; padding:18px 8px 8px; }.auth-success h3 { margin:12px 0 8px; }.auth-success p { color:var(--muted); line-height:1.5; }
 .auth-success-icon { width:54px; height:54px; display:grid; place-items:center; margin:auto; border-radius:50%; background:#75e0b424; color:var(--accent); font-size:27px; }
 .auth-card button.secondary { background:transparent; border:1px solid var(--line); color:var(--ink); }
-#cloud-signed-in { padding-top:10px; } #cloud-signed-in p { color:var(--ink); font-weight:700; }
+#cloud-signed-in { display:flex; align-items:center; gap:12px; } #cloud-signed-in p { margin:0; color:var(--ink); font-weight:700; }
+.workspace-layout { min-height:calc(100vh - 98px); display:grid; grid-template-columns:240px minmax(0,1fr); overflow:hidden; border:1px solid var(--line); border-radius:24px; background:#091310e8; box-shadow:0 30px 90px #0005; }
+.workspace-sidebar { display:flex; flex-direction:column; padding:24px 16px; border-right:1px solid var(--line); background:#07100ded; }
+.workspace-logo { display:flex; align-items:center; gap:11px; padding:0 8px 24px; }.workspace-logo span { width:38px; height:38px; display:grid; place-items:center; border:1px solid var(--accent); border-radius:11px; color:var(--accent); font-weight:800; }.workspace-logo strong { font-size:20px; }
+.workspace-sidebar nav { display:grid; gap:6px; }.workspace-sidebar nav button { width:100%; padding:12px 13px; border:0; border-radius:10px; background:transparent; color:var(--muted); font:inherit; font-weight:650; text-align:left; cursor:pointer; }.workspace-sidebar nav button:hover,.workspace-sidebar nav button.active { background:#75e0b419; color:var(--ink); }
+.workspace-security { margin-top:auto; padding:16px 10px 4px; border-top:1px solid var(--line); color:var(--muted); font-size:12px; }.workspace-security span { color:var(--accent2); }
+.workspace-main { min-width:0; padding:28px; }
+.workspace-header { display:flex; align-items:center; justify-content:space-between; gap:24px; padding-bottom:24px; border-bottom:1px solid var(--line); }.workspace-header h2 { margin:6px 0 0; font-size:28px; }.workspace-header .secondary { border:1px solid var(--line); border-radius:10px; padding:9px 13px; background:transparent; color:var(--ink); font:inherit; cursor:pointer; }
+.workspace-panel { margin:28px 0 0; padding:0; border:0; border-radius:0; background:transparent; }
+.workspace-welcome { display:flex; align-items:center; justify-content:space-between; gap:24px; padding:26px; border:1px solid var(--line); border-radius:18px; background:linear-gradient(135deg,#11251de8,#0a1512); }.workspace-welcome h2 { margin:7px 0 0; font-size:30px; }
+.workspace-stats { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:14px; margin-top:18px; }.workspace-stats button { display:grid; gap:7px; min-height:150px; padding:22px; border:1px solid var(--line); border-radius:16px; background:#08110e; color:var(--ink); font:inherit; text-align:left; cursor:pointer; }.workspace-stats button:hover { border-color:#75e0b478; background:#0d1b16; }.workspace-stats span { color:var(--accent); font:700 34px ui-monospace,monospace; }.workspace-stats strong { font-size:18px; }.workspace-stats small { color:var(--muted); }
+.workspace-notice { margin-top:18px; padding:20px 22px; border:1px solid #c8ff7847; border-radius:14px; background:#c8ff780a; }.workspace-notice strong { color:var(--accent2); }.workspace-notice p { margin:8px 0 0; color:var(--muted); line-height:1.55; }
+.workspace-devices { padding:0; }.workspace-devices>.vault-heading { padding:24px; border:1px solid var(--line); border-radius:16px; background:#08110e; }
+.record-filters { display:flex; flex-wrap:wrap; gap:8px; margin:22px 0 4px; }.record-filters button { border:1px solid var(--line); border-radius:999px; padding:8px 13px; background:transparent; color:var(--muted); font:inherit; font-size:13px; cursor:pointer; }.record-filters button.active { border-color:var(--accent); background:#75e0b419; color:var(--ink); }
 .local-vault { margin:50px 0; padding:34px; border:1px solid var(--line); border-radius:22px; background:#0c1714e8; }
 .team-vault { margin:50px 0; padding:34px; border:1px solid #75e0b45c; border-radius:22px; background:linear-gradient(145deg,#0c1714f2,#102019e8); }
 .team-onboarding,.team-columns { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:18px; margin-top:26px; }
@@ -104,7 +128,10 @@ body { margin:0; min-height:100vh; background:radial-gradient(circle at 70% 15%,
 .vault-conflicts legend { padding:0 6px; font-weight:750; }.vault-conflicts label { display:flex; gap:8px; align-items:flex-start; color:var(--ink); overflow-wrap:anywhere; }
 .vault-conflicts input { margin-top:3px; }.vault-conflicts button { border:0; border-radius:10px; padding:12px 18px; background:var(--accent); color:#082016; font:inherit; font-weight:750; cursor:pointer; }
 .vault-conflicts button:disabled { opacity:.6; cursor:not-allowed; }
+.local-vault.workspace-panel,.team-vault.workspace-panel { margin:28px 0 0; padding:0; border:0; border-radius:0; background:transparent; }
+.workspace-devices button { border:1px solid var(--line); border-radius:10px; padding:10px 14px; background:transparent; color:var(--ink); font:inherit; font-weight:700; cursor:pointer; }.workspace-devices button.danger { border-color:#ff8f7a66; color:#ffb4a6; }
 .access { display:flex; justify-content:space-between; gap:40px; align-items:end; padding:34px; border:1px solid var(--line); border-radius:18px; background:#0c1714cc; }.access h2 { margin:8px 0 0; }.access>p { max-width:500px; margin:0; }
 @keyframes spin { to { transform:rotate(360deg); } }
-@media (max-width:880px) { .shell{width:min(100% - 24px,1180px);padding-top:18px}.hero{grid-template-columns:1fr;padding:48px 0;gap:36px}.hero h2{font-size:clamp(40px,11vw,68px)}.auth-card{width:100%;max-width:560px}.vault-visual{width:230px}.grid,.team-onboarding,.team-columns,.team-lifecycle-forms{grid-template-columns:1fr}.vault-heading,.vault-toolbar,.access,.team-summary,.team-devices-heading{align-items:start;flex-direction:column}.vault-actions{justify-content:flex-start}.vault-panel form,.record-form{grid-template-columns:1fr}.vault-panel button,.record-form button{grid-column:1}.vault-records{grid-template-columns:1fr}.team-picker,.team-picker.compact{grid-template-columns:1fr}.team-members article,.team-devices article{grid-template-columns:1fr}.team-members strong,.team-members small,.team-members select,.team-members button,.team-members button.danger,.team-devices strong,.team-devices small,.team-device-fingerprint,.team-devices button,.team-devices button.danger{grid-column:1;grid-row:auto}.status{font-size:0}.status::after{content:"●";font-size:16px} }
+@media (max-width:880px) { .shell{width:min(100% - 24px,1180px);padding-top:18px}.brand{flex-wrap:wrap}.brand-actions{order:3;width:100%}.brand-actions button{flex:1}.status{margin-left:auto}.hero{grid-template-columns:1fr;padding:48px 0;gap:36px}.hero.auth-active{grid-template-columns:1fr;min-height:620px}.hero h2{font-size:clamp(40px,11vw,68px)}.hero-preview{padding:22px}.auth-card{width:100%;max-width:560px}.vault-visual{width:230px}.grid,.team-onboarding,.team-columns,.team-lifecycle-forms,.workspace-stats{grid-template-columns:1fr}.workspace-layout{grid-template-columns:1fr;min-height:0}.workspace-sidebar{border-right:0;border-bottom:1px solid var(--line)}.workspace-sidebar nav{grid-template-columns:repeat(2,minmax(0,1fr))}.workspace-security{display:none}.workspace-main{padding:20px}.workspace-header,.workspace-welcome{align-items:flex-start;flex-direction:column}.vault-heading,.vault-toolbar,.access,.team-summary,.team-devices-heading{align-items:start;flex-direction:column}.vault-actions{justify-content:flex-start}.vault-panel form,.record-form{grid-template-columns:1fr}.vault-panel button,.record-form button{grid-column:1}.vault-records{grid-template-columns:1fr}.team-picker,.team-picker.compact{grid-template-columns:1fr}.team-members article,.team-devices article{grid-template-columns:1fr}.team-members strong,.team-members small,.team-members select,.team-members button,.team-members button.danger,.team-devices strong,.team-devices small,.team-device-fingerprint,.team-devices button,.team-devices button.danger{grid-column:1;grid-row:auto}.status{font-size:0}.status::after{content:"●";font-size:16px} }
+@media (max-width:560px) { .workspace-sidebar nav{grid-template-columns:1fr}.workspace-main{padding:16px}.workspace-header{padding-bottom:18px}.hero-preview-grid{grid-template-columns:1fr}.auth-card{padding:22px}.workspace-welcome{padding:20px} }
 @media (prefers-reduced-motion:reduce) { .orbit{animation:none} }

--- a/cloud/src/server.mjs
+++ b/cloud/src/server.mjs
@@ -424,7 +424,7 @@ async function readJSON(request, maximumBytes = maxBodyBytes) {
 }
 
 async function serveStatic(pathname, response, head) {
-  const relative = pathname === "/" ? "index.html" : pathname.slice(1);
+  const relative = ["/", "/login", "/app"].includes(pathname) ? "index.html" : pathname.slice(1);
   if (!/^[a-zA-Z0-9._/-]+$/.test(relative) || relative.includes("..")) return sendError(response, 404, "not_found");
   try {
     const data = await readFile(join(publicDirectory, relative));

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -80,15 +80,20 @@ test("conflict choices expose only bounded metadata and never record secrets or 
   );
 });
 
-test("portal exposes memory-only login and explicit manual synchronization controls", async () => {
-  const [html, styles, application, synchronization, teamSynchronization] = await Promise.all([
+test("portal exposes separate public, authentication and workspace states", async () => {
+  const [html, styles, application, synchronization, teamSynchronization, server] = await Promise.all([
     readFile(new URL("../public/index.html", import.meta.url), "utf8"),
     readFile(new URL("../public/styles.css", import.meta.url), "utf8"),
     readFile(new URL("../public/app.js", import.meta.url), "utf8"),
     readFile(new URL("../public/vault-sync.js", import.meta.url), "utf8"),
     readFile(new URL("../public/team-vault-sync.js", import.meta.url), "utf8"),
+    readFile(new URL("../src/server.mjs", import.meta.url), "utf8"),
   ]);
 
+  assert.match(html, /id="cloud-account"[^>]*hidden/u);
+  assert.match(html, /id="cloud-workspace"[^>]*hidden/u);
+  assert.match(html, /data-open-auth="login"/u);
+  assert.match(html, /data-open-auth="registration"/u);
   assert.match(html, /id="cloud-login-form"/u);
   assert.match(html, /id="cloud-vault-sync"/u);
   assert.match(html, /id="cloud-logout"/u);
@@ -108,7 +113,20 @@ test("portal exposes memory-only login and explicit manual synchronization contr
   assert.match(html, /id="team-vault-rotate"[^>]*hidden/u);
   assert.match(html, /id="team-vault-record-form"/u);
   assert.match(html, /id="team-vault-conflicts-form"/u);
+  assert.match(html, /id="workspace-overview"/u);
+  assert.match(html, /data-workspace-target="local-vault"/u);
+  assert.match(html, /data-workspace-target="workspace-devices"/u);
+  assert.match(html, /data-record-filter="host"/u);
+  assert.match(html, /data-record-filter="credential"/u);
+  assert.match(html, /data-record-filter="snippet"/u);
+  assert.match(html, /data-record-filter="forwarding"/u);
+  assert.match(html, /Текущая версия macOS-клиента ещё не выполняет этот импорт автоматически/u);
   assert.match(styles, /\[hidden\]\s*\{\s*display:\s*none\s*!important;\s*\}/u);
+  assert.match(styles, /\.workspace-layout/u);
+  assert.match(application, /initializePortalNavigation/u);
+  assert.match(application, /setPath\("\/login"/u);
+  assert.match(application, /setPath\("\/app"/u);
+  assert.match(server, /\["\/", "\/login", "\/app"\]\.includes\(pathname\)/u);
   assert.match(application, /createAuthenticatedVaultClient/u);
   assert.match(application, /synchronizeVault/u);
   assert.match(application, /ensureTeamDeviceIdentity/u);


### PR DESCRIPTION
## Что меняется

- лендинг больше не показывает формы входа, регистрации и восстановления сразу;
- `/login` становится отдельным состоянием авторизации;
- успешный вход открывает отдельный Cloud Workspace на `/app`;
- добавлена навигация: Overview, Personal Vault, Teams/Vaults, Devices;
- Personal Vault разделён по Hosts, Credentials, Snippets и Forwarding со счётчиками;
- интерфейс явно сообщает, что импорт существующих данных с Mac ещё требует отдельной реализации;
- `/login` и `/app` безопасно отдаются через тот же статический entry point; bearer-сессия по-прежнему хранится только в памяти вкладки.

## Проверка

- `node --test tests/*.test.mjs`
- 239 passed, 0 failed, 1 skipped (`TEST_DATABASE_URL` не задан)

## Зависимость

Stacked поверх PR #59, который исправляет базовую семантику `hidden`. Публичный `main` этим PR не изменён.