### PR TITLE
Add automatic Personal Vault synchronization

### DIFF
--- a/Sources/SelectiveRemote/CloudPersonalVaultAutoSync.swift
+++ b/Sources/SelectiveRemote/CloudPersonalVaultAutoSync.swift
@@ -1,0 +1,160 @@
+import CryptoKit
+import Foundation
+import Security
+
+struct SelectiveRemotePersonalVaultKeyMaterial: Codable, Equatable, Sendable {
+    let vaultID: UUID
+    let vaultKey: Data
+    let wrappedKey: SelectiveRemotePersonalVaultWrappedKey
+    var revision: Int
+    var documentHash: Data
+    let includesCredentials: Bool
+
+    init(
+        vaultID: UUID,
+        vaultKey: Data,
+        wrappedKey: SelectiveRemotePersonalVaultWrappedKey,
+        revision: Int,
+        documentHash: Data,
+        includesCredentials: Bool = false
+    ) throws {
+        guard vaultID.isSelectiveRemoteCloudUUID, vaultKey.count == 32,
+              revision > 0, documentHash.count == 32
+        else { throw SelectiveRemotePersonalVaultError.invalidEnvelope }
+        self.vaultID = vaultID
+        self.vaultKey = vaultKey
+        self.wrappedKey = wrappedKey
+        self.revision = revision
+        self.documentHash = documentHash
+        self.includesCredentials = includesCredentials
+    }
+}
+
+protocol SelectiveRemotePersonalVaultKeyStore: Sendable {
+    func material(endpoint: URL, deviceID: UUID) throws -> SelectiveRemotePersonalVaultKeyMaterial?
+    func save(_ material: SelectiveRemotePersonalVaultKeyMaterial, endpoint: URL, deviceID: UUID) throws
+    func remove(endpoint: URL, deviceID: UUID) throws
+}
+
+struct SelectiveRemotePersonalVaultKeychainStore: SelectiveRemotePersonalVaultKeyStore {
+    static let service = "local.selectiveremote.cloud.personal-vault-key.v1"
+
+    func material(endpoint: URL, deviceID: UUID) throws -> SelectiveRemotePersonalVaultKeyMaterial? {
+        let query = baseQuery(endpoint: endpoint, deviceID: deviceID).merging([
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]) { _, new in new }
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound { return nil }
+        guard status == errSecSuccess, let data = result as? Data else {
+            throw status == errSecSuccess ? KeychainError.invalidData : KeychainError.unexpectedStatus(status)
+        }
+        do { return try JSONDecoder().decode(SelectiveRemotePersonalVaultKeyMaterial.self, from: data) }
+        catch { throw KeychainError.invalidData }
+    }
+
+    func save(_ material: SelectiveRemotePersonalVaultKeyMaterial, endpoint: URL, deviceID: UUID) throws {
+        let data = try JSONEncoder().encode(material)
+        let query = baseQuery(endpoint: endpoint, deviceID: deviceID)
+        let updateStatus = SecItemUpdate(query as CFDictionary, [kSecValueData as String: data] as CFDictionary)
+        if updateStatus == errSecSuccess { return }
+        guard updateStatus == errSecItemNotFound else { throw KeychainError.unexpectedStatus(updateStatus) }
+        let item = query.merging([
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        ]) { _, new in new }
+        let addStatus = SecItemAdd(item as CFDictionary, nil)
+        guard addStatus == errSecSuccess else { throw KeychainError.unexpectedStatus(addStatus) }
+    }
+
+    func remove(endpoint: URL, deviceID: UUID) throws {
+        let status = SecItemDelete(baseQuery(endpoint: endpoint, deviceID: deviceID) as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+
+    private func baseQuery(endpoint: URL, deviceID: UUID) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.service,
+            kSecAttrAccount as String: "\(endpoint.absoluteString)|\(deviceID.uuidString.lowercased())"
+        ]
+    }
+}
+
+actor SelectiveRemotePersonalVaultAutoSync {
+    private let client: SelectiveRemoteCloudAPIClient
+    private let keyStore: any SelectiveRemotePersonalVaultKeyStore
+    private var pending: Task<Void, Never>?
+
+    init(
+        client: SelectiveRemoteCloudAPIClient = .init(),
+        keyStore: any SelectiveRemotePersonalVaultKeyStore = SelectiveRemotePersonalVaultKeychainStore()
+    ) {
+        self.client = client
+        self.keyStore = keyStore
+    }
+
+    func schedule(
+        endpoint: URL,
+        deviceID: UUID,
+        profiles: [ConnectionProfile],
+        snippets: [TerminalCommandTemplate],
+        forwarding: [IndependentPortForward]
+    ) {
+        pending?.cancel()
+        pending = Task {
+            try? await Task.sleep(for: .seconds(2))
+            guard !Task.isCancelled else { return }
+            try? await synchronize(
+                endpoint: endpoint,
+                deviceID: deviceID,
+                profiles: profiles,
+                snippets: snippets,
+                forwarding: forwarding
+            )
+        }
+    }
+
+    private func synchronize(
+        endpoint: URL,
+        deviceID: UUID,
+        profiles: [ConnectionProfile],
+        snippets: [TerminalCommandTemplate],
+        forwarding: [IndependentPortForward]
+    ) async throws {
+        guard var material = try keyStore.material(endpoint: endpoint, deviceID: deviceID),
+              !material.includesCredentials,
+              await client.hasStoredSession(endpoint: endpoint)
+        else { return }
+        let exported = try SelectiveRemotePersonalVaultExporter.makeExport(
+            profiles: profiles,
+            credentials: [],
+            snippets: snippets,
+            forwarding: forwarding,
+            deviceID: deviceID,
+            allowEmpty: true
+        )
+        let documentHash = Data(SHA256.hash(data: try exported.document.encoded()))
+        guard documentHash != material.documentHash else { return }
+        let remote = try await client.personalVault(endpoint: endpoint)
+        guard remote.id == material.vaultID, remote.revision == material.revision else {
+            throw SelectiveRemotePersonalVaultError.uploadConflict(remote.revision)
+        }
+        let envelope = try SelectiveRemotePersonalVaultCrypto.reseal(
+            exported.document,
+            vaultKey: material.vaultKey,
+            wrappedKey: material.wrappedKey,
+            baseRevision: remote.revision
+        )
+        let result = try await client.putPersonalVault(endpoint: endpoint, envelope: envelope)
+        guard !result.conflict, result.revision == remote.revision + 1 else {
+            throw SelectiveRemotePersonalVaultError.uploadConflict(result.revision)
+        }
+        material.revision = result.revision
+        material.documentHash = documentHash
+        try keyStore.save(material, endpoint: endpoint, deviceID: deviceID)
+    }
+}

