### PR TITLE
Fix macOS Cloud state and add encrypted Team sharing

### DIFF
--- a/Sources/SelectiveRemote/CloudAPIClient.swift
+++ b/Sources/SelectiveRemote/CloudAPIClient.swift
@@ -239,6 +239,18 @@ enum SelectiveRemoteCloudEndpoint {
     }
 }
 
+enum SelectiveRemoteCloudPortalURL {
+    static let login = URL(string: "https://cloud.pastfly.ru/?auth=login")!
+
+    static func registration(endpoint: URL) -> URL {
+        var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: false)!
+        components.path = "/"
+        components.queryItems = [URLQueryItem(name: "auth", value: "registration")]
+        components.fragment = nil
+        return components.url!
+    }
+}
+
 actor SelectiveRemoteCloudAPIClient {
     private let dataLoader: SelectiveRemoteCloudDataLoader
     private let tokenStore: any SelectiveRemoteCloudTokenStore

--- a/Sources/SelectiveRemote/CloudPersonalVaultSync.swift
+++ b/Sources/SelectiveRemote/CloudPersonalVaultSync.swift
@@ -402,8 +402,12 @@ extension SelectiveRemoteCloudAPIClient {
             throw SelectiveRemoteCloudError.invalidResponse
         }
         if revision == 0 {
-            let emptyKeys = ["envelopeVersion", "wrappedKey", "ciphertext", "nonce", "authTag", "contentHash"]
-            guard emptyKeys.allSatisfy({ object[$0] is NSNull }) else {
+            let emptyPayloadKeys = ["wrappedKey", "ciphertext", "nonce", "authTag", "contentHash"]
+            let emptyEnvelopeVersion = object["envelopeVersion"] is NSNull
+                || object["envelopeVersion"] as? Int == 1
+            guard emptyEnvelopeVersion,
+                  emptyPayloadKeys.allSatisfy({ object[$0] is NSNull })
+            else {
                 throw SelectiveRemoteCloudError.invalidResponse
             }
             return .init(id: id, revision: 0, envelope: nil, updatedAt: updatedAt)

--- a/Sources/SelectiveRemote/CloudProfileShareView.swift
+++ b/Sources/SelectiveRemote/CloudProfileShareView.swift
@@ -1,0 +1,209 @@
+import SwiftUI
+
+enum SelectiveRemoteCloudProfileShareError: LocalizedError {
+    case signInRequired
+    case noWritableTeam
+    case noVault
+    case initializationRequiresManager
+    case conflict
+
+    var errorDescription: String? {
+        switch self {
+        case .signInRequired:
+            UpdateLocalization.text(ru: "Сначала войдите в Cloud.", en: "Sign in to Cloud first.")
+        case .noWritableTeam:
+            UpdateLocalization.text(ru: "Нет Team с правом записи.", en: "No Team allows you to write.")
+        case .noVault:
+            UpdateLocalization.text(ru: "В выбранной Team нет Shared Vault.", en: "The selected Team has no Shared Vault.")
+        case .initializationRequiresManager:
+            UpdateLocalization.text(
+                ru: "Пустую Team Vault сначала должен инициализировать Owner или Admin.",
+                en: "An Owner or Admin must initialize the empty Team Vault first."
+            )
+        case .conflict:
+            UpdateLocalization.text(
+                ru: "Team Vault изменилась параллельно. Откройте её в Cloud и разрешите конфликт.",
+                en: "The Team Vault changed concurrently. Open it in Cloud and resolve the conflict."
+            )
+        }
+    }
+}
+
+struct SelectiveRemoteCloudProfileShareView: View {
+    let profile: ConnectionProfile
+
+    @Environment(\.dismiss) private var dismiss
+    @AppStorage("SelectiveRemote.cloud.endpoint.v1") private var endpoint = SelectiveRemoteCloudEndpoint.production
+    @AppStorage("SelectiveRemote.cloud.device-id.v1") private var storedDeviceID = ""
+    @State private var teams: [SelectiveRemoteCloudTeam] = []
+    @State private var vaults: [SelectiveRemoteCloudSharedVault] = []
+    @State private var selectedTeamID: UUID?
+    @State private var selectedVaultID: UUID?
+    @State private var isLoading = true
+    @State private var isSharing = false
+    @State private var message: String?
+    @State private var messageIsError = false
+
+    private let client = SelectiveRemoteCloudAPIClient()
+    private let identityManager = SelectiveRemoteTeamDeviceIdentityManager()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Text(UpdateLocalization.text(ru: "Поделиться Host с командой", en: "Share Host with a Team"))
+                .font(.title2.bold())
+            LabeledContent(UpdateLocalization.text(ru: "Host", en: "Host")) {
+                Text(profile.friendlyName).lineLimit(1)
+            }
+
+            if isLoading {
+                HStack { ProgressView().controlSize(.small); Text("Cloud…") }
+            } else {
+                Picker("Team", selection: $selectedTeamID) {
+                    ForEach(teams) { team in Text("\(team.name) · \(team.role.rawValue)").tag(Optional(team.id)) }
+                }
+                Picker("Shared Vault", selection: $selectedVaultID) {
+                    ForEach(vaults) { vault in Text(vault.name).tag(Optional(vault.id)) }
+                }
+                .disabled(selectedTeamID == nil)
+            }
+
+            Text(UpdateLocalization.text(
+                ru: "В Team Vault отправляется только выбранный профиль без сохранённого пароля. Данные шифруются на этом Mac.",
+                en: "Only this profile is sent to the Team Vault, without its saved password. Data is encrypted on this Mac."
+            ))
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+            if let message {
+                Label(message, systemImage: messageIsError ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
+                    .foregroundStyle(messageIsError ? Color.orange : Color.green)
+                    .font(.caption)
+            }
+
+            HStack {
+                Spacer()
+                Button(UpdateLocalization.text(ru: "Закрыть", en: "Close")) { dismiss() }
+                    .disabled(isSharing)
+                Button(UpdateLocalization.text(ru: "Зашифровать и поделиться", en: "Encrypt and Share")) {
+                    share()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isLoading || isSharing || selectedVaultID == nil)
+            }
+        }
+        .padding(24)
+        .frame(width: 520)
+        .task { await load() }
+        .onChange(of: selectedTeamID) { _, _ in Task { await loadVaults() } }
+    }
+
+    @MainActor
+    private func load() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            let url = try SelectiveRemoteCloudEndpoint.normalized(endpoint)
+            guard await client.hasStoredSession(endpoint: url) else {
+                throw SelectiveRemoteCloudProfileShareError.signInRequired
+            }
+            _ = try await client.currentUser(endpoint: url)
+            teams = try await client.teams(endpoint: url).filter { $0.role != .viewer }
+            guard !teams.isEmpty else { throw SelectiveRemoteCloudProfileShareError.noWritableTeam }
+            selectedTeamID = teams[0].id
+            await loadVaults()
+        } catch {
+            message = error.localizedDescription
+            messageIsError = true
+        }
+    }
+
+    @MainActor
+    private func loadVaults() async {
+        guard let teamID = selectedTeamID,
+              let url = try? SelectiveRemoteCloudEndpoint.normalized(endpoint)
+        else { return }
+        do {
+            vaults = try await client.sharedVaults(endpoint: url, teamID: teamID)
+            selectedVaultID = vaults.first?.id
+            if vaults.isEmpty { throw SelectiveRemoteCloudProfileShareError.noVault }
+        } catch {
+            vaults = []
+            selectedVaultID = nil
+            message = error.localizedDescription
+            messageIsError = true
+        }
+    }
+
+    @MainActor
+    private func share() {
+        guard let team = teams.first(where: { $0.id == selectedTeamID }),
+              let vaultID = selectedVaultID,
+              let url = try? SelectiveRemoteCloudEndpoint.normalized(endpoint)
+        else { return }
+        isSharing = true
+        message = nil
+        Task { @MainActor in
+            defer { isSharing = false }
+            do {
+                let deviceID = try resolvedDeviceID()
+                let identity = try await identityManager.identity(endpoint: url, deviceID: deviceID)
+                let coordinator = try SelectiveRemoteTeamVaultSyncCoordinator(
+                    endpoint: url,
+                    remote: client,
+                    snapshots: SelectiveRemoteTeamVaultFileSnapshotStore()
+                )
+                let refreshed = try await coordinator.refresh(teamID: team.id, vaultID: vaultID, identity: identity)
+                let host = try SelectiveRemotePersonalVaultExporter.makeExport(
+                    profiles: [profile], credentials: [], snippets: [], forwarding: [], deviceID: deviceID
+                ).document.records[0]
+
+                let outcome: SelectiveRemoteTeamVaultPushOutcome
+                switch refreshed {
+                case .empty:
+                    guard team.role == .owner || team.role == .admin else {
+                        throw SelectiveRemoteCloudProfileShareError.initializationRequiresManager
+                    }
+                    let devices = try await client.teamKeyDevices(endpoint: url, teamID: team.id, vaultID: vaultID)
+                    let document = try SelectiveRemoteVaultDocument(records: [host])
+                    outcome = try await coordinator.initialize(
+                        payload: document.encoded(), teamID: team.id, vaultID: vaultID,
+                        identity: identity, keyDevices: devices
+                    )
+                case let .synchronized(snapshot), let .localChanges(snapshot):
+                    let current = try SelectiveRemoteVaultDocument.decode(snapshot.payload)
+                    let priorVersion = current.records.first(where: { $0.id == host.id })?.version
+                        ?? current.tombstones.first(where: { $0.id == host.id })?.version
+                    let record = try SelectiveRemoteVaultRecord(
+                        id: host.id, type: .host,
+                        version: try priorVersion?.incrementing(deviceID) ?? SelectiveRemoteVaultVersion([deviceID: 1]),
+                        modifiedAt: host.modifiedAt, data: host.data
+                    )
+                    let document = try SelectiveRemoteVaultDocument(
+                        records: current.records.filter { $0.id != host.id } + [record],
+                        tombstones: current.tombstones.filter { $0.id != host.id }
+                    )
+                    _ = try await coordinator.stage(
+                        document.encoded(), teamID: team.id, vaultID: vaultID, identity: identity
+                    )
+                    outcome = try await coordinator.push(teamID: team.id, vaultID: vaultID, identity: identity)
+                case .conflict:
+                    throw SelectiveRemoteCloudProfileShareError.conflict
+                }
+                guard case .uploaded = outcome else { throw SelectiveRemoteCloudProfileShareError.conflict }
+                message = UpdateLocalization.text(ru: "Host зашифрован и добавлен в Team Vault.", en: "The Host was encrypted and added to the Team Vault.")
+                messageIsError = false
+            } catch {
+                message = error.localizedDescription
+                messageIsError = true
+            }
+        }
+    }
+
+    @MainActor
+    private func resolvedDeviceID() throws -> UUID {
+        if let value = UUID(uuidString: storedDeviceID), value.isSelectiveRemoteCloudUUID { return value }
+        let value = UUID()
+        storedDeviceID = value.canonicalCloudString
+        return value
+    }
+}

