### PR TITLE
Cloud roll-up: auth views and first encrypted macOS Personal Vault upload

### DIFF
--- a/Sources/SelectiveRemote/CloudAPIClient.swift
+++ b/Sources/SelectiveRemote/CloudAPIClient.swift
@@ -545,7 +545,7 @@ actor SelectiveRemoteCloudAPIClient {
         return data
     }
 
-    private func authorizedResponse(
+    func authorizedResponse(
         endpoint: URL,
         path: String,
         method: String = "GET",

--- a/Sources/SelectiveRemote/CloudPersonalVaultSync.swift
+++ b/Sources/SelectiveRemote/CloudPersonalVaultSync.swift
@@ -1,0 +1,472 @@
+import CommonCrypto
+import CryptoKit
+import Foundation
+import Security
+
+enum SelectiveRemotePersonalVaultError: LocalizedError, Equatable {
+    case invalidRecoveryPhrase
+    case invalidEnvelope
+    case cryptoFailure
+    case emptyLocalVault
+    case remoteVaultNotEmpty(Int)
+    case uploadConflict(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidRecoveryPhrase:
+            UpdateLocalization.text(
+                ru: "Recovery-фраза должна содержать от 16 до 1024 байт.",
+                en: "The recovery phrase must contain between 16 and 1024 bytes."
+            )
+        case .invalidEnvelope, .cryptoFailure:
+            UpdateLocalization.text(
+                ru: "Не удалось безопасно зашифровать Personal Vault.",
+                en: "Personal Vault could not be encrypted safely."
+            )
+        case .emptyLocalVault:
+            UpdateLocalization.text(
+                ru: "На этом Mac нет заполненных Hosts, Snippets или Forwarding для отправки.",
+                en: "This Mac has no populated Hosts, Snippets or Forwarding records to upload."
+            )
+        case let .remoteVaultNotEmpty(revision):
+            UpdateLocalization.text(
+                ru: "Cloud Vault уже содержит ревизию \(revision). Автоматическая перезапись остановлена; сначала требуется безопасное объединение.",
+                en: "Cloud Vault already contains revision \(revision). Automatic replacement was stopped; a safe merge is required first."
+            )
+        case let .uploadConflict(revision):
+            UpdateLocalization.text(
+                ru: "Cloud Vault изменился до ревизии \(revision). Локальные данные не перезаписаны.",
+                en: "Cloud Vault changed to revision \(revision). Local data was not replaced."
+            )
+        }
+    }
+}
+
+struct SelectiveRemotePersonalVaultWrappedKey: Codable, Equatable, Sendable {
+    let algorithm: String
+    let iterations: Int
+    let salt: String
+    let value: String
+
+    init(salt: Data, value: Data) throws {
+        guard salt.count == 16, value.count == 40 else {
+            throw SelectiveRemotePersonalVaultError.invalidEnvelope
+        }
+        algorithm = "PBKDF2-SHA256+A256KW"
+        iterations = 600_000
+        self.salt = salt.selectiveRemoteBase64URL
+        self.value = value.selectiveRemoteBase64URL
+    }
+}
+
+struct SelectiveRemotePersonalVaultEnvelope: Codable, Equatable, Sendable {
+    let baseRevision: Int
+    let envelopeVersion: Int
+    let wrappedKey: SelectiveRemotePersonalVaultWrappedKey
+    let ciphertext: String
+    let nonce: String
+    let authTag: String
+    let contentHash: String
+
+    init(
+        baseRevision: Int,
+        wrappedKey: SelectiveRemotePersonalVaultWrappedKey,
+        ciphertext: Data,
+        nonce: Data,
+        authTag: Data
+    ) throws {
+        guard baseRevision >= 0,
+              ciphertext.count <= 24 * 1024 * 1024,
+              nonce.count == 12,
+              authTag.count == 16
+        else { throw SelectiveRemotePersonalVaultError.invalidEnvelope }
+        self.baseRevision = baseRevision
+        envelopeVersion = 1
+        self.wrappedKey = wrappedKey
+        self.ciphertext = ciphertext.selectiveRemoteBase64URL
+        self.nonce = nonce.selectiveRemoteBase64URL
+        self.authTag = authTag.selectiveRemoteBase64URL
+        contentHash = Data(SHA256.hash(data: Data([1]) + nonce + ciphertext + authTag))
+            .selectiveRemoteBase64URL
+    }
+}
+
+struct SelectiveRemoteCloudPersonalVault: Equatable, Sendable {
+    let id: UUID
+    let revision: Int
+    let envelope: SelectiveRemotePersonalVaultEnvelope?
+    let updatedAt: String
+}
+
+struct SelectiveRemoteCloudPersonalVaultWriteResult: Equatable, Sendable {
+    let conflict: Bool
+    let revision: Int
+}
+
+struct SelectiveRemotePersonalVaultCredentialInput: Equatable, Sendable {
+    let sourceID: UUID
+    let kind: KeychainCredentialKind
+    let title: String
+    let username: String
+    let secret: String
+}
+
+struct SelectiveRemotePersonalVaultExportSummary: Equatable, Sendable {
+    let hosts: Int
+    let credentials: Int
+    let snippets: Int
+    let forwarding: Int
+
+    var total: Int { hosts + credentials + snippets + forwarding }
+}
+
+struct SelectiveRemotePersonalVaultExport: Equatable, Sendable {
+    let document: SelectiveRemoteVaultDocument
+    let summary: SelectiveRemotePersonalVaultExportSummary
+}
+
+enum SelectiveRemotePersonalVaultExporter {
+    static func makeExport(
+        profiles: [ConnectionProfile],
+        credentials: [SelectiveRemotePersonalVaultCredentialInput],
+        snippets: [TerminalCommandTemplate],
+        forwarding: [IndependentPortForward],
+        deviceID: UUID,
+        now: Date = Date()
+    ) throws -> SelectiveRemotePersonalVaultExport {
+        let timestamp = timestamp(now)
+        let version = try SelectiveRemoteVaultVersion([deviceID: 1])
+        let populatedProfiles = profiles.filter { profile in
+            !profile.host.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                || !profile.serialDevicePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        var records: [SelectiveRemoteVaultRecord] = try populatedProfiles.map { profile in
+            let address = profile.connectionType == .serial ? profile.serialDevicePath : profile.host
+            return try SelectiveRemoteVaultRecord(
+                id: profile.id,
+                type: .host,
+                version: version,
+                modifiedAt: timestamp,
+                data: .object([
+                    "title": .string(boundedTitle(profile.friendlyName, fallback: address)),
+                    "address": .string(address),
+                    "username": .string(profile.username),
+                    "connectionType": .string(profile.connectionType.rawValue),
+                    "profile": .string(try encoded(profile))
+                ])
+            )
+        }
+        records += try credentials.map { credential in
+            try SelectiveRemoteVaultRecord(
+                id: derivedID(sourceID: credential.sourceID, discriminator: "credential:\(credential.kind.rawValue)"),
+                type: .credential,
+                version: version,
+                modifiedAt: timestamp,
+                data: .object([
+                    "title": .string(boundedTitle(credential.title, fallback: credential.kind.rawValue)),
+                    "username": .string(credential.username),
+                    "secret": .string(credential.secret),
+                    "kind": .string(credential.kind.rawValue),
+                    "sourceID": .string(credential.sourceID.canonicalCloudString)
+                ])
+            )
+        }
+        records += try snippets.map { snippet in
+            try SelectiveRemoteVaultRecord(
+                id: snippet.id,
+                type: .snippet,
+                version: version,
+                modifiedAt: timestamp,
+                data: .object([
+                    "title": .string(boundedTitle(snippet.title, fallback: "Snippet")),
+                    "body": .string(snippet.command),
+                    "category": .string(snippet.category),
+                    "template": .string(try encoded(snippet))
+                ])
+            )
+        }
+        records += try forwarding.map { item in
+            let destination = item.rule.kind == .dynamic
+                ? "\(item.rule.bindAddress):\(item.rule.sourcePort)"
+                : "\(item.rule.destinationHost):\(item.rule.destinationPort)"
+            return try SelectiveRemoteVaultRecord(
+                id: item.id,
+                type: .forwarding,
+                version: version,
+                modifiedAt: timestamp,
+                data: .object([
+                    "title": .string(boundedTitle(item.rule.displayName, fallback: "Forwarding")),
+                    "destination": .string(destination),
+                    "configuration": .string(try encoded(item)),
+                    "kind": .string(item.rule.kind.rawValue)
+                ])
+            )
+        }
+        let document = try SelectiveRemoteVaultDocument(records: records)
+        let summary = SelectiveRemotePersonalVaultExportSummary(
+            hosts: populatedProfiles.count,
+            credentials: credentials.count,
+            snippets: snippets.count,
+            forwarding: forwarding.count
+        )
+        guard summary.total > 0 else { throw SelectiveRemotePersonalVaultError.emptyLocalVault }
+        return .init(document: document, summary: summary)
+    }
+
+    private static func encoded<T: Encodable>(_ value: T) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(value).selectiveRemoteBase64URL
+    }
+
+    private static func boundedTitle(_ value: String, fallback: String) -> String {
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        let selected = normalized.isEmpty ? fallback : normalized
+        return String(selected.prefix(120))
+    }
+
+    private static func timestamp(_ value: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: value)
+    }
+
+    private static func derivedID(sourceID: UUID, discriminator: String) -> UUID {
+        var bytes = Array(SHA256.hash(data: Data("selective-remote/personal-vault/v1\0\(sourceID.canonicalCloudString)\0\(discriminator)".utf8)).prefix(16))
+        bytes[6] = (bytes[6] & 0x0f) | 0x50
+        bytes[8] = (bytes[8] & 0x3f) | 0x80
+        return UUID(uuid: (
+            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]
+        ))
+    }
+}
+
+enum SelectiveRemotePersonalVaultCrypto {
+    static let recoveryIterations: UInt32 = 600_000
+    private static let additionalData = Data("selective-remote:vault-envelope:v1".utf8)
+
+    static func seal(
+        _ document: SelectiveRemoteVaultDocument,
+        recoveryPhrase: String,
+        baseRevision: Int,
+        vaultKey: Data? = nil,
+        salt: Data? = nil,
+        nonce: Data? = nil
+    ) throws -> SelectiveRemotePersonalVaultEnvelope {
+        let normalized = recoveryPhrase.precomposedStringWithCanonicalMapping
+        let phrase = Data(normalized.utf8)
+        guard (16...1_024).contains(phrase.count), baseRevision >= 0 else {
+            throw SelectiveRemotePersonalVaultError.invalidRecoveryPhrase
+        }
+        let rawVaultKey = try vaultKey ?? randomData(count: 32)
+        let rawSalt = try salt ?? randomData(count: 16)
+        let rawNonce = try nonce ?? randomData(count: 12)
+        guard rawVaultKey.count == 32, rawSalt.count == 16, rawNonce.count == 12 else {
+            throw SelectiveRemotePersonalVaultError.invalidEnvelope
+        }
+        let recoveryKey = try deriveKey(password: phrase, salt: rawSalt)
+        let wrapped = try wrapRFC3394(rawVaultKey, keyEncryptionKey: recoveryKey)
+        do {
+            let sealed = try AES.GCM.seal(
+                document.encoded(),
+                using: SymmetricKey(data: rawVaultKey),
+                nonce: AES.GCM.Nonce(data: rawNonce),
+                authenticating: additionalData
+            )
+            return try .init(
+                baseRevision: baseRevision,
+                wrappedKey: .init(salt: rawSalt, value: wrapped),
+                ciphertext: sealed.ciphertext,
+                nonce: rawNonce,
+                authTag: sealed.tag
+            )
+        } catch let error as SelectiveRemotePersonalVaultError {
+            throw error
+        } catch {
+            throw SelectiveRemotePersonalVaultError.cryptoFailure
+        }
+    }
+
+    static func wrapRFC3394(_ value: Data, keyEncryptionKey: Data) throws -> Data {
+        guard keyEncryptionKey.count == 32, value.count >= 16, value.count.isMultiple(of: 8) else {
+            throw SelectiveRemotePersonalVaultError.invalidEnvelope
+        }
+        let blockCount = value.count / 8
+        var accumulator = Data(repeating: 0xa6, count: 8)
+        var blocks = stride(from: 0, to: value.count, by: 8).map { offset in
+            Data(value[offset..<offset + 8])
+        }
+        for round in 0..<6 {
+            for index in 0..<blockCount {
+                let encrypted = try encryptAESBlock(accumulator + blocks[index], key: keyEncryptionKey)
+                var nextAccumulator = Data(encrypted.prefix(8))
+                var counter = UInt64(blockCount * round + index + 1).bigEndian
+                withUnsafeBytes(of: &counter) { counterBytes in
+                    for offset in 0..<8 { nextAccumulator[offset] ^= counterBytes[offset] }
+                }
+                accumulator = nextAccumulator
+                blocks[index] = Data(encrypted.suffix(8))
+            }
+        }
+        return blocks.reduce(into: accumulator) { $0.append($1) }
+    }
+
+    private static func deriveKey(password: Data, salt: Data) throws -> Data {
+        var derived = Data(count: 32)
+        let outputLength = derived.count
+        let status = derived.withUnsafeMutableBytes { output in
+            password.withUnsafeBytes { passwordBytes in
+                salt.withUnsafeBytes { saltBytes in
+                    CCKeyDerivationPBKDF(
+                        CCPBKDFAlgorithm(kCCPBKDF2),
+                        passwordBytes.baseAddress?.assumingMemoryBound(to: Int8.self),
+                        password.count,
+                        saltBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                        salt.count,
+                        CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA256),
+                        recoveryIterations,
+                        output.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                        outputLength
+                    )
+                }
+            }
+        }
+        guard status == kCCSuccess else { throw SelectiveRemotePersonalVaultError.cryptoFailure }
+        return derived
+    }
+
+    private static func encryptAESBlock(_ block: Data, key: Data) throws -> Data {
+        guard block.count == kCCBlockSizeAES128, key.count == kCCKeySizeAES256 else {
+            throw SelectiveRemotePersonalVaultError.invalidEnvelope
+        }
+        var output = Data(count: kCCBlockSizeAES128)
+        var moved = 0
+        let outputCapacity = output.count
+        let status = output.withUnsafeMutableBytes { outputBytes in
+            block.withUnsafeBytes { blockBytes in
+                key.withUnsafeBytes { keyBytes in
+                    CCCrypt(
+                        CCOperation(kCCEncrypt),
+                        CCAlgorithm(kCCAlgorithmAES),
+                        CCOptions(kCCOptionECBMode),
+                        keyBytes.baseAddress,
+                        key.count,
+                        nil,
+                        blockBytes.baseAddress,
+                        block.count,
+                        outputBytes.baseAddress,
+                        outputCapacity,
+                        &moved
+                    )
+                }
+            }
+        }
+        guard status == kCCSuccess, moved == kCCBlockSizeAES128 else {
+            throw SelectiveRemotePersonalVaultError.cryptoFailure
+        }
+        return output
+    }
+
+    private static func randomData(count: Int) throws -> Data {
+        var value = Data(count: count)
+        let status = value.withUnsafeMutableBytes { bytes in
+            SecRandomCopyBytes(kSecRandomDefault, count, bytes.baseAddress!)
+        }
+        guard status == errSecSuccess else { throw SelectiveRemotePersonalVaultError.cryptoFailure }
+        return value
+    }
+}
+
+extension SelectiveRemoteCloudAPIClient {
+    func personalVault(endpoint: URL) async throws -> SelectiveRemoteCloudPersonalVault {
+        let (data, response) = try await authorizedResponse(endpoint: endpoint, path: "v1/vault")
+        guard (200..<300).contains(response.statusCode),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              Set(object.keys) == [
+                "id", "revision", "envelopeVersion", "wrappedKey", "ciphertext",
+                "nonce", "authTag", "contentHash", "updatedAt"
+              ],
+              let idText = object["id"] as? String,
+              let id = UUID(uuidString: idText),
+              id.isSelectiveRemoteCloudUUID,
+              let revision = object["revision"] as? Int,
+              revision >= 0,
+              let updatedAt = object["updatedAt"] as? String,
+              !updatedAt.isEmpty
+        else {
+            if !(200..<300).contains(response.statusCode) {
+                throw SelectiveRemoteCloudError.serviceError(response.statusCode, nil)
+            }
+            throw SelectiveRemoteCloudError.invalidResponse
+        }
+        if revision == 0 {
+            let emptyKeys = ["envelopeVersion", "wrappedKey", "ciphertext", "nonce", "authTag", "contentHash"]
+            guard emptyKeys.allSatisfy({ object[$0] is NSNull }) else {
+                throw SelectiveRemoteCloudError.invalidResponse
+            }
+            return .init(id: id, revision: 0, envelope: nil, updatedAt: updatedAt)
+        }
+        do {
+            let decoder = JSONDecoder()
+            guard object["envelopeVersion"] as? Int == 1,
+                  let wrappedObject = object["wrappedKey"] as? [String: Any],
+                  Set(wrappedObject.keys) == ["algorithm", "iterations", "salt", "value"]
+            else { throw SelectiveRemoteCloudError.invalidResponse }
+            let wrappedData = try JSONSerialization.data(withJSONObject: wrappedObject)
+            let wrapped = try decoder.decode(SelectiveRemotePersonalVaultWrappedKey.self, from: wrappedData)
+            guard wrapped.algorithm == "PBKDF2-SHA256+A256KW", wrapped.iterations == 600_000,
+                  Data(selectiveRemoteBase64URL: wrapped.salt, expectedLength: 16) != nil,
+                  Data(selectiveRemoteBase64URL: wrapped.value, expectedLength: 40) != nil,
+                  let ciphertext = Data(selectiveRemoteBase64URL: object["ciphertext"] as? String ?? ""),
+                  ciphertext.count <= 24 * 1024 * 1024,
+                  let nonce = Data(selectiveRemoteBase64URL: object["nonce"] as? String ?? "", expectedLength: 12),
+                  let authTag = Data(selectiveRemoteBase64URL: object["authTag"] as? String ?? "", expectedLength: 16),
+                  Data(selectiveRemoteBase64URL: object["contentHash"] as? String ?? "", expectedLength: 32) != nil
+            else { throw SelectiveRemoteCloudError.invalidResponse }
+            let envelope = try SelectiveRemotePersonalVaultEnvelope(
+                baseRevision: revision - 1,
+                wrappedKey: wrapped,
+                ciphertext: ciphertext,
+                nonce: nonce,
+                authTag: authTag
+            )
+            guard envelope.contentHash == object["contentHash"] as? String else {
+                throw SelectiveRemoteCloudError.invalidResponse
+            }
+            return .init(id: id, revision: revision, envelope: envelope, updatedAt: updatedAt)
+        } catch let error as SelectiveRemoteCloudError {
+            throw error
+        } catch {
+            throw SelectiveRemoteCloudError.invalidResponse
+        }
+    }
+
+    func putPersonalVault(
+        endpoint: URL,
+        envelope: SelectiveRemotePersonalVaultEnvelope
+    ) async throws -> SelectiveRemoteCloudPersonalVaultWriteResult {
+        let body = try JSONEncoder().encode(envelope)
+        let (data, response) = try await authorizedResponse(
+            endpoint: endpoint,
+            path: "v1/vault",
+            method: "PUT",
+            body: body
+        )
+        guard response.statusCode == 200 || response.statusCode == 409,
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              Set(object.keys) == ["conflict", "revision"],
+              let conflict = object["conflict"] as? Bool,
+              let revision = object["revision"] as? Int,
+              revision >= 0,
+              conflict == (response.statusCode == 409)
+        else {
+            if !(200..<300).contains(response.statusCode), response.statusCode != 409 {
+                throw SelectiveRemoteCloudError.serviceError(response.statusCode, nil)
+            }
+            throw SelectiveRemoteCloudError.invalidResponse
+        }
+        return .init(conflict: conflict, revision: revision)
+    }
+}

