### PR TITLE
Remove duplicate Cloud calls to action

### DIFF
--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -335,7 +335,7 @@ export async function initializeLocalVault({
   updateLabels();
   try {
     mode(await controller.status());
-    setText(message, "Данные зашифрованы локально; после входа доступна ручная Cloud-синхронизация.");
+    setText(message, "Данные зашифрованы локально; браузер разблокирует Vault только на этом устройстве.");
   } catch {
     setup.hidden = true;
     unlock.hidden = true;

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -172,7 +172,7 @@
           </div>
           <div class="workspace-notice">
             <strong>Ожидается первая синхронизация с Mac</strong>
-            <p>Локальные подключения из установленного приложения появятся здесь после отправки Personal Vault с Mac. Текущая версия macOS-клиента ещё не выполняет этот импорт автоматически.</p>
+            <p>Локальные подключения появятся здесь после защищённой синхронизации Personal Vault с Mac.</p>
           </div>
         </section>
 
@@ -222,7 +222,7 @@
 
       <div class="vault-workspace" id="local-vault-workspace" hidden>
         <div class="vault-toolbar">
-          <div><h3>Личный Vault</h3><p>Зашифрованная локальная копия с ручной Cloud-синхронизацией.</p></div>
+          <div><h3>Личный Vault</h3><p>Зашифрованная копия, которая разблокируется только на вашем устройстве.</p></div>
           <div class="vault-actions">
             <button type="button" id="cloud-vault-sync" disabled>Синхронизировать</button>
             <button type="button" class="secondary" id="local-vault-lock">Заблокировать</button>

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -17,7 +17,6 @@
       </div>
       <nav class="brand-actions" id="public-actions" aria-label="Аккаунт">
         <button type="button" class="secondary" data-open-auth="login">Войти</button>
-        <button type="button" data-open-auth="registration">Создать аккаунт</button>
       </nav>
       <span class="status" id="service-status">Проверка сервиса…</span>
     </header>
@@ -54,8 +53,7 @@
           <span>HTTPS</span>
         </div>
         <div class="hero-actions">
-          <button type="button" data-open-auth="login">Войти в Cloud</button>
-          <button type="button" class="secondary" data-open-auth="registration">Создать аккаунт</button>
+          <button type="button" data-open-auth="registration">Создать аккаунт</button>
         </div>
       </div>
 

--- a/cloud/public/styles.css
+++ b/cloud/public/styles.css
@@ -99,10 +99,10 @@ body { margin:0; min-height:100vh; background:radial-gradient(circle at 70% 15%,
 .team-devices small,.team-device-fingerprint { color:var(--muted); }.team-device-fingerprint { margin:0; font:12px ui-monospace,monospace; }
 .team-devices button { grid-row:1 / span 3; }.team-devices button.danger { grid-column:3; }
 .team-members { display:grid; gap:10px; margin-bottom:20px; }
-.team-members article { display:grid; grid-template-columns:minmax(0,1fr) auto auto; gap:8px 10px; align-items:center; padding:14px; border:1px solid var(--line); border-radius:12px; }
+.team-members article { display:grid; grid-template-columns:minmax(180px,1fr) minmax(110px,auto); gap:8px 10px; align-items:center; padding:14px; border:1px solid var(--line); border-radius:12px; }
 .team-members strong,.team-members small { grid-column:1; overflow-wrap:anywhere; }.team-members small { color:var(--muted); }
 .team-members select { grid-column:2; grid-row:1 / span 2; min-width:110px; }
-.team-members button { padding:9px 11px; }.team-members button.danger { grid-column:3; }
+.team-members button { grid-column:1; grid-row:3; justify-self:start; padding:9px 11px; }.team-members button.danger { grid-column:2; grid-row:3; }
 .team-lifecycle { margin-top:26px; padding:20px; border:1px solid var(--line); border-radius:14px; background:#08110e; }
 .team-lifecycle>h3,.team-lifecycle>p,.team-lifecycle h4 { margin-top:0; }.team-lifecycle>p { color:var(--muted); line-height:1.5; }
 .team-lifecycle-forms { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:16px; }

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -94,6 +94,8 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(html, /id="cloud-workspace"[^>]*hidden/u);
   assert.match(html, /data-open-auth="login"/u);
   assert.match(html, /data-open-auth="registration"/u);
+  assert.equal((html.match(/data-open-auth="login"/gu) ?? []).length, 1);
+  assert.equal((html.match(/data-open-auth="registration"/gu) ?? []).length, 1);
   assert.match(html, /id="cloud-login-form"/u);
   assert.match(html, /id="cloud-vault-sync"/u);
   assert.match(html, /id="cloud-logout"/u);
@@ -131,6 +133,7 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(html, /Текущая версия macOS-клиента ещё не выполняет этот импорт автоматически/u);
   assert.match(styles, /\[hidden\]\s*\{\s*display:\s*none\s*!important;\s*\}/u);
   assert.match(styles, /\.workspace-layout/u);
+  assert.match(styles, /\.team-members article\s*\{[^}]*grid-template-columns:minmax\(180px,1fr\) minmax\(110px,auto\)/u);
   assert.match(application, /initializePortalNavigation/u);
   assert.match(application, /hostDetail\?\.showModal\(\)/u);
   assert.match(application, /resourceTitles/u);

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -130,7 +130,8 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(html, /data-record-filter="credential"/u);
   assert.match(html, /data-record-filter="snippet"/u);
   assert.match(html, /data-record-filter="forwarding"/u);
-  assert.match(html, /Текущая версия macOS-клиента ещё не выполняет этот импорт автоматически/u);
+  assert.match(html, /защищённой синхронизации Personal Vault с Mac/u);
+  assert.doesNotMatch(html, /ещё не выполняет этот импорт автоматически/u);
   assert.match(styles, /\[hidden\]\s*\{\s*display:\s*none\s*!important;\s*\}/u);
   assert.match(styles, /\.workspace-layout/u);
   assert.match(styles, /\.team-members article\s*\{[^}]*grid-template-columns:minmax\(180px,1fr\) minmax\(110px,auto\)/u);


### PR DESCRIPTION
## Summary
- keep one Sign In entry in the public header
- keep one Create Account call to action in the hero
- prevent the Team member email from collapsing into one character per line
- lock the single-entry CTA contract with tests

## Validation
- Cloud suite: 246 passed, 1 skipped without TEST_DATABASE_URL