--- a/Sources/SelectiveRemote/CloudPersonalVaultSync.swift
+++ b/Sources/SelectiveRemote/CloudPersonalVaultSync.swift
@@ -91,6 +91,11 @@ struct SelectiveRemotePersonalVaultEnvelope: Codable, Equatable, Sendable {
     }
 }
 
+struct SelectiveRemotePersonalVaultSetup: Equatable, Sendable {
+    let envelope: SelectiveRemotePersonalVaultEnvelope
+    let vaultKey: Data
+}
+
 struct SelectiveRemoteCloudPersonalVault: Equatable, Sendable {
     let id: UUID
     let revision: Int
@@ -132,7 +137,8 @@ enum SelectiveRemotePersonalVaultExporter {
         snippets: [TerminalCommandTemplate],
         forwarding: [IndependentPortForward],
         deviceID: UUID,
-        now: Date = Date()
+        now: Date = Date(),
+        allowEmpty: Bool = false
     ) throws -> SelectiveRemotePersonalVaultExport {
         let timestamp = timestamp(now)
         let version = try SelectiveRemoteVaultVersion([deviceID: 1])
@@ -209,7 +215,9 @@ enum SelectiveRemotePersonalVaultExporter {
             snippets: snippets.count,
             forwarding: forwarding.count
         )
-        guard summary.total > 0 else { throw SelectiveRemotePersonalVaultError.emptyLocalVault }
+        guard allowEmpty || summary.total > 0 else {
+            throw SelectiveRemotePersonalVaultError.emptyLocalVault
+        }
         return .init(document: document, summary: summary)
     }
 
@@ -278,6 +286,55 @@ enum SelectiveRemotePersonalVaultCrypto {
             return try .init(
                 baseRevision: baseRevision,
                 wrappedKey: .init(salt: rawSalt, value: wrapped),
+                ciphertext: sealed.ciphertext,
+                nonce: rawNonce,
+                authTag: sealed.tag
+            )
+        } catch let error as SelectiveRemotePersonalVaultError {
+            throw error
+        } catch {
+            throw SelectiveRemotePersonalVaultError.cryptoFailure
+        }
+    }
+
+    static func createSetup(
+        _ document: SelectiveRemoteVaultDocument,
+        recoveryPhrase: String,
+        baseRevision: Int
+    ) throws -> SelectiveRemotePersonalVaultSetup {
+        let key = try randomData(count: 32)
+        return try .init(
+            envelope: seal(
+                document,
+                recoveryPhrase: recoveryPhrase,
+                baseRevision: baseRevision,
+                vaultKey: key
+            ),
+            vaultKey: key
+        )
+    }
+
+    static func reseal(
+        _ document: SelectiveRemoteVaultDocument,
+        vaultKey: Data,
+        wrappedKey: SelectiveRemotePersonalVaultWrappedKey,
+        baseRevision: Int,
+        nonce: Data? = nil
+    ) throws -> SelectiveRemotePersonalVaultEnvelope {
+        let rawNonce = try nonce ?? randomData(count: 12)
+        guard vaultKey.count == 32, rawNonce.count == 12, baseRevision > 0 else {
+            throw SelectiveRemotePersonalVaultError.invalidEnvelope
+        }
+        do {
+            let sealed = try AES.GCM.seal(
+                document.encoded(),
+                using: SymmetricKey(data: vaultKey),
+                nonce: AES.GCM.Nonce(data: rawNonce),
+                authenticating: additionalData
+            )
+            return try .init(
+                baseRevision: baseRevision,
+                wrappedKey: wrappedKey,
                 ciphertext: sealed.ciphertext,
                 nonce: rawNonce,
                 authTag: sealed.tag

--- a/Sources/SelectiveRemote/CloudSettingsView.swift
+++ b/Sources/SelectiveRemote/CloudSettingsView.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import SwiftUI
 
 struct CloudSettingsView: View {
@@ -33,9 +34,11 @@ struct CloudSettingsView: View {
     @State private var personalVaultRecoveryPhrase = ""
     @State private var personalVaultRecoveryConfirmation = ""
     @State private var includePersonalVaultCredentials = false
+    @State private var personalVaultAutoSyncConfigured = false
 
     private let client = SelectiveRemoteCloudAPIClient()
     private let identityManager = SelectiveRemoteTeamDeviceIdentityManager()
+    private let personalVaultKeyStore = SelectiveRemotePersonalVaultKeychainStore()
 
     var body: some View {
         Form {
@@ -190,11 +193,17 @@ struct CloudSettingsView: View {
                         Text(localPersonalVaultSummary)
                             .foregroundStyle(.secondary)
                     }
+                    LabeledContent(UpdateLocalization.text(ru: "Автосинхронизация", en: "Automatic sync")) {
+                        Text(personalVaultAutoSyncConfigured
+                            ? UpdateLocalization.text(ru: "Включена", en: "Enabled")
+                            : UpdateLocalization.text(ru: "Не настроена", en: "Not configured"))
+                            .foregroundStyle(personalVaultAutoSyncConfigured ? Color.green : Color.secondary)
+                    }
 
                     Button(
                         UpdateLocalization.text(
-                            ru: "Зашифровать и отправить локальные данные…",
-                            en: "Encrypt and Upload Local Data…"
+                            ru: "Настроить защищённую синхронизацию…",
+                            en: "Set Up Secure Sync…"
                         ),
                         systemImage: "lock.doc.fill"
                     ) {
@@ -225,8 +234,8 @@ struct CloudSettingsView: View {
                     }
 
                     Text(UpdateLocalization.text(
-                        ru: "Первая отправка доступна только для пустого Cloud Vault. Recovery-фраза и открытые данные не сохраняются на сервере; существующая ревизия никогда не перезаписывается этим действием.",
-                        en: "The first upload is available only for an empty Cloud Vault. The recovery phrase and plaintext are never stored on the server; this action never replaces an existing revision."
+                        ru: "Настройка выполняется один раз для пустого Cloud Vault. Затем Hosts, Snippets и Forwarding синхронизируются автоматически. Recovery-фраза и открытые данные не сохраняются на сервере; конфликты никогда не перезаписываются молча.",
+                        en: "Setup runs once for an empty Cloud Vault. Hosts, Snippets and Forwarding then sync automatically. The recovery phrase and plaintext are never stored on the server, and conflicts are never overwritten silently."
                     ))
                     .font(.caption2)
                     .foregroundStyle(.secondary)
@@ -553,6 +562,12 @@ struct CloudSettingsView: View {
         do {
             let personalVault = try await client.personalVault(endpoint: url)
             personalVaultRevision = personalVault.revision
+            if let deviceID = UUID(uuidString: storedDeviceID), deviceID.isSelectiveRemoteCloudUUID {
+                let material = try? personalVaultKeyStore.material(endpoint: url, deviceID: deviceID)
+                personalVaultAutoSyncConfigured = material?.vaultID == personalVault.id
+                    && material?.revision == personalVault.revision
+                    && material?.includesCredentials == false
+            }
         } catch {
             if error as? SelectiveRemoteCloudError == .authenticationRequired {
                 resetAccountPresentation(endpoint: url)
@@ -613,6 +628,7 @@ struct CloudSettingsView: View {
         personalVaultRevision = nil
         personalVaultMessage = nil
         personalVaultMessageIsError = false
+        personalVaultAutoSyncConfigured = false
         accountErrorMessage = nil
         inventoryErrorMessage = nil
         personalVaultLoadErrorMessage = nil
@@ -753,22 +769,36 @@ struct CloudSettingsView: View {
                     forwarding: model.independentPortForwards,
                     deviceID: resolvedDeviceID()
                 )
-                let document = exported.document
-                let envelope = try await Task.detached(priority: .userInitiated) {
-                    try SelectiveRemotePersonalVaultCrypto.seal(
-                        document,
+                let setup = try await Task.detached(priority: .userInitiated) {
+                    try SelectiveRemotePersonalVaultCrypto.createSetup(
+                        exported.document,
                         recoveryPhrase: recoveryPhrase,
                         baseRevision: 0
                     )
                 }.value
-                let result = try await client.putPersonalVault(endpoint: url, envelope: envelope)
+                let result = try await client.putPersonalVault(endpoint: url, envelope: setup.envelope)
                 guard !result.conflict else {
                     throw SelectiveRemotePersonalVaultError.uploadConflict(result.revision)
                 }
+                let documentHash = Data(SHA256.hash(data: try exported.document.encoded()))
+                let material = try SelectiveRemotePersonalVaultKeyMaterial(
+                    vaultID: remote.id,
+                    vaultKey: setup.vaultKey,
+                    wrappedKey: setup.envelope.wrappedKey,
+                    revision: result.revision,
+                    documentHash: documentHash,
+                    includesCredentials: !credentials.isEmpty
+                )
+                try personalVaultKeyStore.save(material, endpoint: url, deviceID: resolvedDeviceID())
+                personalVaultAutoSyncConfigured = credentials.isEmpty
                 personalVaultRevision = result.revision
                 personalVaultMessage = UpdateLocalization.text(
-                    ru: "Personal Vault отправлен: Hosts \(exported.summary.hosts), Credentials \(exported.summary.credentials), Snippets \(exported.summary.snippets), Forwarding \(exported.summary.forwarding). Ревизия r\(result.revision).",
-                    en: "Personal Vault uploaded: Hosts \(exported.summary.hosts), Credentials \(exported.summary.credentials), Snippets \(exported.summary.snippets), Forwarding \(exported.summary.forwarding). Revision r\(result.revision)."
+                    ru: credentials.isEmpty
+                        ? "Защищённая автосинхронизация включена. Первая ревизия r\(result.revision) отправлена."
+                        : "Ревизия r\(result.revision) отправлена с паролями. Фоновая синхронизация для неё отключена, чтобы не удалить секреты без подтверждения.",
+                    en: credentials.isEmpty
+                        ? "Secure automatic sync is enabled. Initial revision r\(result.revision) was uploaded."
+                        : "Revision r\(result.revision) was uploaded with passwords. Background sync is disabled for it so secrets cannot be removed without confirmation."
                 )
                 personalVaultMessageIsError = false
                 personalVaultUploading = false

--- a/Sources/SelectiveRemote/SelectiveRemoteApp.swift
+++ b/Sources/SelectiveRemote/SelectiveRemoteApp.swift
@@ -130,6 +130,7 @@ struct SelectiveRemoteApp: App {
     @StateObject private var language = AppLanguageStore()
     @StateObject private var appAppearance = AppAppearanceStore.shared
     @StateObject private var appLock = AppLockStore()
+    private let personalVaultAutoSync = SelectiveRemotePersonalVaultAutoSync()
 
     private var menuBarSystemImage: String {
         if appLock.isLocked { return "lock.fill" }
@@ -154,6 +155,12 @@ struct SelectiveRemoteApp: App {
                     .frame(minWidth: 1050, minHeight: 700)
                     .onAppear {
                         model.presentWhatsNewAfterUpgradeIfNeeded()
+                        schedulePersonalVaultAutoSync()
+                    }
+                    .onChange(of: model.profiles) { _, _ in schedulePersonalVaultAutoSync() }
+                    .onChange(of: model.independentPortForwards) { _, _ in schedulePersonalVaultAutoSync() }
+                    .onReceive(TerminalCommandHistoryStore.shared.$snippetRevision) { _ in
+                        schedulePersonalVaultAutoSync()
                     }
             }
         }
@@ -386,5 +393,25 @@ struct SelectiveRemoteApp: App {
         }
         .menuBarExtraStyle(.menu)
         .environment(\.locale, language.locale)
+    }
+
+    private func schedulePersonalVaultAutoSync() {
+        guard let endpointText = UserDefaults.standard.string(forKey: "SelectiveRemote.cloud.endpoint.v1"),
+              let endpoint = try? SelectiveRemoteCloudEndpoint.normalized(endpointText),
+              let deviceText = UserDefaults.standard.string(forKey: "SelectiveRemote.cloud.device-id.v1"),
+              let deviceID = UUID(uuidString: deviceText), deviceID.isSelectiveRemoteCloudUUID
+        else { return }
+        let profiles = model.profiles
+        let snippets = TerminalCommandHistoryStore.shared.templates()
+        let forwarding = model.independentPortForwards
+        Task {
+            await personalVaultAutoSync.schedule(
+                endpoint: endpoint,
+                deviceID: deviceID,
+                profiles: profiles,
+                snippets: snippets,
+                forwarding: forwarding
+            )
+        }
     }
 }

--- a/Tests/SelectiveRemoteTests/CloudPersonalVaultSyncTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudPersonalVaultSyncTests.swift
@@ -142,6 +142,43 @@ struct CloudPersonalVaultSyncTests {
             == .init(conflict: false, revision: 1))
     }
 
+    @Test("automatic revisions reuse the local Vault key without the recovery phrase")
+    func automaticReseal() throws {
+        let firstDocument = try SelectiveRemoteVaultDocument(records: [Self.syntheticRecord()])
+        let first = try SelectiveRemotePersonalVaultCrypto.seal(
+            firstDocument,
+            recoveryPhrase: "correct horse battery staple",
+            baseRevision: 0,
+            vaultKey: Data(repeating: 0x11, count: 32),
+            salt: Data(repeating: 0x22, count: 16),
+            nonce: Data(repeating: 0x33, count: 12)
+        )
+        let next = try SelectiveRemotePersonalVaultCrypto.reseal(
+            firstDocument,
+            vaultKey: Data(repeating: 0x11, count: 32),
+            wrappedKey: first.wrappedKey,
+            baseRevision: 1,
+            nonce: Data(repeating: 0x44, count: 12)
+        )
+
+        #expect(next.baseRevision == 1)
+        #expect(next.wrappedKey == first.wrappedKey)
+        #expect(next.nonce != first.nonce)
+        #expect(next.ciphertext != first.ciphertext)
+        #expect(next.authTag != first.authTag)
+    }
+
+    @Test("automatic export can represent deletion of every local record")
+    func automaticEmptyExport() throws {
+        let deviceID = try #require(UUID(uuidString: "44444444-4444-4444-8444-444444444444"))
+        let exported = try SelectiveRemotePersonalVaultExporter.makeExport(
+            profiles: [], credentials: [], snippets: [], forwarding: [],
+            deviceID: deviceID, allowEmpty: true
+        )
+        #expect(exported.summary.total == 0)
+        #expect(exported.document.records.isEmpty)
+    }
+
     @Test("an empty Personal Vault accepts only the deployed envelope marker")
     func emptyVaultEnvelopeMarker() async throws {
         let endpoint = try SelectiveRemoteCloudEndpoint.normalized("https://cloud.example.invalid")


### PR DESCRIPTION
## Summary
- store the Personal Vault key only in this Mac's device-only Keychain after one-time recovery-phrase setup
- automatically debounce and upload encrypted Hosts, Snippets, and Forwarding changes after two seconds
- stop on any remote revision divergence instead of overwriting conflicts
- keep saved passwords out of background synchronization
- rebased onto current `main` `38ee744a2b3c6745897654ac165b2e7d61461833`

## Validation
- current Cloud suite: 248 tests, 247 passed, 1 skipped without `TEST_DATABASE_URL`
- CI #541: success
- Test DMG #221: success
- artifact: `SelectiveRemote-test-66-arm64`, SHA-256 `57a7da19fb959e8b7417f10ebf232e2b6cca608a9ffb6a9ef185590c542f7370`
- diff remains limited to five macOS/Swift files

`main` is unchanged pending explicit exact-head approval for `0ebc810f7aa55c5e94cee5a5cc94260fbcc44287`.