--- a/Sources/SelectiveRemote/CloudSettingsView.swift
+++ b/Sources/SelectiveRemote/CloudSettingsView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct CloudSettingsView: View {
+    @ObservedObject var model: AppModel
+
     @AppStorage("SelectiveRemote.cloud.endpoint.v1")
     private var endpoint = SelectiveRemoteCloudEndpoint.production
     @AppStorage("SelectiveRemote.cloud.device-id.v1")
@@ -22,6 +24,14 @@ struct CloudSettingsView: View {
     @State private var accountSheetMode = AccountSheetMode.signIn
     @State private var showsConflictReview = false
     @State private var conflictReviewMessage: String?
+    @State private var personalVaultRevision: Int?
+    @State private var personalVaultMessage: String?
+    @State private var personalVaultMessageIsError = false
+    @State private var personalVaultUploading = false
+    @State private var showsPersonalVaultUpload = false
+    @State private var personalVaultRecoveryPhrase = ""
+    @State private var personalVaultRecoveryConfirmation = ""
+    @State private var includePersonalVaultCredentials = false
 
     private let client = SelectiveRemoteCloudAPIClient()
     private let identityManager = SelectiveRemoteTeamDeviceIdentityManager()
@@ -160,6 +170,51 @@ struct CloudSettingsView: View {
             }
 
             if accountUser != nil {
+                Section("Personal Vault") {
+                    LabeledContent(UpdateLocalization.text(ru: "Ревизия в Cloud", en: "Cloud revision")) {
+                        Text(personalVaultRevision.map { "r\($0)" } ?? "—")
+                            .monospacedDigit()
+                    }
+                    LabeledContent(UpdateLocalization.text(ru: "Локальные данные", en: "Local data")) {
+                        Text(localPersonalVaultSummary)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Button(
+                        UpdateLocalization.text(
+                            ru: "Зашифровать и отправить локальные данные…",
+                            en: "Encrypt and Upload Local Data…"
+                        ),
+                        systemImage: "lock.doc.fill"
+                    ) {
+                        personalVaultMessage = nil
+                        personalVaultMessageIsError = false
+                        showsPersonalVaultUpload = true
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(personalVaultUploading || personalVaultRevision != 0)
+
+                    if let personalVaultMessage {
+                        Label(
+                            personalVaultMessage,
+                            systemImage: personalVaultMessageIsError
+                                ? "exclamationmark.triangle.fill"
+                                : "checkmark.circle.fill"
+                        )
+                        .foregroundStyle(personalVaultMessageIsError ? Color.orange : Color.green)
+                        .font(.caption)
+                        .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    Text(UpdateLocalization.text(
+                        ru: "Первая отправка доступна только для пустого Cloud Vault. Recovery-фраза и открытые данные не сохраняются на сервере; существующая ревизия никогда не перезаписывается этим действием.",
+                        en: "The first upload is available only for an empty Cloud Vault. The recovery phrase and plaintext are never stored on the server; this action never replaces an existing revision."
+                    ))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                }
+
                 SelectiveRemoteCloudTeamInventoryView(
                     teams: teams,
                     vaultsByTeam: vaultsByTeam,
@@ -222,6 +277,9 @@ struct CloudSettingsView: View {
         }
         .sheet(isPresented: $showsConflictReview) {
             conflictReviewSheet
+        }
+        .sheet(isPresented: $showsPersonalVaultUpload) {
+            personalVaultUploadSheet
         }
     }
 
@@ -473,6 +531,8 @@ struct CloudSettingsView: View {
         accountPhase = .refreshing
         inventoryErrorMessage = nil
         do {
+            let personalVault = try await client.personalVault(endpoint: url)
+            personalVaultRevision = personalVault.revision
             let loadedTeams = try await client.teams(endpoint: url)
             var loadedVaults: [UUID: [SelectiveRemoteCloudSharedVault]] = [:]
             for team in loadedTeams {
@@ -490,6 +550,7 @@ struct CloudSettingsView: View {
             }
             teams = []
             vaultsByTeam = [:]
+            personalVaultRevision = nil
             inventoryErrorMessage = error.localizedDescription
         }
         accountPhase = .signedIn
@@ -517,6 +578,9 @@ struct CloudSettingsView: View {
         accountUser = nil
         teams = []
         vaultsByTeam = [:]
+        personalVaultRevision = nil
+        personalVaultMessage = nil
+        personalVaultMessageIsError = false
         accountErrorMessage = nil
         inventoryErrorMessage = nil
     }
@@ -529,6 +593,236 @@ struct CloudSettingsView: View {
         let generated = UUID()
         storedDeviceID = generated.canonicalCloudString
         return generated
+    }
+
+    @MainActor
+    private var localPersonalVaultSummary: String {
+        let hosts = model.profiles.filter {
+            !$0.host.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                || !$0.serialDevicePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }.count
+        let snippets = TerminalCommandHistoryStore.shared.templates().count
+        let forwarding = model.independentPortForwards.count
+        return UpdateLocalization.text(
+            ru: "Hosts: \(hosts) · Snippets: \(snippets) · Forwarding: \(forwarding)",
+            en: "Hosts: \(hosts) · Snippets: \(snippets) · Forwarding: \(forwarding)"
+        )
+    }
+
+    @MainActor @ViewBuilder
+    private var personalVaultUploadSheet: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Text(UpdateLocalization.text(ru: "Первая отправка Personal Vault", en: "First Personal Vault Upload"))
+                .font(.title2.bold())
+            Text(UpdateLocalization.text(
+                ru: "Придумайте отдельную recovery-фразу длиной не менее 16 символов. Она шифрует ключ Vault на этом Mac и не отправляется в Cloud. Сохраните её в надёжном месте: восстановить её на сервере нельзя.",
+                en: "Create a separate recovery phrase of at least 16 characters. It protects the Vault key on this Mac and is never sent to Cloud. Keep it somewhere safe: the server cannot recover it."
+            ))
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+            SecureField(
+                UpdateLocalization.text(ru: "Recovery-фраза", en: "Recovery phrase"),
+                text: $personalVaultRecoveryPhrase
+            )
+            .textFieldStyle(.roundedBorder)
+            SecureField(
+                UpdateLocalization.text(ru: "Повторите recovery-фразу", en: "Confirm recovery phrase"),
+                text: $personalVaultRecoveryConfirmation
+            )
+            .textFieldStyle(.roundedBorder)
+
+            Toggle(
+                UpdateLocalization.text(
+                    ru: "Добавить сохранённые пароли (потребуется Touch ID или пароль Mac)",
+                    en: "Include saved passwords (Touch ID or Mac password required)"
+                ),
+                isOn: $includePersonalVaultCredentials
+            )
+
+            if personalVaultUploading {
+                HStack(spacing: 8) {
+                    ProgressView().controlSize(.small)
+                    Text(UpdateLocalization.text(ru: "Шифрование и отправка…", en: "Encrypting and uploading…"))
+                }
+                .foregroundStyle(.secondary)
+            }
+
+            if let personalVaultMessage, personalVaultMessageIsError {
+                Label(personalVaultMessage, systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .font(.caption)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack {
+                Spacer()
+                Button(UpdateLocalization.text(ru: "Отмена", en: "Cancel")) {
+                    closePersonalVaultUploadSheet()
+                }
+                .disabled(personalVaultUploading)
+                Button(UpdateLocalization.text(ru: "Зашифровать и отправить", en: "Encrypt and Upload")) {
+                    uploadPersonalVault()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(
+                    personalVaultUploading
+                        || personalVaultRecoveryPhrase.utf8.count < 16
+                        || personalVaultRecoveryPhrase != personalVaultRecoveryConfirmation
+                )
+            }
+        }
+        .padding(24)
+        .frame(width: 540)
+    }
+
+    @MainActor
+    private func closePersonalVaultUploadSheet() {
+        guard !personalVaultUploading else { return }
+        personalVaultRecoveryPhrase = ""
+        personalVaultRecoveryConfirmation = ""
+        includePersonalVaultCredentials = false
+        showsPersonalVaultUpload = false
+    }
+
+    @MainActor
+    private func uploadPersonalVault() {
+        let recoveryPhrase = personalVaultRecoveryPhrase
+        guard recoveryPhrase == personalVaultRecoveryConfirmation,
+              (16...1_024).contains(recoveryPhrase.precomposedStringWithCanonicalMapping.utf8.count),
+              let url = try? SelectiveRemoteCloudEndpoint.normalized(endpoint),
+              accountUser != nil
+        else {
+            personalVaultMessage = SelectiveRemotePersonalVaultError.invalidRecoveryPhrase.localizedDescription
+            personalVaultMessageIsError = true
+            return
+        }
+
+        personalVaultUploading = true
+        personalVaultMessage = nil
+        personalVaultMessageIsError = false
+        Task { @MainActor in
+            do {
+                let remote = try await client.personalVault(endpoint: url)
+                guard remote.revision == 0 else {
+                    throw SelectiveRemotePersonalVaultError.remoteVaultNotEmpty(remote.revision)
+                }
+                let credentials = try await personalVaultCredentialsIfRequested()
+                let exported = try SelectiveRemotePersonalVaultExporter.makeExport(
+                    profiles: model.profiles,
+                    credentials: credentials,
+                    snippets: TerminalCommandHistoryStore.shared.templates(),
+                    forwarding: model.independentPortForwards,
+                    deviceID: resolvedDeviceID()
+                )
+                let document = exported.document
+                let envelope = try await Task.detached(priority: .userInitiated) {
+                    try SelectiveRemotePersonalVaultCrypto.seal(
+                        document,
+                        recoveryPhrase: recoveryPhrase,
+                        baseRevision: 0
+                    )
+                }.value
+                let result = try await client.putPersonalVault(endpoint: url, envelope: envelope)
+                guard !result.conflict else {
+                    throw SelectiveRemotePersonalVaultError.uploadConflict(result.revision)
+                }
+                personalVaultRevision = result.revision
+                personalVaultMessage = UpdateLocalization.text(
+                    ru: "Personal Vault отправлен: Hosts \(exported.summary.hosts), Credentials \(exported.summary.credentials), Snippets \(exported.summary.snippets), Forwarding \(exported.summary.forwarding). Ревизия r\(result.revision).",
+                    en: "Personal Vault uploaded: Hosts \(exported.summary.hosts), Credentials \(exported.summary.credentials), Snippets \(exported.summary.snippets), Forwarding \(exported.summary.forwarding). Revision r\(result.revision)."
+                )
+                personalVaultMessageIsError = false
+                personalVaultUploading = false
+                closePersonalVaultUploadSheet()
+            } catch {
+                personalVaultUploading = false
+                personalVaultMessage = error.localizedDescription
+                personalVaultMessageIsError = true
+            }
+        }
+    }
+
+    @MainActor
+    private func personalVaultCredentialsIfRequested() async throws
+        -> [SelectiveRemotePersonalVaultCredentialInput]
+    {
+        guard includePersonalVaultCredentials else { return [] }
+        try await KeychainService.authenticateDeviceOwner(reason: UpdateLocalization.text(
+            ru: "Разрешить Selective Remote прочитать сохранённые пароли для шифрования Personal Vault",
+            en: "Allow Selective Remote to read saved passwords for Personal Vault encryption"
+        ))
+        var result: [SelectiveRemotePersonalVaultCredentialInput] = []
+        for profile in model.profiles {
+            switch profile.connectionType {
+            case .rdp:
+                try appendPersonalVaultCredential(
+                    to: &result,
+                    sourceID: profile.id,
+                    kind: .rdp,
+                    title: "\(profile.friendlyName) · RDP",
+                    username: profile.username
+                )
+                if !profile.gatewayHost.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    try appendPersonalVaultCredential(
+                        to: &result,
+                        sourceID: profile.id,
+                        kind: .gateway,
+                        title: "\(profile.friendlyName) · Gateway",
+                        username: profile.gatewayUsername
+                    )
+                }
+            case .ssh, .telnet:
+                try appendPersonalVaultCredential(
+                    to: &result,
+                    sourceID: profile.id,
+                    kind: .ssh,
+                    title: "\(profile.friendlyName) · \(profile.connectionType.title)",
+                    username: profile.username
+                )
+                if profile.sshProxyMode != .none {
+                    try appendPersonalVaultCredential(
+                        to: &result,
+                        sourceID: profile.id,
+                        kind: .proxy,
+                        title: "\(profile.friendlyName) · Proxy",
+                        username: profile.sshProxyUsername
+                    )
+                }
+            case .serial:
+                break
+            }
+        }
+        for forwarding in model.independentPortForwards {
+            try appendPersonalVaultCredential(
+                to: &result,
+                sourceID: forwarding.id,
+                kind: .forwarding,
+                title: "\(forwarding.rule.displayName) · Forwarding",
+                username: forwarding.connection.username
+            )
+        }
+        return result
+    }
+
+    @MainActor
+    private func appendPersonalVaultCredential(
+        to values: inout [SelectiveRemotePersonalVaultCredentialInput],
+        sourceID: UUID,
+        kind: KeychainCredentialKind,
+        title: String,
+        username: String
+    ) throws {
+        guard let secret = try KeychainService.readPassword(profileID: sourceID, kind: kind),
+              !secret.isEmpty
+        else { return }
+        values.append(.init(
+            sourceID: sourceID,
+            kind: kind,
+            title: title,
+            username: username,
+            secret: secret
+        ))
     }
 
     @ViewBuilder

--- a/Sources/SelectiveRemote/UpdateExperienceView.swift
+++ b/Sources/SelectiveRemote/UpdateExperienceView.swift
@@ -22,7 +22,7 @@ struct AppSettingsView: View {
             AppLockSettingsView(store: appLock)
                 .tabItem { Label("Безопасность", systemImage: "lock.shield") }
 
-            CloudSettingsView()
+            CloudSettingsView(model: model)
                 .tabItem { Label("Cloud", systemImage: "cloud") }
 
             BackupSettingsView(model: model)

--- a/Tests/SelectiveRemoteTests/CloudPersonalVaultSyncTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudPersonalVaultSyncTests.swift
@@ -86,7 +86,7 @@ struct CloudPersonalVaultSyncTests {
             #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer \(token)")
             switch (request.httpMethod, request.url?.path) {
             case ("GET", "/v1/vault"):
-                return Self.response(request, status: 200, json: [
+                return try Self.response(request, status: 200, json: [
                     "id": vaultID.canonicalCloudString,
                     "revision": 0,
                     "envelopeVersion": NSNull(),
@@ -108,10 +108,10 @@ struct CloudPersonalVaultSyncTests {
                 let wrappedKey = try #require(object["wrappedKey"] as? [String: Any])
                 #expect(Set(wrappedKey.keys) == ["algorithm", "iterations", "salt", "value"])
                 #expect(object["baseRevision"] as? Int == 0)
-                return Self.response(request, status: 200, json: ["conflict": false, "revision": 1])
+                return try Self.response(request, status: 200, json: ["conflict": false, "revision": 1])
             default:
                 Issue.record("Unexpected request: \(request.httpMethod ?? "nil") \(request.url?.path ?? "nil")")
-                return Self.response(request, status: 500, json: ["error": "unexpected_request"])
+                return try Self.response(request, status: 500, json: ["error": "unexpected_request"])
             }
         }
         let client = SelectiveRemoteCloudAPIClient(
@@ -124,7 +124,7 @@ struct CloudPersonalVaultSyncTests {
         #expect(remote.revision == 0)
         #expect(remote.envelope == nil)
 
-        let document = try SelectiveRemoteVaultDocument(records: [try syntheticRecord()])
+        let document = try SelectiveRemoteVaultDocument(records: [Self.syntheticRecord()])
         let envelope = try SelectiveRemotePersonalVaultCrypto.seal(
             document,
             recoveryPhrase: "correct horse battery staple",
@@ -147,7 +147,7 @@ struct CloudPersonalVaultSyncTests {
         let endpoint = try SelectiveRemoteCloudEndpoint.normalized("https://cloud.example.invalid")
         let tokenStore = SelectiveRemoteCloudMemoryTokenStore()
         try tokenStore.saveToken(String(repeating: "t", count: 43), for: endpoint)
-        let document = try SelectiveRemoteVaultDocument(records: [try syntheticRecord()])
+        let document = try SelectiveRemoteVaultDocument(records: [Self.syntheticRecord()])
         let envelope = try SelectiveRemotePersonalVaultCrypto.seal(
             document,
             recoveryPhrase: "correct horse battery staple",
@@ -159,7 +159,7 @@ struct CloudPersonalVaultSyncTests {
         let client = SelectiveRemoteCloudAPIClient(
             tokenStore: tokenStore,
             dataLoader: { request in
-                Self.response(request, status: 200, json: [
+                try Self.response(request, status: 200, json: [
                     "id": "77777777-7777-4777-8777-777777777777",
                     "revision": 1,
                     "envelopeVersion": 1,
@@ -202,14 +202,20 @@ struct CloudPersonalVaultSyncTests {
         json: Any?
     ) throws -> (Data, URLResponse) {
         let data = try json.map { try JSONSerialization.data(withJSONObject: $0) } ?? Data()
-        let response = try #require(HTTPURLResponse(
-            url: try #require(request.url),
+        guard let url = request.url,
+              let response = HTTPURLResponse(
+            url: url,
             statusCode: status,
             httpVersion: nil,
             headerFields: ["Content-Type": "application/json"]
-        ))
+              )
+        else { throw PersonalVaultTestError.invalidHTTPResponse }
         return (data, response)
     }
+}
+
+private enum PersonalVaultTestError: Error {
+    case invalidHTTPResponse
 }
 
 private final class PersonalVaultHTTPStub: @unchecked Sendable {

--- a/Tests/SelectiveRemoteTests/CloudPersonalVaultSyncTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudPersonalVaultSyncTests.swift
@@ -1,0 +1,241 @@
+import Foundation
+import Testing
+@testable import SelectiveRemote
+
+@Suite("macOS Personal Vault first upload")
+struct CloudPersonalVaultSyncTests {
+    @Test("AES-256 key wrap matches the RFC 3394 vector")
+    func aesKeyWrapVector() throws {
+        let keyEncryptionKey = try #require(Data(hex: "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"))
+        let vaultKey = try #require(Data(hex: "00112233445566778899aabbccddeeff"))
+        let expected = try #require(Data(hex: "64e8c3f9ce0f5ba263e9777905818a2a93c8191e7d6e8ae7"))
+
+        #expect(try SelectiveRemotePersonalVaultCrypto.wrapRFC3394(
+            vaultKey,
+            keyEncryptionKey: keyEncryptionKey
+        ) == expected)
+    }
+
+    @Test("export maps local records and the envelope contains no plaintext")
+    func ciphertextOnlyExport() async throws {
+        let deviceID = try #require(UUID(uuidString: "44444444-4444-4444-8444-444444444444"))
+        let profileID = try #require(UUID(uuidString: "11111111-1111-4111-8111-111111111111"))
+        let snippetID = try #require(UUID(uuidString: "22222222-2222-4222-8222-222222222222"))
+        var profile = ConnectionProfile(connectionType: .ssh)
+        profile.id = profileID
+        profile.friendlyName = "Production Host"
+        profile.host = "host.example.invalid"
+        profile.username = "operator"
+        let snippet = TerminalCommandTemplate(
+            id: snippetID,
+            profileID: profileID,
+            title: "Deploy",
+            command: "synthetic-secret-command",
+            category: "Operations",
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        let exported = try SelectiveRemotePersonalVaultExporter.makeExport(
+            profiles: [profile],
+            credentials: [.init(
+                sourceID: profileID,
+                kind: .ssh,
+                title: "Production Host · SSH",
+                username: "operator",
+                secret: "synthetic-secret-password"
+            )],
+            snippets: [snippet],
+            forwarding: [],
+            deviceID: deviceID,
+            now: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        #expect(exported.summary == .init(hosts: 1, credentials: 1, snippets: 1, forwarding: 0))
+        #expect(exported.document.records.map(\.type).sorted(by: { $0.rawValue < $1.rawValue }) == [
+            .credential, .host, .snippet
+        ])
+
+        let document = exported.document
+        let envelope = try await Task.detached {
+            try SelectiveRemotePersonalVaultCrypto.seal(
+                document,
+                recoveryPhrase: "correct horse battery staple",
+                baseRevision: 0,
+                vaultKey: Data(repeating: 0x11, count: 32),
+                salt: Data(repeating: 0x22, count: 16),
+                nonce: Data(repeating: 0x33, count: 12)
+            )
+        }.value
+        let encodedEnvelope = try JSONEncoder().encode(envelope)
+        let wireText = try #require(String(data: encodedEnvelope, encoding: .utf8))
+        #expect(!wireText.contains("Production Host"))
+        #expect(!wireText.contains("host.example.invalid"))
+        #expect(!wireText.contains("synthetic-secret-command"))
+        #expect(!wireText.contains("synthetic-secret-password"))
+        #expect(envelope.envelopeVersion == 1)
+        #expect(envelope.wrappedKey.iterations == 600_000)
+        #expect(Data(selectiveRemoteBase64URL: envelope.contentHash)?.count == 32)
+    }
+
+    @Test("authenticated GET and PUT use the strict Personal Vault contract")
+    func personalVaultTransport() async throws {
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized("https://cloud.example.invalid")
+        let vaultID = try #require(UUID(uuidString: "77777777-7777-4777-8777-777777777777"))
+        let token = String(repeating: "t", count: 43)
+        let tokenStore = SelectiveRemoteCloudMemoryTokenStore()
+        try tokenStore.saveToken(token, for: endpoint)
+        let stub = PersonalVaultHTTPStub { request in
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer \(token)")
+            switch (request.httpMethod, request.url?.path) {
+            case ("GET", "/v1/vault"):
+                return Self.response(request, status: 200, json: [
+                    "id": vaultID.canonicalCloudString,
+                    "revision": 0,
+                    "envelopeVersion": NSNull(),
+                    "wrappedKey": NSNull(),
+                    "ciphertext": NSNull(),
+                    "nonce": NSNull(),
+                    "authTag": NSNull(),
+                    "contentHash": NSNull(),
+                    "updatedAt": "2026-09-08T00:00:00.000Z"
+                ])
+            case ("PUT", "/v1/vault"):
+                #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+                let body = try #require(request.httpBody)
+                let object = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+                #expect(Set(object.keys) == [
+                    "baseRevision", "envelopeVersion", "wrappedKey", "ciphertext",
+                    "nonce", "authTag", "contentHash"
+                ])
+                let wrappedKey = try #require(object["wrappedKey"] as? [String: Any])
+                #expect(Set(wrappedKey.keys) == ["algorithm", "iterations", "salt", "value"])
+                #expect(object["baseRevision"] as? Int == 0)
+                return Self.response(request, status: 200, json: ["conflict": false, "revision": 1])
+            default:
+                Issue.record("Unexpected request: \(request.httpMethod ?? "nil") \(request.url?.path ?? "nil")")
+                return Self.response(request, status: 500, json: ["error": "unexpected_request"])
+            }
+        }
+        let client = SelectiveRemoteCloudAPIClient(
+            tokenStore: tokenStore,
+            dataLoader: { request in try stub.data(for: request) }
+        )
+
+        let remote = try await client.personalVault(endpoint: endpoint)
+        #expect(remote.id == vaultID)
+        #expect(remote.revision == 0)
+        #expect(remote.envelope == nil)
+
+        let document = try SelectiveRemoteVaultDocument(records: [try syntheticRecord()])
+        let envelope = try SelectiveRemotePersonalVaultCrypto.seal(
+            document,
+            recoveryPhrase: "correct horse battery staple",
+            baseRevision: 0,
+            vaultKey: Data(repeating: 0x11, count: 32),
+            salt: Data(repeating: 0x22, count: 16),
+            nonce: Data(repeating: 0x33, count: 12)
+        )
+        #expect(envelope.wrappedKey.value == "3MfifkLZxvfeMvM1VS7k5LH_yWgHYmMYUb56NqdNdXg38MMYxCUsIA")
+        #expect(envelope.nonce == "MzMzMzMzMzMzMzMz")
+        #expect(envelope.ciphertext == "_6EgI6n9B0jBmtE23AmHSXKpLQ7x-_HFjCZsp5ms2VO4UQ_1wpaCNzedjjmLM8O6fJKXcJEiEGh9_ieRYNDjfG4MGZ2XeedxmDStAy0iFPs2bqemOV0RrQ2CzfDG6zvEdwLP5kCQwzmHHXff5EaanuL2VmEe_HyBVlXy5TUX6er8mK5oqeugtjYUx_eFd4oC8g508mcybOGKDM9fUleqBWWGK9watV9fQQBHcCrRx0a3_39mhrztZPgdhYBd8cgNgVSQkbb-uKR-wdDDJmSiqICNqFD2QgNcRlwMAwcOS44AJ-6R3xNMdm9w")
+        #expect(envelope.authTag == "1IYkH8A_1_UG7ELGr1DBqQ")
+        #expect(envelope.contentHash == "H2eTTOL2LATd622JBSfi6-vwew2LdNCo8v1kSoVshyk")
+        #expect(try await client.putPersonalVault(endpoint: endpoint, envelope: envelope)
+            == .init(conflict: false, revision: 1))
+    }
+
+    @Test("extended wrapped-key responses are rejected")
+    func rejectsExtendedWrappedKey() async throws {
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized("https://cloud.example.invalid")
+        let tokenStore = SelectiveRemoteCloudMemoryTokenStore()
+        try tokenStore.saveToken(String(repeating: "t", count: 43), for: endpoint)
+        let document = try SelectiveRemoteVaultDocument(records: [try syntheticRecord()])
+        let envelope = try SelectiveRemotePersonalVaultCrypto.seal(
+            document,
+            recoveryPhrase: "correct horse battery staple",
+            baseRevision: 0,
+            vaultKey: Data(repeating: 0x11, count: 32),
+            salt: Data(repeating: 0x22, count: 16),
+            nonce: Data(repeating: 0x33, count: 12)
+        )
+        let client = SelectiveRemoteCloudAPIClient(
+            tokenStore: tokenStore,
+            dataLoader: { request in
+                Self.response(request, status: 200, json: [
+                    "id": "77777777-7777-4777-8777-777777777777",
+                    "revision": 1,
+                    "envelopeVersion": 1,
+                    "wrappedKey": [
+                        "algorithm": envelope.wrappedKey.algorithm,
+                        "iterations": envelope.wrappedKey.iterations,
+                        "salt": envelope.wrappedKey.salt,
+                        "value": envelope.wrappedKey.value,
+                        "unexpected": true
+                    ],
+                    "ciphertext": envelope.ciphertext,
+                    "nonce": envelope.nonce,
+                    "authTag": envelope.authTag,
+                    "contentHash": envelope.contentHash,
+                    "updatedAt": "2026-09-08T00:00:00.000Z"
+                ])
+            }
+        )
+
+        await #expect(throws: SelectiveRemoteCloudError.invalidResponse) {
+            try await client.personalVault(endpoint: endpoint)
+        }
+    }
+
+    private static func syntheticRecord() throws -> SelectiveRemoteVaultRecord {
+        try .init(
+            id: UUID(uuidString: "11111111-1111-4111-8111-111111111111")!,
+            type: .host,
+            version: SelectiveRemoteVaultVersion([
+                UUID(uuidString: "44444444-4444-4444-8444-444444444444")!: 1
+            ]),
+            modifiedAt: "2026-09-08T00:00:00.000Z",
+            data: .object(["title": .string("Synthetic Host")])
+        )
+    }
+
+    private static func response(
+        _ request: URLRequest,
+        status: Int,
+        json: Any?
+    ) throws -> (Data, URLResponse) {
+        let data = try json.map { try JSONSerialization.data(withJSONObject: $0) } ?? Data()
+        let response = try #require(HTTPURLResponse(
+            url: try #require(request.url),
+            statusCode: status,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        ))
+        return (data, response)
+    }
+}
+
+private final class PersonalVaultHTTPStub: @unchecked Sendable {
+    let handler: @Sendable (URLRequest) throws -> (Data, URLResponse)
+
+    init(handler: @escaping @Sendable (URLRequest) throws -> (Data, URLResponse)) {
+        self.handler = handler
+    }
+
+    func data(for request: URLRequest) throws -> (Data, URLResponse) {
+        try handler(request)
+    }
+}
+
+private extension Data {
+    init?(hex: String) {
+        guard hex.count.isMultiple(of: 2) else { return nil }
+        var bytes: [UInt8] = []
+        bytes.reserveCapacity(hex.count / 2)
+        var index = hex.startIndex
+        while index < hex.endIndex {
+            let next = hex.index(index, offsetBy: 2)
+            guard let byte = UInt8(hex[index..<next], radix: 16) else { return nil }
+            bytes.append(byte)
+            index = next
+        }
+        self.init(bytes)
+    }
+}

--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -129,8 +129,10 @@ export async function initializeLocalVault({
   const conflictPanel = documentValue.querySelector("#local-vault-conflicts");
   const conflictForm = documentValue.querySelector("#local-vault-conflicts-form");
   const conflictList = documentValue.querySelector("#local-vault-conflicts-list");
+  const filterButtons = [...documentValue.querySelectorAll("#personal-vault-filters [data-record-filter]")];
   const controller = createLocalVaultController({ repository });
   let conflictResetListener = () => {};
+  let activeRecordFilter = "all";
 
   function clearConflictUI() {
     conflictPanel.hidden = true;
@@ -173,15 +175,27 @@ export async function initializeLocalVault({
 
   function render() {
     const current = controller.document();
+    const counts = { host: 0, credential: 0, snippet: 0, forwarding: 0 };
+    for (const record of current.records) {
+      if (Object.hasOwn(counts, record.type)) counts[record.type] += 1;
+    }
+    for (const [recordType, count] of Object.entries(counts)) {
+      setText(documentValue.querySelector(`#workspace-${recordType}-count`), String(count));
+    }
+    const visibleRecords = activeRecordFilter === "all"
+      ? current.records
+      : current.records.filter((record) => record.type === activeRecordFilter);
     records.replaceChildren();
-    if (current.records.length === 0) {
+    if (visibleRecords.length === 0) {
       const empty = documentValue.createElement("p");
       empty.className = "vault-empty";
-      empty.textContent = "Vault пока пуст.";
+      empty.textContent = current.records.length === 0
+        ? "Personal Vault пока пуст. Данные появятся после первой синхронизации с Mac или ручного добавления."
+        : "Записей этого типа пока нет.";
       records.append(empty);
       return;
     }
-    for (const record of current.records) {
+    for (const record of visibleRecords) {
       const card = documentValue.createElement("article");
       const heading = documentValue.createElement("h4");
       const summary = documentValue.createElement("p");
@@ -275,6 +289,15 @@ export async function initializeLocalVault({
   });
 
   type.addEventListener("change", updateLabels);
+  for (const button of filterButtons) {
+    button.addEventListener("click", () => {
+      activeRecordFilter = button.dataset.recordFilter || "all";
+      for (const candidate of filterButtons) {
+        candidate.classList.toggle("active", candidate === button);
+      }
+      if (!workspace.hidden) render();
+    });
+  }
   lockButton.addEventListener("click", () => {
     controller.lock();
     hideRecovery();
@@ -300,6 +323,13 @@ export async function initializeLocalVault({
     render,
     clearConflictUI,
     setConflictMode,
+    setFilter(value) {
+      activeRecordFilter = ["all", "host", "credential", "snippet", "forwarding"].includes(value) ? value : "all";
+      for (const button of filterButtons) {
+        button.classList.toggle("active", button.dataset.recordFilter === activeRecordFilter);
+      }
+      if (!workspace.hidden) render();
+    },
     setConflictResetListener(listener) {
       conflictResetListener = typeof listener === "function" ? listener : () => {};
     },
@@ -1018,7 +1048,6 @@ export function initializeTeamWorkspace({
   return {
     async activate(nextIdentity) {
       identity = nextIdentity;
-      section.hidden = false;
       await Promise.all([loadDevices(), loadTeams()]);
     },
     deactivate() {
@@ -1032,7 +1061,6 @@ export function initializeTeamWorkspace({
       devices.replaceChildren();
       members.replaceChildren();
       selectedPanel.hidden = true;
-      section.hidden = true;
     },
   };
 }
@@ -1042,6 +1070,7 @@ export async function initializeCloudAccount({
   vaultUI,
   fetchValue = fetch,
   metadata = null,
+  onSessionChange = () => {},
 } = {}) {
   const vault = vaultUI?.controller;
   const section = documentValue.querySelector("#cloud-account");
@@ -1157,6 +1186,7 @@ export async function initializeCloudAccount({
     signedIn.hidden = !user;
     syncButton.disabled = !user;
     setText(accountName, user ? `${user.displayName || user.email} · ${user.email}` : "");
+    onSessionChange(user);
   }
 
   loginTab.addEventListener("click", () => setAuthMode("login"));
@@ -1383,7 +1413,131 @@ export async function initializeCloudAccount({
 
   showSession(null);
   setAuthMode("login");
-  return client;
+  return { client, showAuth: setAuthMode };
+}
+
+export function initializePortalNavigation({
+  documentValue = document,
+  locationValue = location,
+  historyValue = history,
+  vaultUI = null,
+  showAuthMode = () => {},
+} = {}) {
+  const brand = documentValue.querySelector("#site-brand");
+  const publicActions = documentValue.querySelector("#public-actions");
+  const hero = documentValue.querySelector("#public-hero");
+  const heroCopy = documentValue.querySelector("#public-hero-copy");
+  const heroPreview = documentValue.querySelector("#cloud-hero-preview");
+  const auth = documentValue.querySelector("#cloud-account");
+  const authBack = documentValue.querySelector("#cloud-auth-back");
+  const publicGrid = documentValue.querySelector("#public-grid");
+  const publicAccess = documentValue.querySelector("#public-access");
+  const workspace = documentValue.querySelector("#cloud-workspace");
+  const workspaceTitle = documentValue.querySelector("#workspace-title");
+  const workspacePanels = [...documentValue.querySelectorAll(".workspace-panel")];
+  const workspaceButtons = [...documentValue.querySelectorAll("[data-workspace-target]")];
+  const sidebarButtons = [...documentValue.querySelectorAll(".workspace-sidebar [data-workspace-target]")];
+  const titles = {
+    "workspace-overview": "Обзор",
+    "local-vault": "Personal Vault",
+    "team-vault": "Teams и Vaults",
+    "workspace-devices": "Устройства",
+  };
+  let sessionActive = false;
+
+  function setPath(path, replace = false) {
+    if (locationValue.pathname === path) return;
+    const method = replace ? "replaceState" : "pushState";
+    historyValue[method]?.({}, "", path);
+  }
+
+  function selectWorkspacePanel(target, recordFilter = null) {
+    const panelID = Object.hasOwn(titles, target) ? target : "workspace-overview";
+    for (const panel of workspacePanels) panel.hidden = panel.id !== panelID;
+    for (const button of sidebarButtons) button.classList.toggle("active", button.dataset.workspaceTarget === panelID);
+    setText(workspaceTitle, titles[panelID]);
+    if (recordFilter) vaultUI?.setFilter(recordFilter);
+  }
+
+  function showLanding({ replace = false } = {}) {
+    brand.hidden = false;
+    publicActions.hidden = false;
+    hero.hidden = false;
+    hero.classList.remove("auth-active");
+    heroCopy.hidden = false;
+    heroPreview.hidden = false;
+    auth.hidden = true;
+    publicGrid.hidden = false;
+    publicAccess.hidden = false;
+    workspace.hidden = true;
+    setPath("/", replace);
+  }
+
+  function showAuthentication(mode = "login", { replace = false } = {}) {
+    brand.hidden = false;
+    publicActions.hidden = true;
+    hero.hidden = false;
+    hero.classList.add("auth-active");
+    heroCopy.hidden = true;
+    heroPreview.hidden = true;
+    auth.hidden = false;
+    publicGrid.hidden = true;
+    publicAccess.hidden = true;
+    workspace.hidden = true;
+    showAuthMode(mode);
+    setPath("/login", replace);
+    documentValue.querySelector(mode === "registration" ? "#cloud-registration-name" : "#cloud-email")?.focus();
+  }
+
+  function showWorkspace({ replace = false } = {}) {
+    brand.hidden = true;
+    hero.hidden = true;
+    publicGrid.hidden = true;
+    publicAccess.hidden = true;
+    workspace.hidden = false;
+    selectWorkspacePanel("workspace-overview");
+    setPath("/app", replace);
+  }
+
+  for (const button of documentValue.querySelectorAll("[data-open-auth]")) {
+    button.addEventListener("click", () => showAuthentication(button.dataset.openAuth || "login"));
+  }
+  authBack.addEventListener("click", () => showLanding());
+  for (const button of workspaceButtons) {
+    button.addEventListener("click", () => selectWorkspacePanel(
+      button.dataset.workspaceTarget,
+      button.dataset.recordFilter || null,
+    ));
+  }
+
+  const view = {
+    sessionChanged(user) {
+      if (user) {
+        sessionActive = true;
+        showWorkspace();
+      } else if (sessionActive) {
+        sessionActive = false;
+        showAuthentication("login", { replace: true });
+      }
+    },
+    showAuthentication,
+    showLanding,
+    showWorkspace,
+    selectWorkspacePanel,
+  };
+
+  const initialPath = String(locationValue.pathname || "/");
+  if (initialPath === "/login" || initialPath === "/app") {
+    showAuthentication("login", { replace: initialPath === "/app" });
+  } else {
+    showLanding({ replace: initialPath !== "/" });
+  }
+  documentValue.defaultView?.addEventListener("popstate", () => {
+    if (sessionActive && locationValue.pathname === "/app") showWorkspace({ replace: true });
+    else if (locationValue.pathname === "/login") showAuthentication("login", { replace: true });
+    else showLanding({ replace: true });
+  });
+  return view;
 }
 
 async function updateServiceStatus(documentValue, fetchValue) {
@@ -1474,7 +1628,21 @@ export async function initializePortal({
   }
   const metadata = await updateServiceStatus(documentValue, fetchValue);
   const vaultUI = await initializeLocalVault({ documentValue });
-  await initializeCloudAccount({ documentValue, vaultUI, fetchValue, metadata });
+  let navigation = null;
+  const account = await initializeCloudAccount({
+    documentValue,
+    vaultUI,
+    fetchValue,
+    metadata,
+    onSessionChange: (user) => navigation?.sessionChanged(user),
+  });
+  navigation = initializePortalNavigation({
+    documentValue,
+    locationValue,
+    historyValue,
+    vaultUI,
+    showAuthMode: account?.showAuth,
+  });
 }
 
 if (typeof document !== "undefined") await initializePortal();

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -9,12 +9,16 @@
 </head>
 <body>
   <main class="shell">
-    <header class="brand">
+    <header class="brand" id="site-brand">
       <div class="mark" aria-hidden="true">SR</div>
       <div>
         <p class="eyebrow">SELECTIVE REMOTE</p>
         <h1>Cloud</h1>
       </div>
+      <nav class="brand-actions" id="public-actions" aria-label="Аккаунт">
+        <button type="button" class="secondary" data-open-auth="login">Войти</button>
+        <button type="button" data-open-auth="registration">Создать аккаунт</button>
+      </nav>
       <span class="status" id="service-status">Проверка сервиса…</span>
     </header>
 
@@ -39,8 +43,8 @@
       <a href="/" id="password-reset-home" hidden>Вернуться на главную</a>
     </section>
 
-    <section class="hero hero-with-auth">
-      <div class="hero-copy">
+    <section class="hero hero-with-auth" id="public-hero">
+      <div class="hero-copy" id="public-hero-copy">
         <p class="kicker">Ваши подключения — на ваших устройствах</p>
         <h2>Синхронизация без доступа сервера к данным.</h2>
         <p class="lead">Профили, Snippets и секреты шифруются на Mac до отправки. Cloud хранит только зашифрованные ревизии.</p>
@@ -49,9 +53,25 @@
           <span>Сессия только в памяти</span>
           <span>HTTPS</span>
         </div>
+        <div class="hero-actions">
+          <button type="button" data-open-auth="login">Войти в Cloud</button>
+          <button type="button" class="secondary" data-open-auth="registration">Создать аккаунт</button>
+        </div>
       </div>
 
-      <section class="auth-card" id="cloud-account" aria-labelledby="cloud-account-title">
+      <aside class="hero-preview" id="cloud-hero-preview" aria-label="Возможности Cloud">
+        <p class="eyebrow">CLOUD WORKSPACE</p>
+        <h3>Одна рабочая область для всех подключений</h3>
+        <div class="hero-preview-grid">
+          <span><strong>Hosts</strong><small>RDP и SSH</small></span>
+          <span><strong>Vault</strong><small>Личный и Team</small></span>
+          <span><strong>Snippets</strong><small>Команды</small></span>
+          <span><strong>Devices</strong><small>Контроль доступа</small></span>
+        </div>
+      </aside>
+
+      <section class="auth-card" id="cloud-account" aria-labelledby="cloud-account-title" hidden>
+        <button type="button" class="auth-back" id="cloud-auth-back">← На главную</button>
         <div class="auth-card-heading">
           <div class="auth-icon" aria-hidden="true">SR</div>
           <div>
@@ -103,24 +123,58 @@
           <button type="button" class="secondary" id="cloud-registration-done">Вернуться ко входу</button>
         </div>
 
-        <div id="cloud-signed-in" hidden>
-          <p id="cloud-account-name"></p>
-          <button type="button" class="secondary" id="cloud-logout">Выйти и удалить токен из памяти</button>
-        </div>
       </section>
     </section>
 
-    <section class="grid" aria-label="Возможности первой версии">
+    <section class="grid" id="public-grid" aria-label="Возможности первой версии">
       <article><span>01</span><h3>Личный Vault</h3><p>Одна зашифрованная библиотека с историей ревизий и защитой от перезаписи.</p></article>
       <article><span>02</span><h3>Ваши устройства</h3><p>Список активных Mac, дата последнего доступа и мгновенный отзыв сессии.</p></article>
       <article><span>03</span><h3>Локальный режим</h3><p>Аккаунт необязателен: приложение продолжает полноценно работать автономно.</p></article>
     </section>
 
-    <section class="local-vault" id="local-vault" aria-labelledby="local-vault-title">
+    <section class="workspace-layout" id="cloud-workspace" hidden>
+      <aside class="workspace-sidebar">
+        <div class="workspace-logo"><span>SR</span><strong>Cloud</strong></div>
+        <nav aria-label="Разделы Cloud">
+          <button type="button" class="active" data-workspace-target="workspace-overview">Обзор</button>
+          <button type="button" data-workspace-target="local-vault">Personal Vault</button>
+          <button type="button" data-workspace-target="team-vault">Teams и Vaults</button>
+          <button type="button" data-workspace-target="workspace-devices">Устройства</button>
+        </nav>
+        <div class="workspace-security"><span>●</span> E2EE включено</div>
+      </aside>
+
+      <div class="workspace-main">
+        <header class="workspace-header">
+          <div><p class="eyebrow">SELECTIVE REMOTE CLOUD</p><h2 id="workspace-title">Обзор</h2></div>
+          <div id="cloud-signed-in" hidden>
+            <p id="cloud-account-name"></p>
+            <button type="button" class="secondary" id="cloud-logout">Выйти</button>
+          </div>
+        </header>
+
+        <section class="workspace-panel workspace-overview" id="workspace-overview">
+          <div class="workspace-welcome">
+            <div><p class="eyebrow">ВАША РАБОЧАЯ ОБЛАСТЬ</p><h2>Подключения и Vaults</h2></div>
+            <button type="button" data-workspace-target="local-vault">Открыть Personal Vault</button>
+          </div>
+          <div class="workspace-stats">
+            <button type="button" data-workspace-target="local-vault" data-record-filter="host"><span id="workspace-host-count">0</span><strong>Hosts</strong><small>RDP и SSH подключения</small></button>
+            <button type="button" data-workspace-target="local-vault" data-record-filter="credential"><span id="workspace-credential-count">0</span><strong>Credentials</strong><small>Секреты и учётные записи</small></button>
+            <button type="button" data-workspace-target="local-vault" data-record-filter="snippet"><span id="workspace-snippet-count">0</span><strong>Snippets</strong><small>Сохранённые команды</small></button>
+            <button type="button" data-workspace-target="local-vault" data-record-filter="forwarding"><span id="workspace-forwarding-count">0</span><strong>Forwarding</strong><small>Туннели и правила</small></button>
+          </div>
+          <div class="workspace-notice">
+            <strong>Ожидается первая синхронизация с Mac</strong>
+            <p>Локальные подключения из установленного приложения появятся здесь после отправки Personal Vault с Mac. Текущая версия macOS-клиента ещё не выполняет этот импорт автоматически.</p>
+          </div>
+        </section>
+
+    <section class="local-vault workspace-panel" id="local-vault" aria-labelledby="local-vault-title" hidden>
       <div class="vault-heading">
         <div>
-          <p class="eyebrow">PERSONAL VAULT · LOCAL PREVIEW</p>
-          <h2 id="local-vault-title">Зашифрованное хранилище в браузере</h2>
+          <p class="eyebrow">PERSONAL VAULT · E2EE</p>
+          <h2 id="local-vault-title">Личный Vault</h2>
         </div>
         <p id="local-vault-message" aria-live="polite">Проверяем локальное хранилище…</p>
       </div>
@@ -168,6 +222,13 @@
             <button type="button" class="secondary" id="local-vault-lock">Заблокировать</button>
           </div>
         </div>
+        <nav class="record-filters" id="personal-vault-filters" aria-label="Типы записей">
+          <button type="button" class="active" data-record-filter="all">Все</button>
+          <button type="button" data-record-filter="host">Hosts</button>
+          <button type="button" data-record-filter="credential">Credentials</button>
+          <button type="button" data-record-filter="snippet">Snippets</button>
+          <button type="button" data-record-filter="forwarding">Forwarding</button>
+        </nav>
         <form class="record-form" id="local-vault-record-form">
           <label for="local-record-type">Тип записи</label>
           <select id="local-record-type" name="type">
@@ -196,24 +257,27 @@
       </div>
     </section>
 
-    <section class="team-vault" id="team-vault" aria-labelledby="team-vault-title" hidden>
+    <section class="workspace-panel workspace-devices" id="workspace-devices" hidden>
+      <div class="vault-heading">
+        <div><p class="eyebrow">ACCOUNT DEVICES</p><h2>Устройства доступа</h2></div>
+        <p>Одобряйте только свои устройства и сравнивайте SHA-256 отпечаток на обоих экранах.</p>
+      </div>
+      <div class="team-devices-panel">
+        <div class="team-devices-heading">
+          <div><h3>Mac и браузеры</h3><p>Отзыв устройства немедленно завершает связанные сессии. Для Shared Vaults после отзыва потребуется ротация ключа.</p></div>
+          <button type="button" class="secondary" id="team-devices-refresh">Обновить устройства</button>
+        </div>
+        <div class="team-devices" id="team-devices"></div>
+      </div>
+    </section>
+
+    <section class="team-vault workspace-panel" id="team-vault" aria-labelledby="team-vault-title" hidden>
       <div class="vault-heading">
         <div>
           <p class="eyebrow">TEAM VAULTS · CLIENT-SIDE E2EE</p>
           <h2 id="team-vault-title">Командные хранилища</h2>
         </div>
         <p id="team-vault-message" aria-live="polite">Загрузка Teams…</p>
-      </div>
-
-      <div class="team-devices-panel">
-        <div class="team-devices-heading">
-          <div>
-            <h3>Устройства Team-доступа</h3>
-            <p>Перед одобрением сравните SHA-256 отпечаток на обоих устройствах. Отозванное устройство немедленно теряет сессии, а Shared Vaults требуют ротации.</p>
-          </div>
-          <button type="button" class="secondary" id="team-devices-refresh">Обновить устройства</button>
-        </div>
-        <div class="team-devices" id="team-devices"></div>
       </div>
 
       <div class="team-onboarding">
@@ -345,7 +409,10 @@
       </div>
     </section>
 
-    <section class="access">
+      </div>
+    </section>
+
+    <section class="access" id="public-access">
       <div><p class="eyebrow">V0.32 FOUNDATION</p><h2>Cloud управляется вами</h2></div>
       <p>Регистрация доступна только во время контролируемого окна. Вход, подтверждение почты и восстановление пароля остаются доступны для существующего аккаунта.</p>
     </section>

--- a/cloud/public/styles.css
+++ b/cloud/public/styles.css
@@ -6,7 +6,10 @@ body { margin:0; min-height:100vh; background:radial-gradient(circle at 70% 15%,
 .brand { display:flex; align-items:center; gap:14px; border-bottom:1px solid var(--line); padding-bottom:24px; }
 .mark { width:46px; height:46px; display:grid; place-items:center; border:1px solid var(--accent); color:var(--accent); border-radius:13px; font-weight:750; }
 .brand h1,.brand p { margin:0; }.brand h1 { font-size:22px; }.eyebrow { color:var(--accent); letter-spacing:.16em; font-size:11px; font-weight:750; }
-.status { margin-left:auto; color:var(--muted); font-size:13px; }.status.ok { color:var(--accent2); }
+.brand-actions { display:flex; gap:9px; margin-left:auto; }
+.brand-actions button,.hero-actions button,.workspace-welcome button { border:0; border-radius:11px; padding:11px 16px; background:var(--accent); color:#082016; font:inherit; font-weight:750; cursor:pointer; }
+.brand-actions button.secondary,.hero-actions button.secondary { border:1px solid var(--line); background:transparent; color:var(--ink); }
+.status { color:var(--muted); font-size:13px; }.status.ok { color:var(--accent2); }
 .verification { margin:32px 0 0; padding:30px; border:1px solid var(--line); border-radius:18px; background:#0c1714e8; }
 .verification h2 { margin:8px 0 10px; }.verification p:last-of-type { color:var(--muted); margin-bottom:20px; }
 .verification a { color:var(--accent2); font-weight:650; }.verification.success { border-color:#75e0b477; }.verification.error { border-color:#ff8f7a88; }
@@ -19,6 +22,13 @@ body { margin:0; min-height:100vh; background:radial-gradient(circle at 70% 15%,
 .lead { max-width:660px; color:var(--muted); line-height:1.65; font-size:18px; }
 .trust-row { display:flex; flex-wrap:wrap; gap:9px; margin-top:28px; }
 .trust-row span { padding:8px 11px; border:1px solid var(--line); border-radius:999px; color:#bdd0c9; background:#0c1714b8; font-size:12px; }
+.hero-actions { display:flex; flex-wrap:wrap; gap:10px; margin-top:24px; }
+.hero-preview { padding:30px; border:1px solid #75e0b452; border-radius:28px; background:linear-gradient(150deg,#11221ce8,#09120ff5); box-shadow:0 28px 80px #0006; }
+.hero-preview h3 { margin:9px 0 28px; font-size:28px; line-height:1.12; letter-spacing:-.035em; }
+.hero-preview-grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:10px; }
+.hero-preview-grid span { display:grid; gap:5px; min-height:96px; align-content:end; padding:16px; border:1px solid var(--line); border-radius:14px; background:#07100dbd; }
+.hero-preview-grid strong { font-size:17px; }.hero-preview-grid small { color:var(--muted); }
+.hero.auth-active { grid-template-columns:minmax(320px,560px); justify-content:center; min-height:680px; border-bottom:0; }
 .vault-visual { width:min(320px,75vw); aspect-ratio:1; position:relative; display:grid; place-items:center; margin:auto; }
 .orbit { position:absolute; inset:10%; border:1px solid #4a7a67; border-radius:42% 58% 63% 37%; animation:spin 18s linear infinite; }.orbit-two { inset:22%; border-color:#75e0b477; animation-direction:reverse; animation-duration:12s; }
 .vault-core { width:120px; height:120px; display:grid; place-content:center; text-align:center; border-radius:28px; background:linear-gradient(145deg,#a9ffc9,#78dcaa); color:#082016; box-shadow:0 0 70px #75e0b438; transform:rotate(-5deg); }
@@ -26,6 +36,7 @@ body { margin:0; min-height:100vh; background:radial-gradient(circle at 70% 15%,
 .grid { display:grid; grid-template-columns:repeat(3,1fr); gap:1px; background:var(--line); border:1px solid var(--line); margin:50px 0; }
 .grid article { background:var(--panel); padding:30px; min-height:210px; }.grid span { color:var(--accent); font-family:ui-monospace,monospace; }.grid h3 { margin:38px 0 12px; font-size:20px; }.grid p,.access p { color:var(--muted); line-height:1.55; }
 .auth-card { position:relative; overflow:hidden; padding:28px; border:1px solid #75e0b452; border-radius:24px; background:linear-gradient(150deg,#12221de8,#09120ff5); box-shadow:0 28px 80px #0007,0 0 0 1px #ffffff08 inset; }
+.auth-back { margin:0 0 22px; padding:0; border:0; background:transparent; color:var(--accent); font:inherit; font-weight:700; cursor:pointer; }
 .auth-card::before { content:""; position:absolute; width:180px; height:180px; right:-70px; top:-90px; border-radius:50%; background:#75e0b41f; filter:blur(8px); pointer-events:none; }
 .auth-card-heading { display:flex; align-items:center; gap:14px; position:relative; }
 .auth-card-heading h2 { margin:5px 0 0; font-size:25px; letter-spacing:-.025em; }
@@ -48,7 +59,20 @@ body { margin:0; min-height:100vh; background:radial-gradient(circle at 70% 15%,
 .auth-success { text-align:center; padding:18px 8px 8px; }.auth-success h3 { margin:12px 0 8px; }.auth-success p { color:var(--muted); line-height:1.5; }
 .auth-success-icon { width:54px; height:54px; display:grid; place-items:center; margin:auto; border-radius:50%; background:#75e0b424; color:var(--accent); font-size:27px; }
 .auth-card button.secondary { background:transparent; border:1px solid var(--line); color:var(--ink); }
-#cloud-signed-in { padding-top:10px; } #cloud-signed-in p { color:var(--ink); font-weight:700; }
+#cloud-signed-in { display:flex; align-items:center; gap:12px; } #cloud-signed-in p { margin:0; color:var(--ink); font-weight:700; }
+.workspace-layout { min-height:calc(100vh - 98px); display:grid; grid-template-columns:240px minmax(0,1fr); overflow:hidden; border:1px solid var(--line); border-radius:24px; background:#091310e8; box-shadow:0 30px 90px #0005; }
+.workspace-sidebar { display:flex; flex-direction:column; padding:24px 16px; border-right:1px solid var(--line); background:#07100ded; }
+.workspace-logo { display:flex; align-items:center; gap:11px; padding:0 8px 24px; }.workspace-logo span { width:38px; height:38px; display:grid; place-items:center; border:1px solid var(--accent); border-radius:11px; color:var(--accent); font-weight:800; }.workspace-logo strong { font-size:20px; }
+.workspace-sidebar nav { display:grid; gap:6px; }.workspace-sidebar nav button { width:100%; padding:12px 13px; border:0; border-radius:10px; background:transparent; color:var(--muted); font:inherit; font-weight:650; text-align:left; cursor:pointer; }.workspace-sidebar nav button:hover,.workspace-sidebar nav button.active { background:#75e0b419; color:var(--ink); }
+.workspace-security { margin-top:auto; padding:16px 10px 4px; border-top:1px solid var(--line); color:var(--muted); font-size:12px; }.workspace-security span { color:var(--accent2); }
+.workspace-main { min-width:0; padding:28px; }
+.workspace-header { display:flex; align-items:center; justify-content:space-between; gap:24px; padding-bottom:24px; border-bottom:1px solid var(--line); }.workspace-header h2 { margin:6px 0 0; font-size:28px; }.workspace-header .secondary { border:1px solid var(--line); border-radius:10px; padding:9px 13px; background:transparent; color:var(--ink); font:inherit; cursor:pointer; }
+.workspace-panel { margin:28px 0 0; padding:0; border:0; border-radius:0; background:transparent; }
+.workspace-welcome { display:flex; align-items:center; justify-content:space-between; gap:24px; padding:26px; border:1px solid var(--line); border-radius:18px; background:linear-gradient(135deg,#11251de8,#0a1512); }.workspace-welcome h2 { margin:7px 0 0; font-size:30px; }
+.workspace-stats { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:14px; margin-top:18px; }.workspace-stats button { display:grid; gap:7px; min-height:150px; padding:22px; border:1px solid var(--line); border-radius:16px; background:#08110e; color:var(--ink); font:inherit; text-align:left; cursor:pointer; }.workspace-stats button:hover { border-color:#75e0b478; background:#0d1b16; }.workspace-stats span { color:var(--accent); font:700 34px ui-monospace,monospace; }.workspace-stats strong { font-size:18px; }.workspace-stats small { color:var(--muted); }
+.workspace-notice { margin-top:18px; padding:20px 22px; border:1px solid #c8ff7847; border-radius:14px; background:#c8ff780a; }.workspace-notice strong { color:var(--accent2); }.workspace-notice p { margin:8px 0 0; color:var(--muted); line-height:1.55; }
+.workspace-devices { padding:0; }.workspace-devices>.vault-heading { padding:24px; border:1px solid var(--line); border-radius:16px; background:#08110e; }
+.record-filters { display:flex; flex-wrap:wrap; gap:8px; margin:22px 0 4px; }.record-filters button { border:1px solid var(--line); border-radius:999px; padding:8px 13px; background:transparent; color:var(--muted); font:inherit; font-size:13px; cursor:pointer; }.record-filters button.active { border-color:var(--accent); background:#75e0b419; color:var(--ink); }
 .local-vault { margin:50px 0; padding:34px; border:1px solid var(--line); border-radius:22px; background:#0c1714e8; }
 .team-vault { margin:50px 0; padding:34px; border:1px solid #75e0b45c; border-radius:22px; background:linear-gradient(145deg,#0c1714f2,#102019e8); }
 .team-onboarding,.team-columns { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:18px; margin-top:26px; }
@@ -104,7 +128,10 @@ body { margin:0; min-height:100vh; background:radial-gradient(circle at 70% 15%,
 .vault-conflicts legend { padding:0 6px; font-weight:750; }.vault-conflicts label { display:flex; gap:8px; align-items:flex-start; color:var(--ink); overflow-wrap:anywhere; }
 .vault-conflicts input { margin-top:3px; }.vault-conflicts button { border:0; border-radius:10px; padding:12px 18px; background:var(--accent); color:#082016; font:inherit; font-weight:750; cursor:pointer; }
 .vault-conflicts button:disabled { opacity:.6; cursor:not-allowed; }
+.local-vault.workspace-panel,.team-vault.workspace-panel { margin:28px 0 0; padding:0; border:0; border-radius:0; background:transparent; }
+.workspace-devices button { border:1px solid var(--line); border-radius:10px; padding:10px 14px; background:transparent; color:var(--ink); font:inherit; font-weight:700; cursor:pointer; }.workspace-devices button.danger { border-color:#ff8f7a66; color:#ffb4a6; }
 .access { display:flex; justify-content:space-between; gap:40px; align-items:end; padding:34px; border:1px solid var(--line); border-radius:18px; background:#0c1714cc; }.access h2 { margin:8px 0 0; }.access>p { max-width:500px; margin:0; }
 @keyframes spin { to { transform:rotate(360deg); } }
-@media (max-width:880px) { .shell{width:min(100% - 24px,1180px);padding-top:18px}.hero{grid-template-columns:1fr;padding:48px 0;gap:36px}.hero h2{font-size:clamp(40px,11vw,68px)}.auth-card{width:100%;max-width:560px}.vault-visual{width:230px}.grid,.team-onboarding,.team-columns,.team-lifecycle-forms{grid-template-columns:1fr}.vault-heading,.vault-toolbar,.access,.team-summary,.team-devices-heading{align-items:start;flex-direction:column}.vault-actions{justify-content:flex-start}.vault-panel form,.record-form{grid-template-columns:1fr}.vault-panel button,.record-form button{grid-column:1}.vault-records{grid-template-columns:1fr}.team-picker,.team-picker.compact{grid-template-columns:1fr}.team-members article,.team-devices article{grid-template-columns:1fr}.team-members strong,.team-members small,.team-members select,.team-members button,.team-members button.danger,.team-devices strong,.team-devices small,.team-device-fingerprint,.team-devices button,.team-devices button.danger{grid-column:1;grid-row:auto}.status{font-size:0}.status::after{content:"●";font-size:16px} }
+@media (max-width:880px) { .shell{width:min(100% - 24px,1180px);padding-top:18px}.brand{flex-wrap:wrap}.brand-actions{order:3;width:100%}.brand-actions button{flex:1}.status{margin-left:auto}.hero{grid-template-columns:1fr;padding:48px 0;gap:36px}.hero.auth-active{grid-template-columns:1fr;min-height:620px}.hero h2{font-size:clamp(40px,11vw,68px)}.hero-preview{padding:22px}.auth-card{width:100%;max-width:560px}.vault-visual{width:230px}.grid,.team-onboarding,.team-columns,.team-lifecycle-forms,.workspace-stats{grid-template-columns:1fr}.workspace-layout{grid-template-columns:1fr;min-height:0}.workspace-sidebar{border-right:0;border-bottom:1px solid var(--line)}.workspace-sidebar nav{grid-template-columns:repeat(2,minmax(0,1fr))}.workspace-security{display:none}.workspace-main{padding:20px}.workspace-header,.workspace-welcome{align-items:flex-start;flex-direction:column}.vault-heading,.vault-toolbar,.access,.team-summary,.team-devices-heading{align-items:start;flex-direction:column}.vault-actions{justify-content:flex-start}.vault-panel form,.record-form{grid-template-columns:1fr}.vault-panel button,.record-form button{grid-column:1}.vault-records{grid-template-columns:1fr}.team-picker,.team-picker.compact{grid-template-columns:1fr}.team-members article,.team-devices article{grid-template-columns:1fr}.team-members strong,.team-members small,.team-members select,.team-members button,.team-members button.danger,.team-devices strong,.team-devices small,.team-device-fingerprint,.team-devices button,.team-devices button.danger{grid-column:1;grid-row:auto}.status{font-size:0}.status::after{content:"●";font-size:16px} }
+@media (max-width:560px) { .workspace-sidebar nav{grid-template-columns:1fr}.workspace-main{padding:16px}.workspace-header{padding-bottom:18px}.hero-preview-grid{grid-template-columns:1fr}.auth-card{padding:22px}.workspace-welcome{padding:20px} }
 @media (prefers-reduced-motion:reduce) { .orbit{animation:none} }

--- a/cloud/public/styles.css
+++ b/cloud/public/styles.css
@@ -1,5 +1,6 @@
 :root { color-scheme: dark; --bg:#08100e; --panel:#0e1916; --line:#244138; --ink:#f2f7f4; --muted:#9bb0a9; --accent:#75e0b4; --accent2:#c8ff78; }
 * { box-sizing:border-box; }
+[hidden] { display:none !important; }
 body { margin:0; min-height:100vh; background:radial-gradient(circle at 70% 15%,#183b2e 0,transparent 32%),linear-gradient(145deg,#07100d,#0a1412 58%,#101a14); color:var(--ink); font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
 .shell { width:min(1180px,calc(100% - 40px)); margin:0 auto; padding:38px 0 60px; }
 .brand { display:flex; align-items:center; gap:14px; border-bottom:1px solid var(--line); padding-bottom:24px; }

--- a/cloud/src/server.mjs
+++ b/cloud/src/server.mjs
@@ -424,7 +424,7 @@ async function readJSON(request, maximumBytes = maxBodyBytes) {
 }
 
 async function serveStatic(pathname, response, head) {
-  const relative = pathname === "/" ? "index.html" : pathname.slice(1);
+  const relative = ["/", "/login", "/app"].includes(pathname) ? "index.html" : pathname.slice(1);
   if (!/^[a-zA-Z0-9._/-]+$/.test(relative) || relative.includes("..")) return sendError(response, 404, "not_found");
   try {
     const data = await readFile(join(publicDirectory, relative));

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -132,3 +132,24 @@ test("macOS Cloud settings expose real device-bound sign-in and read-only Team i
   assert.match(sessions, /kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly/);
   assert.doesNotMatch(sessions, /UserDefaults/);
 });
+
+test("macOS Personal Vault first upload is encrypted, explicit and non-destructive", async () => {
+  const [sync, settings, appSettings] = await Promise.all([
+    readFile(new URL("CloudPersonalVaultSync.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudSettingsView.swift", sourceRoot), "utf8"),
+    readFile(new URL("UpdateExperienceView.swift", sourceRoot), "utf8"),
+  ]);
+  assert.match(sync, /PBKDF2-SHA256\+A256KW/);
+  assert.match(sync, /600_000/);
+  assert.match(sync, /selective-remote:vault-envelope:v1/);
+  assert.match(sync, /AES\.GCM\.seal/);
+  assert.match(sync, /wrapRFC3394/);
+  assert.match(sync, /remoteVaultNotEmpty/);
+  assert.match(sync, /uploadConflict/);
+  assert.match(settings, /includePersonalVaultCredentials = false/);
+  assert.match(settings, /authenticateDeviceOwner/);
+  assert.match(settings, /guard remote\.revision == 0/);
+  assert.match(settings, /Task\.detached/);
+  assert.match(settings, /personalVaultRecoveryPhrase = ""/);
+  assert.match(appSettings, /CloudSettingsView\(model: model\)/);
+});

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -80,15 +80,20 @@ test("conflict choices expose only bounded metadata and never record secrets or 
   );
 });
 
-test("portal exposes memory-only login and explicit manual synchronization controls", async () => {
-  const [html, styles, application, synchronization, teamSynchronization] = await Promise.all([
+test("portal exposes separate public, authentication and workspace states", async () => {
+  const [html, styles, application, synchronization, teamSynchronization, server] = await Promise.all([
     readFile(new URL("../public/index.html", import.meta.url), "utf8"),
     readFile(new URL("../public/styles.css", import.meta.url), "utf8"),
     readFile(new URL("../public/app.js", import.meta.url), "utf8"),
     readFile(new URL("../public/vault-sync.js", import.meta.url), "utf8"),
     readFile(new URL("../public/team-vault-sync.js", import.meta.url), "utf8"),
+    readFile(new URL("../src/server.mjs", import.meta.url), "utf8"),
   ]);
 
+  assert.match(html, /id="cloud-account"[^>]*hidden/u);
+  assert.match(html, /id="cloud-workspace"[^>]*hidden/u);
+  assert.match(html, /data-open-auth="login"/u);
+  assert.match(html, /data-open-auth="registration"/u);
   assert.match(html, /id="cloud-login-form"/u);
   assert.match(html, /id="cloud-vault-sync"/u);
   assert.match(html, /id="cloud-logout"/u);
@@ -108,7 +113,20 @@ test("portal exposes memory-only login and explicit manual synchronization contr
   assert.match(html, /id="team-vault-rotate"[^>]*hidden/u);
   assert.match(html, /id="team-vault-record-form"/u);
   assert.match(html, /id="team-vault-conflicts-form"/u);
+  assert.match(html, /id="workspace-overview"/u);
+  assert.match(html, /data-workspace-target="local-vault"/u);
+  assert.match(html, /data-workspace-target="workspace-devices"/u);
+  assert.match(html, /data-record-filter="host"/u);
+  assert.match(html, /data-record-filter="credential"/u);
+  assert.match(html, /data-record-filter="snippet"/u);
+  assert.match(html, /data-record-filter="forwarding"/u);
+  assert.match(html, /Текущая версия macOS-клиента ещё не выполняет этот импорт автоматически/u);
   assert.match(styles, /\[hidden\]\s*\{\s*display:\s*none\s*!important;\s*\}/u);
+  assert.match(styles, /\.workspace-layout/u);
+  assert.match(application, /initializePortalNavigation/u);
+  assert.match(application, /setPath\("\/login"/u);
+  assert.match(application, /setPath\("\/app"/u);
+  assert.match(server, /\["\/", "\/login", "\/app"\]\.includes\(pathname\)/u);
   assert.match(application, /createAuthenticatedVaultClient/u);
   assert.match(application, /synchronizeVault/u);
   assert.match(application, /ensureTeamDeviceIdentity/u);

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -81,8 +81,9 @@ test("conflict choices expose only bounded metadata and never record secrets or 
 });
 
 test("portal exposes memory-only login and explicit manual synchronization controls", async () => {
-  const [html, application, synchronization, teamSynchronization] = await Promise.all([
+  const [html, styles, application, synchronization, teamSynchronization] = await Promise.all([
     readFile(new URL("../public/index.html", import.meta.url), "utf8"),
+    readFile(new URL("../public/styles.css", import.meta.url), "utf8"),
     readFile(new URL("../public/app.js", import.meta.url), "utf8"),
     readFile(new URL("../public/vault-sync.js", import.meta.url), "utf8"),
     readFile(new URL("../public/team-vault-sync.js", import.meta.url), "utf8"),
@@ -107,6 +108,7 @@ test("portal exposes memory-only login and explicit manual synchronization contr
   assert.match(html, /id="team-vault-rotate"[^>]*hidden/u);
   assert.match(html, /id="team-vault-record-form"/u);
   assert.match(html, /id="team-vault-conflicts-form"/u);
+  assert.match(styles, /\[hidden\]\s*\{\s*display:\s*none\s*!important;\s*\}/u);
   assert.match(application, /createAuthenticatedVaultClient/u);
   assert.match(application, /synchronizeVault/u);
   assert.match(application, /ensureTeamDeviceIdentity/u);


### PR DESCRIPTION
## Roll-up PR #59–61

Этот PR собирает в одной проверяемой цепочке:

- исправление скрытия неактивных auth-форм из #59;
- отдельные `/`, `/login` и `/app`, а также workspace-навигацию из #60;
- первую явную E2E-зашифрованную отправку локальных данных macOS в Personal Vault.

## macOS Personal Vault

- отправляет Hosts, Snippets и Forwarding только после явного действия пользователя;
- сохранённые Credentials выключены по умолчанию и читаются только после системной аутентификации macOS;
- PBKDF2-SHA256 (600 000), AES-256-KW и AES-GCM совпадают с браузерным протоколом;
- recovery-фраза не сохраняется и не отправляется;
- непосредственно перед PUT повторно читается серверная ревизия;
- любая ненулевая ревизия или optimistic conflict останавливает отправку без перезаписи.

## Граница этого этапа

Это первая отправка только в пустой Personal Vault. Импорт, последующая двусторонняя синхронизация, tombstones и реальные конфликты будут отдельным этапом.

## Локальные проверки

- полный Cloud suite: 241 тест, 240 passed, 0 failed, 1 skipped (`TEST_DATABASE_URL` не настроен);
- целевые Cloud/Vault тесты: 26 passed;
- Swift tests включают RFC 3394 known-answer vector, детерминированный browser/macOS envelope fixture, ciphertext-only и строгий API contract.

Retargeted to `main` so repository CI and Test DMG workflows validate the complete roll-up. Public `main` is unchanged.