--- a/Sources/SelectiveRemote/CloudSettingsView.swift
+++ b/Sources/SelectiveRemote/CloudSettingsView.swift
@@ -620,7 +620,7 @@ struct CloudSettingsView: View {
 
     private var registrationURL: URL? {
         guard let base = try? SelectiveRemoteCloudEndpoint.normalized(endpoint) else { return nil }
-        return base.appending(path: "login")
+        return SelectiveRemoteCloudPortalURL.registration(endpoint: base)
     }
 
     @MainActor

--- a/Sources/SelectiveRemote/CloudSettingsView.swift
+++ b/Sources/SelectiveRemote/CloudSettingsView.swift
@@ -19,6 +19,7 @@ struct CloudSettingsView: View {
     @State private var registrationErrorMessage: String?
     @State private var registeredEmail: String?
     @State private var inventoryErrorMessage: String?
+    @State private var personalVaultLoadErrorMessage: String?
     @State private var accountEndpoint: String?
     @State private var showsAccountSheet = false
     @State private var accountSheetMode = AccountSheetMode.signIn
@@ -129,6 +130,16 @@ struct CloudSettingsView: View {
                     .buttonStyle(.borderedProminent)
                     .disabled(accountPhase.isBusy)
 
+                    if let registrationURL {
+                        Link(
+                            UpdateLocalization.text(
+                                ru: "Регистрация на сайте…",
+                                en: "Register on the Website…"
+                            ),
+                            destination: registrationURL
+                        )
+                    }
+
                     if metadata?.registrationEnabled == true {
                         Button(
                             UpdateLocalization.text(ru: "Создать аккаунт…", en: "Create Account…"),
@@ -204,6 +215,13 @@ struct CloudSettingsView: View {
                         .foregroundStyle(personalVaultMessageIsError ? Color.orange : Color.green)
                         .font(.caption)
                         .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    if let personalVaultLoadErrorMessage {
+                        Label(personalVaultLoadErrorMessage, systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                            .font(.caption)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
 
                     Text(UpdateLocalization.text(
@@ -343,30 +361,31 @@ struct CloudSettingsView: View {
 
     private func checkConnection() {
         Task { @MainActor in
-            await loadCloudState(force: true)
+            _ = await refreshCloudMetadata()
         }
     }
 
     @MainActor
     private func loadCloudStateIfNeeded() async {
         guard phase == .idle else { return }
-        await loadCloudState(force: false)
+        guard let url = await refreshCloudMetadata() else { return }
+        await restoreStoredSession(at: url)
     }
 
     @MainActor
-    private func loadCloudState(force: Bool) async {
+    private func refreshCloudMetadata() async -> URL? {
         phase = .checking
-        metadata = nil
         errorMessage = nil
         do {
             let url = try SelectiveRemoteCloudEndpoint.normalized(endpoint)
             endpoint = url.absoluteString
             metadata = try await client.metadata(endpoint: url)
             phase = .available
-            await restoreStoredSession(at: url, force: force)
+            return url
         } catch {
             errorMessage = error.localizedDescription
             phase = .failed
+            return nil
         }
     }
 
@@ -436,8 +455,8 @@ struct CloudSettingsView: View {
     }
 
     @MainActor
-    private func restoreStoredSession(at url: URL, force: Bool) async {
-        if !force, accountEndpoint == url.absoluteString { return }
+    private func restoreStoredSession(at url: URL) async {
+        if accountEndpoint == url.absoluteString, accountUser != nil { return }
         resetAccountPresentation(endpoint: url)
         guard await client.hasStoredSession(endpoint: url) else { return }
         accountPhase = .restoring
@@ -530,9 +549,21 @@ struct CloudSettingsView: View {
     private func loadInventory(endpoint url: URL) async {
         accountPhase = .refreshing
         inventoryErrorMessage = nil
+        personalVaultLoadErrorMessage = nil
         do {
             let personalVault = try await client.personalVault(endpoint: url)
             personalVaultRevision = personalVault.revision
+        } catch {
+            if error as? SelectiveRemoteCloudError == .authenticationRequired {
+                resetAccountPresentation(endpoint: url)
+                accountErrorMessage = error.localizedDescription
+                return
+            }
+            personalVaultRevision = nil
+            personalVaultLoadErrorMessage = error.localizedDescription
+        }
+
+        do {
             let loadedTeams = try await client.teams(endpoint: url)
             var loadedVaults: [UUID: [SelectiveRemoteCloudSharedVault]] = [:]
             for team in loadedTeams {
@@ -550,10 +581,11 @@ struct CloudSettingsView: View {
             }
             teams = []
             vaultsByTeam = [:]
-            personalVaultRevision = nil
             inventoryErrorMessage = error.localizedDescription
         }
-        accountPhase = .signedIn
+        if accountUser != nil {
+            accountPhase = .signedIn
+        }
     }
 
     private func signOut() {
@@ -583,6 +615,12 @@ struct CloudSettingsView: View {
         personalVaultMessageIsError = false
         accountErrorMessage = nil
         inventoryErrorMessage = nil
+        personalVaultLoadErrorMessage = nil
+    }
+
+    private var registrationURL: URL? {
+        guard let base = try? SelectiveRemoteCloudEndpoint.normalized(endpoint) else { return nil }
+        return base.appending(path: "login")
     }
 
     @MainActor

--- a/Sources/SelectiveRemote/CloudTeamVaultSyncCoordinator.swift
+++ b/Sources/SelectiveRemote/CloudTeamVaultSyncCoordinator.swift
@@ -11,6 +11,7 @@ enum SelectiveRemoteTeamVaultSyncError: Error, Equatable {
     case invalidWriteAcknowledgement
     case invalidConflictResponse
     case staleConflict
+    case invalidKeyDevices
 }
 
 protocol SelectiveRemoteTeamVaultRemote: Sendable {
@@ -74,6 +75,98 @@ actor SelectiveRemoteTeamVaultSyncCoordinator {
         self.endpoint = try SelectiveRemoteCloudEndpoint.normalized(endpoint.absoluteString)
         self.remote = remote
         self.snapshots = snapshots
+    }
+
+    func initialize(
+        payload: Data,
+        teamID: UUID,
+        vaultID: UUID,
+        identity: SelectiveRemoteTeamDeviceIdentity,
+        keyDevices: [SelectiveRemoteCloudTeamKeyDevice]
+    ) async throws -> SelectiveRemoteTeamVaultPushOutcome {
+        guard try snapshots.load(endpoint: endpoint, teamID: teamID, vaultID: vaultID) == nil,
+              !keyDevices.isEmpty,
+              keyDevices.count <= 1_024,
+              Set(keyDevices.map(\.deviceID)).count == keyDevices.count,
+              keyDevices.contains(where: { $0.deviceID == identity.deviceID })
+        else { throw SelectiveRemoteTeamVaultSyncError.invalidKeyDevices }
+
+        var generator = SystemRandomNumberGenerator()
+        let vaultKey = Data((0..<32).map { _ in UInt8.random(in: 0...255, using: &generator) })
+        let wrappers = try keyDevices.map { recipient in
+            try SelectiveRemoteTeamVaultCrypto.wrapVaultKey(
+                vaultKey,
+                for: recipient.publicKey,
+                context: SelectiveRemoteTeamWrapperContext(
+                    teamID: teamID,
+                    vaultID: vaultID,
+                    keyGeneration: 1,
+                    membershipID: recipient.membershipID,
+                    membershipEpoch: recipient.membershipEpoch,
+                    deviceID: recipient.deviceID
+                )
+            )
+        }
+        guard let currentWrapper = wrappers.first(where: { $0.deviceID == identity.deviceID }) else {
+            throw SelectiveRemoteTeamVaultSyncError.invalidKeyDevices
+        }
+        let envelope = try SelectiveRemoteTeamVaultCrypto.encryptPayload(
+            payload,
+            vaultKey: vaultKey,
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: 1,
+            baseRevision: 0
+        )
+        let prepared = try SelectiveRemoteTeamVaultSnapshot(
+            teamID: teamID,
+            vaultID: vaultID,
+            deviceID: identity.deviceID,
+            keyGeneration: 1,
+            localRevision: 1,
+            serverRevision: 0,
+            syncedLocalRevision: 0,
+            envelope: envelope,
+            wrapper: currentWrapper
+        )
+        try snapshots.save(prepared, endpoint: endpoint)
+
+        let write = try await remote.putSharedVault(
+            endpoint: endpoint,
+            teamID: teamID,
+            vaultID: vaultID,
+            upload: .init(envelope: envelope, wrappers: wrappers),
+            idempotencyKey: "macos:team-vault:initialize:\(UUID().canonicalCloudString)"
+        )
+        if write.conflict {
+            let refreshed = try await refresh(
+                teamID: teamID,
+                vaultID: vaultID,
+                identity: identity
+            )
+            guard case let .conflict(conflict) = refreshed else {
+                throw SelectiveRemoteTeamVaultSyncError.invalidConflictResponse
+            }
+            return .conflict(conflict)
+        }
+        guard write.revision == 1,
+              write.keyGeneration == 1,
+              write.rotationCompleted == false
+        else { throw SelectiveRemoteTeamVaultSyncError.invalidWriteAcknowledgement }
+
+        let uploaded = try SelectiveRemoteTeamVaultSnapshot(
+            teamID: teamID,
+            vaultID: vaultID,
+            deviceID: identity.deviceID,
+            keyGeneration: 1,
+            localRevision: 1,
+            serverRevision: 1,
+            syncedLocalRevision: 1,
+            envelope: envelope,
+            wrapper: currentWrapper
+        )
+        try snapshots.save(uploaded, endpoint: endpoint)
+        return .uploaded(.init(snapshot: uploaded, payload: payload))
     }
 
     func refresh(

--- a/Sources/SelectiveRemote/ContentView.swift
+++ b/Sources/SelectiveRemote/ContentView.swift
@@ -114,6 +114,7 @@ struct ContentView: View {
     @State private var showsSSHDiagnostics = false
     @State private var showsAppearanceSettings = false
     @State private var showsUpdatePopover = false
+    @State private var profileToShare: ConnectionProfile?
 
     private var profile: ConnectionProfile { model.selectedProfile }
     private var profileBinding: Binding<ConnectionProfile> {
@@ -263,6 +264,9 @@ struct ContentView: View {
             ) { request, session in
                 model.generateSSHKey(request, session: session)
             }
+        }
+        .sheet(item: $profileToShare) { profile in
+            SelectiveRemoteCloudProfileShareView(profile: profile)
         }
         .onAppear {
             selectedTab = restoredProfileTab(for: profile.id)
@@ -811,6 +815,12 @@ struct ContentView: View {
         Button("Создать копию", systemImage: "doc.on.doc") {
             model.selectProfile(item.id)
             model.duplicateSelectedProfile()
+        }
+        Button(
+            UpdateLocalization.text(ru: "Поделиться с командой…", en: "Share with Team…"),
+            systemImage: "person.2.badge.plus"
+        ) {
+            profileToShare = item
         }
         Divider()
         Button("Удалить", systemImage: "trash", role: .destructive) {

--- a/Sources/SelectiveRemote/SelectiveRemoteApp.swift
+++ b/Sources/SelectiveRemote/SelectiveRemoteApp.swift
@@ -97,6 +97,31 @@ private struct SFTPMenuBarTransferControls: View {
     }
 }
 
+private struct SelectiveRemoteCloudCommands: Commands {
+    @ObservedObject var appLock: AppLockStore
+    @Environment(\.openSettings) private var openSettings
+
+    var body: some Commands {
+        CommandMenu("Cloud") {
+            Button(
+                UpdateLocalization.text(ru: "Открыть настройки Cloud…", en: "Open Cloud Settings…"),
+                systemImage: "cloud"
+            ) {
+                UserDefaults.standard.set("cloud", forKey: "SelectiveRemote.settings.selected-tab.v1")
+                openSettings()
+            }
+            .disabled(appLock.isLocked)
+
+            Button(
+                UpdateLocalization.text(ru: "Открыть Cloud в браузере…", en: "Open Cloud in Browser…"),
+                systemImage: "safari"
+            ) {
+                NSWorkspace.shared.open(SelectiveRemoteCloudPortalURL.login)
+            }
+        }
+    }
+}
+
 @main
 struct SelectiveRemoteApp: App {
     @NSApplicationDelegateAdaptor(SelectiveRemoteApplicationDelegate.self)
@@ -248,23 +273,7 @@ struct SelectiveRemoteApp: App {
                 Text(AppBuildInfo.fullText)
                 }
             }
-            CommandMenu("Cloud") {
-                Button(
-                    UpdateLocalization.text(ru: "Открыть настройки Cloud…", en: "Open Cloud Settings…"),
-                    systemImage: "cloud"
-                ) {
-                    UserDefaults.standard.set("cloud", forKey: "SelectiveRemote.settings.selected-tab.v1")
-                    NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
-                }
-                .disabled(appLock.isLocked)
-
-                Button(
-                    UpdateLocalization.text(ru: "Открыть Cloud в браузере…", en: "Open Cloud in Browser…"),
-                    systemImage: "safari"
-                ) {
-                    NSWorkspace.shared.open(URL(string: "https://cloud.pastfly.ru/login")!)
-                }
-            }
+            SelectiveRemoteCloudCommands(appLock: appLock)
         }
 
         Settings {

--- a/Sources/SelectiveRemote/SelectiveRemoteApp.swift
+++ b/Sources/SelectiveRemote/SelectiveRemoteApp.swift
@@ -248,6 +248,23 @@ struct SelectiveRemoteApp: App {
                 Text(AppBuildInfo.fullText)
                 }
             }
+            CommandMenu("Cloud") {
+                Button(
+                    UpdateLocalization.text(ru: "Открыть настройки Cloud…", en: "Open Cloud Settings…"),
+                    systemImage: "cloud"
+                ) {
+                    UserDefaults.standard.set("cloud", forKey: "SelectiveRemote.settings.selected-tab.v1")
+                    NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+                }
+                .disabled(appLock.isLocked)
+
+                Button(
+                    UpdateLocalization.text(ru: "Открыть Cloud в браузере…", en: "Open Cloud in Browser…"),
+                    systemImage: "safari"
+                ) {
+                    NSWorkspace.shared.open(URL(string: "https://cloud.pastfly.ru/login")!)
+                }
+            }
         }
 
         Settings {

--- a/Sources/SelectiveRemote/UpdateExperienceView.swift
+++ b/Sources/SelectiveRemote/UpdateExperienceView.swift
@@ -4,9 +4,10 @@ struct AppSettingsView: View {
     @ObservedObject var model: AppModel
     @ObservedObject var appearance: AppAppearanceStore
     @ObservedObject var appLock: AppLockStore
+    @AppStorage("SelectiveRemote.settings.selected-tab.v1") private var selectedTab = "appearance"
 
     var body: some View {
-        TabView {
+        TabView(selection: $selectedTab) {
             Form {
                 AppAppearanceSettingsSection(store: appearance)
                 Section {
@@ -15,18 +16,23 @@ struct AppSettingsView: View {
             }
             .formStyle(.grouped)
             .tabItem { Label("Оформление", systemImage: "paintpalette") }
+            .tag("appearance")
 
             UpdateSettingsView(model: model)
                 .tabItem { Label("Обновления", systemImage: "arrow.down.circle") }
+                .tag("updates")
 
             AppLockSettingsView(store: appLock)
                 .tabItem { Label("Безопасность", systemImage: "lock.shield") }
+                .tag("security")
 
             CloudSettingsView(model: model)
                 .tabItem { Label("Cloud", systemImage: "cloud") }
+                .tag("cloud")
 
             BackupSettingsView(model: model)
                 .tabItem { Label("Резервная копия", systemImage: "externaldrive.badge.timemachine") }
+                .tag("backup")
         }
         .frame(width: 610, height: 520)
         .background {

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -502,6 +502,72 @@ struct CloudMacOSFoundationTests {
         #expect(writes.first?.idempotencyKey.contains(staged.snapshot.envelope.contentHash) == true)
     }
 
+    @Test("Team Vault coordinator initializes encrypted host data for the approved device set")
+    func teamVaultInitialization() async throws {
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized("https://cloud.example.invalid")
+        let teamID = try #require(UUID(uuidString: "11111111-1111-4111-8111-111111111111"))
+        let vaultID = try #require(UUID(uuidString: "22222222-2222-4222-8222-222222222222"))
+        let deviceID = try #require(UUID(uuidString: "44444444-4444-4444-8444-444444444444"))
+        let membershipID = try #require(UUID(uuidString: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"))
+        let identity = try SelectiveRemoteTeamDeviceIdentity(
+            deviceID: deviceID,
+            privateKeyRepresentation: Data(repeating: 0x31, count: 32)
+        )
+        let empty = SelectiveRemoteCloudSharedVaultEnvelope(
+            id: vaultID, teamID: teamID, name: "Operations", revision: 0,
+            keyGeneration: 1, rotationRequired: false, envelopeVersion: nil,
+            ciphertext: nil, nonce: nil, authTag: nil, contentHash: nil, wrapper: nil,
+            createdAt: "2026-09-08T00:00:00.000Z", updatedAt: "2026-09-08T00:00:00.000Z"
+        )
+        let remote = TeamVaultRemoteStub(
+            envelope: empty,
+            writeResult: .init(conflict: false, revision: 1, keyGeneration: 1, rotationCompleted: false)
+        )
+        let storage = SelectiveRemoteTeamVaultMemorySnapshotStore()
+        let coordinator = try SelectiveRemoteTeamVaultSyncCoordinator(
+            endpoint: endpoint, remote: remote, snapshots: storage
+        )
+        let payload = Data(#"{"records":["synthetic-host"]}"#.utf8)
+        let outcome = try await coordinator.initialize(
+            payload: payload,
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity,
+            keyDevices: [.init(
+                membershipID: membershipID,
+                membershipEpoch: 1,
+                deviceID: deviceID,
+                publicKeyAlgorithm: "p256-ecdh-v1",
+                publicKey: identity.publicKey,
+                hasWrapper: false
+            )]
+        )
+        guard case let .uploaded(uploaded) = outcome else {
+            Issue.record("Expected initialization to commit")
+            return
+        }
+        #expect(uploaded.payload == payload)
+        #expect(uploaded.snapshot.serverRevision == 1)
+        #expect(uploaded.snapshot.syncedLocalRevision == 1)
+        let writes = await remote.recordedWrites()
+        #expect(writes.count == 1)
+        #expect(writes[0].upload.wrappers?.count == 1)
+        #expect(writes[0].upload.envelope.baseRevision == 0)
+        let vaultKey = try SelectiveRemoteTeamVaultCrypto.unwrapVaultKey(
+            uploaded.snapshot.wrapper,
+            with: identity,
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: 1
+        )
+        #expect(try SelectiveRemoteTeamVaultCrypto.decryptPayload(
+            uploaded.snapshot.envelope,
+            vaultKey: vaultKey,
+            teamID: teamID,
+            vaultID: vaultID
+        ) == payload)
+    }
+
     @Test("Team Vault coordinator preserves the dirty snapshot and both conflict versions")
     func teamVaultSyncConflict() async throws {
         let fixture = try Self.fixture()

--- a/Tests/SelectiveRemoteTests/CloudPersonalVaultSyncTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudPersonalVaultSyncTests.swift
@@ -89,7 +89,7 @@ struct CloudPersonalVaultSyncTests {
                 return try Self.response(request, status: 200, json: [
                     "id": vaultID.canonicalCloudString,
                     "revision": 0,
-                    "envelopeVersion": NSNull(),
+                    "envelopeVersion": 1,
                     "wrappedKey": NSNull(),
                     "ciphertext": NSNull(),
                     "nonce": NSNull(),
@@ -140,6 +140,35 @@ struct CloudPersonalVaultSyncTests {
         #expect(envelope.contentHash == "H2eTTOL2LATd622JBSfi6-vwew2LdNCo8v1kSoVshyk")
         #expect(try await client.putPersonalVault(endpoint: endpoint, envelope: envelope)
             == .init(conflict: false, revision: 1))
+    }
+
+    @Test("an empty Personal Vault accepts only the deployed envelope marker")
+    func emptyVaultEnvelopeMarker() async throws {
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized("https://cloud.example.invalid")
+        let tokenStore = SelectiveRemoteCloudMemoryTokenStore()
+        try tokenStore.saveToken(String(repeating: "t", count: 43), for: endpoint)
+
+        for marker: Any in [NSNull(), 1] {
+            let client = SelectiveRemoteCloudAPIClient(
+                tokenStore: tokenStore,
+                dataLoader: { request in
+                    try Self.response(request, status: 200, json: Self.emptyVault(marker: marker))
+                }
+            )
+            #expect(try await client.personalVault(endpoint: endpoint).revision == 0)
+        }
+
+        for marker: Any in [0, 2, "1"] {
+            let client = SelectiveRemoteCloudAPIClient(
+                tokenStore: tokenStore,
+                dataLoader: { request in
+                    try Self.response(request, status: 200, json: Self.emptyVault(marker: marker))
+                }
+            )
+            await #expect(throws: SelectiveRemoteCloudError.invalidResponse) {
+                try await client.personalVault(endpoint: endpoint)
+            }
+        }
     }
 
     @Test("extended wrapped-key responses are rejected")
@@ -194,6 +223,20 @@ struct CloudPersonalVaultSyncTests {
             modifiedAt: "2026-09-08T00:00:00.000Z",
             data: .object(["title": .string("Synthetic Host")])
         )
+    }
+
+    private static func emptyVault(marker: Any) -> [String: Any] {
+        [
+            "id": "77777777-7777-4777-8777-777777777777",
+            "revision": 0,
+            "envelopeVersion": marker,
+            "wrappedKey": NSNull(),
+            "ciphertext": NSNull(),
+            "nonce": NSNull(),
+            "authTag": NSNull(),
+            "contentHash": NSNull(),
+            "updatedAt": "2026-09-08T00:00:00.000Z"
+        ]
     }
 
     private static func response(

--- a/Tests/SelectiveRemoteTests/CloudPersonalVaultSyncTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudPersonalVaultSyncTests.swift
@@ -149,20 +149,24 @@ struct CloudPersonalVaultSyncTests {
         try tokenStore.saveToken(String(repeating: "t", count: 43), for: endpoint)
 
         for marker: Any in [NSNull(), 1] {
+            let payload = try JSONSerialization.data(withJSONObject: Self.emptyVault(marker: marker))
             let client = SelectiveRemoteCloudAPIClient(
                 tokenStore: tokenStore,
                 dataLoader: { request in
-                    try Self.response(request, status: 200, json: Self.emptyVault(marker: marker))
+                    let json = try JSONSerialization.jsonObject(with: payload)
+                    return try Self.response(request, status: 200, json: json)
                 }
             )
             #expect(try await client.personalVault(endpoint: endpoint).revision == 0)
         }
 
         for marker: Any in [0, 2, "1"] {
+            let payload = try JSONSerialization.data(withJSONObject: Self.emptyVault(marker: marker))
             let client = SelectiveRemoteCloudAPIClient(
                 tokenStore: tokenStore,
                 dataLoader: { request in
-                    try Self.response(request, status: 200, json: Self.emptyVault(marker: marker))
+                    let json = try JSONSerialization.jsonObject(with: payload)
+                    return try Self.response(request, status: 200, json: json)
                 }
             )
             await #expect(throws: SelectiveRemoteCloudError.invalidResponse) {

--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -1527,6 +1527,11 @@ export function initializePortalNavigation({
   };
 
   const initialPath = String(locationValue.pathname || "/");
+  const requestedAuthMode = new URLSearchParams(locationValue.search).get("auth");
+  if (requestedAuthMode === "login" || requestedAuthMode === "registration") {
+    showAuthentication(requestedAuthMode, { replace: true });
+    return view;
+  }
   if (initialPath === "/login" || initialPath === "/app") {
     showAuthentication("login", { replace: initialPath === "/app" });
   } else {

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -72,6 +72,22 @@ test("macOS Team Vault coordinator preserves causal dirty and conflict state", a
   assert.match(coordinator, /baseRevision: latestRemote\.revision/);
   assert.match(coordinator, /return try await push\(teamID: teamID, vaultID: vaultID, identity: identity\)/);
   assert.match(coordinator, /revalidated == current/);
+  assert.match(coordinator, /func initialize\(/);
+  assert.match(coordinator, /wrappers: wrappers/);
+});
+
+test("Host context menu opens a real encrypted Team Vault share flow", async () => {
+  const [content, sharing] = await Promise.all([
+    readFile(new URL("ContentView.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudProfileShareView.swift", sourceRoot), "utf8"),
+  ]);
+  assert.match(content, /Share with Team/);
+  assert.match(content, /SelectiveRemoteCloudProfileShareView/);
+  assert.match(sharing, /client\.teamKeyDevices/);
+  assert.match(sharing, /coordinator\.initialize/);
+  assert.match(sharing, /coordinator\.stage/);
+  assert.match(sharing, /coordinator\.push/);
+  assert.match(sharing, /without its saved password/);
 });
 
 test("macOS Team Vault record workflow mirrors the bounded browser causal model", async () => {

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -160,6 +160,21 @@ test("connection checks preserve the signed-in account and inventory failures st
   assert.match(settings, /Register on the Website/);
 });
 
+test("macOS Cloud commands use the supported settings action and backwards-compatible portal URLs", async () => {
+  const [application, client, settings] = await Promise.all([
+    readFile(new URL("SelectiveRemoteApp.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudAPIClient.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudSettingsView.swift", sourceRoot), "utf8"),
+  ]);
+  assert.match(application, /@Environment\(\\\.openSettings\)/);
+  assert.match(application, /openSettings\(\)/);
+  assert.doesNotMatch(application, /showSettingsWindow:/);
+  assert.match(client, /cloud\.pastfly\.ru\/\?auth=login/);
+  assert.match(client, /URLQueryItem\(name: "auth", value: "registration"\)/);
+  assert.match(settings, /SelectiveRemoteCloudPortalURL\.registration/);
+  assert.doesNotMatch(`${application}\n${settings}`, /appending\(path: "login"\)|cloud\.pastfly\.ru\/login/);
+});
+
 test("macOS Personal Vault first upload is encrypted, explicit and non-destructive", async () => {
   const [sync, settings, appSettings] = await Promise.all([
     readFile(new URL("CloudPersonalVaultSync.swift", sourceRoot), "utf8"),

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -133,6 +133,17 @@ test("macOS Cloud settings expose real device-bound sign-in and read-only Team i
   assert.doesNotMatch(sessions, /UserDefaults/);
 });
 
+test("connection checks preserve the signed-in account and inventory failures stay isolated", async () => {
+  const settings = await readFile(new URL("CloudSettingsView.swift", sourceRoot), "utf8");
+  const checkConnection = settings.match(/private func checkConnection\(\)[\s\S]*?\n    \}\n\n    @MainActor/u)?.[0] ?? "";
+  assert.match(checkConnection, /refreshCloudMetadata/);
+  assert.doesNotMatch(checkConnection, /restoreStoredSession|resetAccountPresentation|loadInventory/);
+  assert.match(settings, /private func refreshCloudMetadata\(\) async -> URL\?/);
+  assert.match(settings, /personalVaultLoadErrorMessage/);
+  assert.match(settings, /do \{[\s\S]*client\.personalVault[\s\S]*\} catch \{[\s\S]*personalVaultLoadErrorMessage[\s\S]*\}\n\n        do \{[\s\S]*client\.teams/u);
+  assert.match(settings, /Register on the Website/);
+});
+
 test("macOS Personal Vault first upload is encrypted, explicit and non-destructive", async () => {
   const [sync, settings, appSettings] = await Promise.all([
     readFile(new URL("CloudPersonalVaultSync.swift", sourceRoot), "utf8"),

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -124,6 +124,8 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(styles, /\[hidden\]\s*\{\s*display:\s*none\s*!important;\s*\}/u);
   assert.match(styles, /\.workspace-layout/u);
   assert.match(application, /initializePortalNavigation/u);
+  assert.match(application, /URLSearchParams\(locationValue\.search\)/u);
+  assert.match(application, /requestedAuthMode === "login" \|\| requestedAuthMode === "registration"/u);
   assert.match(application, /setPath\("\/login"/u);
   assert.match(application, /setPath\("\/app"/u);
   assert.match(server, /\["\/", "\/login", "\/app"\]\.includes\(pathname\)/u);


### PR DESCRIPTION
## What changed

- keep the signed-in Keychain session and loaded account intact when **Check Connection** refreshes Cloud metadata
- accept the deployed empty Personal Vault contract (`revision: 0`, `envelopeVersion: 1`) so first encrypted upload becomes available
- isolate Personal Vault loading from Team inventory loading so one endpoint cannot blank both sections
- show a dedicated Personal Vault load error next to its controls
- add a visible website-registration link in the signed-out account section
- add a top-level **Cloud** app menu and remember/select the Cloud settings tab
- add **Share with Team…** to each Host context menu
- load writable Teams and Shared Vaults, encrypt the selected profile locally, and conditionally append it to the selected Team Vault
- initialize an empty Team Vault only for Owner/Admin and wrap its new key for the complete approved-device set
- exclude saved passwords from the one-profile share operation
- stop on rotation requirements or concurrent record/revision conflicts instead of overwriting data

## Validation

- `npm test --prefix cloud`: 242 passed, 1 PostgreSQL integration test skipped without `TEST_DATABASE_URL`
- Swift transport coverage for the deployed empty-vault marker and rejected downgrade/unknown markers
- Swift Team Vault initialization coverage verifies wrapper creation, ciphertext round-trip and committed snapshot state
- source regressions prove Check Connection does not restore/reset a session and the context menu reaches real Team Vault initialize/stage/push operations

The first native run exposed a Swift 6 Sendable-only test fixture error; the head now captures immutable `Data` instead of `Any` and is being rebuilt.

No server schema, SMTP configuration, or deployment state is changed by this PR.