### PR TITLE
Split Team management, Vaults, and Hosts navigation

### DIFF
--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -379,16 +379,19 @@ export function initializeTeamWorkspace({
 } = {}) {
   const section = documentValue.querySelector("#team-vault");
   if (!section || !client) return null;
+  const sectionTitle = documentValue.querySelector("#team-vault-title");
   const message = documentValue.querySelector("#team-vault-message");
   const devices = documentValue.querySelector("#team-devices");
   const devicesRefresh = documentValue.querySelector("#team-devices-refresh");
   const createTeamForm = documentValue.querySelector("#team-create-form");
   const acceptInvitationForm = documentValue.querySelector("#team-invitation-accept-form");
+  const onboarding = documentValue.querySelector("#team-onboarding");
   const teamSelect = documentValue.querySelector("#team-select");
   const teamRefresh = documentValue.querySelector("#team-refresh");
   const selectedPanel = documentValue.querySelector("#team-selected");
   const teamRole = documentValue.querySelector("#team-role");
   const members = documentValue.querySelector("#team-members");
+  const membersView = documentValue.querySelector("#team-members-view");
   const inviteForm = documentValue.querySelector("#team-invite-form");
   const lifecyclePanel = documentValue.querySelector("#team-lifecycle");
   const renameTeamForm = documentValue.querySelector("#team-rename-form");
@@ -396,6 +399,7 @@ export function initializeTeamWorkspace({
   const transferOwnershipMember = documentValue.querySelector("#team-ownership-member");
   const archiveTeamForm = documentValue.querySelector("#team-archive-form");
   const createVaultForm = documentValue.querySelector("#team-vault-create-form");
+  const vaultDirectoryView = documentValue.querySelector("#team-vault-directory-view");
   const vaultSelect = documentValue.querySelector("#team-vault-select");
   const vaultOpen = documentValue.querySelector("#team-vault-open");
   const workspace = documentValue.querySelector("#team-vault-workspace");
@@ -425,6 +429,7 @@ export function initializeTeamWorkspace({
   let selectedVault = null;
   let controller = null;
   let activeConflicts = null;
+  let activeView = "teams";
 
   function canManage() {
     return ["owner", "admin"].includes(selectedTeam?.role);
@@ -439,6 +444,7 @@ export function initializeTeamWorkspace({
       control.disabled = disabled || !canEdit();
     }
     for (const button of records.querySelectorAll("button")) button.disabled = disabled || !canEdit();
+    recordType.disabled = disabled || !canEdit() || activeView === "hosts";
   }
 
   function clearConflicts() {
@@ -475,7 +481,7 @@ export function initializeTeamWorkspace({
       records.append(empty);
       return;
     }
-    for (const record of current.records) {
+    for (const record of current.records.filter((value) => activeView !== "hosts" || value.type === "host")) {
       const card = documentValue.createElement("article");
       const heading = documentValue.createElement("h4");
       const summary = documentValue.createElement("p");
@@ -681,6 +687,25 @@ export function initializeTeamWorkspace({
     clearConflicts();
   }
 
+  function setView(view) {
+    activeView = ["teams", "vaults", "hosts"].includes(view) ? view : "teams";
+    section.dataset.teamView = activeView;
+    setText(sectionTitle, { teams: "Команды", vaults: "Командные хранилища", hosts: "Командные хосты" }[activeView]);
+    onboarding.hidden = activeView !== "teams";
+    membersView.hidden = activeView !== "teams";
+    vaultDirectoryView.hidden = activeView === "teams";
+    lifecyclePanel.hidden = activeView !== "teams" || selectedTeam?.role !== "owner";
+    createVaultForm.hidden = activeView !== "vaults" || !canManage();
+    workspace.hidden = activeView === "teams" || !controller;
+    if (activeView === "hosts") recordType.value = "host";
+    updateRecordLabels();
+    if (controller) {
+      clearConflicts();
+      renderRecords();
+      setWorkspaceControls(false);
+    }
+  }
+
   async function openSelectedVault() {
     const vault = vaults.find((value) => value.id === vaultSelect.value);
     if (!vault || !identity) return;
@@ -692,7 +717,7 @@ export function initializeTeamWorkspace({
       identity,
       scope,
     });
-    workspace.hidden = false;
+    workspace.hidden = activeView === "teams";
     rotateButton.hidden = !vault.rotationRequired || !canManage();
     rotateButton.disabled = !vault.rotationRequired || !canManage();
     grantWrappersButton.hidden = vault.rotationRequired || !canManage();
@@ -735,8 +760,8 @@ export function initializeTeamWorkspace({
     selectedPanel.hidden = false;
     teamRole.textContent = `${selectedTeam.name} · ${selectedTeam.role}`;
     inviteForm.hidden = !canManage();
-    createVaultForm.hidden = !canManage();
-    lifecyclePanel.hidden = selectedTeam.role !== "owner";
+    createVaultForm.hidden = activeView !== "vaults" || !canManage();
+    lifecyclePanel.hidden = activeView !== "teams" || selectedTeam.role !== "owner";
     renameTeamForm.elements.name.value = selectedTeam.name;
     archiveTeamForm.reset();
     transferOwnershipForm.reset();
@@ -1070,7 +1095,9 @@ export function initializeTeamWorkspace({
   });
 
   updateRecordLabels();
+  setView("teams");
   return {
+    setView,
     async activate(nextIdentity) {
       identity = nextIdentity;
       await Promise.all([loadDevices(), loadTeams()]);
@@ -1472,7 +1499,7 @@ export async function initializeCloudAccount({
 
   showSession(null);
   setAuthMode("login");
-  return { client, showAuth: setAuthMode };
+  return { client, showAuth: setAuthMode, teamWorkspace };
 }
 
 export function initializePortalNavigation({
@@ -1480,6 +1507,7 @@ export function initializePortalNavigation({
   locationValue = location,
   historyValue = history,
   vaultUI = null,
+  teamUI = null,
   showAuthMode = () => {},
 } = {}) {
   const brand = documentValue.querySelector("#site-brand");
@@ -1499,7 +1527,7 @@ export function initializePortalNavigation({
   const titles = {
     "workspace-overview": "Обзор",
     "local-vault": "Personal Vault",
-    "team-vault": "Teams и Vaults",
+    "team-vault": "Команды",
     "workspace-devices": "Устройства",
     "workspace-settings": "Настройки",
   };
@@ -1510,6 +1538,7 @@ export function initializePortalNavigation({
     forwarding: "Forwarding",
     all: "Personal Vault",
   };
+  const teamTitles = { teams: "Команды", vaults: "Team Vaults", hosts: "Team Hosts" };
   let sessionActive = false;
 
   function setPath(path, replace = false) {
@@ -1518,19 +1547,22 @@ export function initializePortalNavigation({
     historyValue[method]?.({}, "", path);
   }
 
-  function selectWorkspacePanel(target, recordFilter = null) {
+  function selectWorkspacePanel(target, recordFilter = null, teamView = null) {
     const panelID = Object.hasOwn(titles, target) ? target : "workspace-overview";
     for (const panel of workspacePanels) panel.hidden = panel.id !== panelID;
     for (const button of sidebarButtons) {
       const matchesPanel = button.dataset.workspaceTarget === panelID;
       const matchesFilter = panelID !== "local-vault"
         || (button.dataset.recordFilter || "all") === (recordFilter || "all");
-      button.classList.toggle("active", matchesPanel && matchesFilter);
+      const matchesTeamView = panelID !== "team-vault"
+        || (button.dataset.teamView || "teams") === (teamView || "teams");
+      button.classList.toggle("active", matchesPanel && matchesFilter && matchesTeamView);
     }
     setText(workspaceTitle, panelID === "local-vault"
       ? resourceTitles[recordFilter || "all"]
-      : titles[panelID]);
+      : panelID === "team-vault" ? teamTitles[teamView || "teams"] : titles[panelID]);
     if (recordFilter) vaultUI?.setFilter(recordFilter);
+    if (panelID === "team-vault") teamUI?.setView(teamView || "teams");
   }
 
   function showLanding({ replace = false } = {}) {
@@ -1581,6 +1613,7 @@ export function initializePortalNavigation({
     button.addEventListener("click", () => selectWorkspacePanel(
       button.dataset.workspaceTarget,
       button.dataset.recordFilter || null,
+      button.dataset.teamView || null,
     ));
   }
 
@@ -1720,6 +1753,7 @@ export async function initializePortal({
     locationValue,
     historyValue,
     vaultUI,
+    teamUI: account?.teamWorkspace,
     showAuthMode: account?.showAuth,
   });
 }

--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -474,14 +474,17 @@ export function initializeTeamWorkspace({
     records.replaceChildren();
     if (!controller) return;
     const current = controller.document();
-    if (current.records.length === 0) {
+    const visibleRecords = current.records.filter((value) => activeView !== "hosts" || value.type === "host");
+    if (visibleRecords.length === 0) {
       const empty = documentValue.createElement("p");
       empty.className = "vault-empty";
-      empty.textContent = "Shared Vault пока пуст.";
+      empty.textContent = activeView === "hosts"
+        ? "В выбранном Team Vault пока нет хостов."
+        : "Shared Vault пока пуст.";
       records.append(empty);
       return;
     }
-    for (const record of current.records.filter((value) => activeView !== "hosts" || value.type === "host")) {
+    for (const record of visibleRecords) {
       const card = documentValue.createElement("article");
       const heading = documentValue.createElement("h4");
       const summary = documentValue.createElement("p");

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -147,7 +147,9 @@
           <button type="button" data-workspace-target="local-vault" data-record-filter="forwarding">Forwarding</button>
           <p class="workspace-nav-label">Хранилища</p>
           <button type="button" data-workspace-target="local-vault" data-record-filter="all">Personal Vault</button>
-          <button type="button" data-workspace-target="team-vault">Команды и Team Vaults</button>
+          <button type="button" data-workspace-target="team-vault" data-team-view="teams">Команды</button>
+          <button type="button" data-workspace-target="team-vault" data-team-view="vaults">Team Vaults</button>
+          <button type="button" data-workspace-target="team-vault" data-team-view="hosts">Team Hosts</button>
           <p class="workspace-nav-label">Аккаунт</p>
           <button type="button" data-workspace-target="workspace-devices">Устройства</button>
           <button type="button" data-workspace-target="workspace-settings">Настройки</button>
@@ -337,7 +339,7 @@
         <p id="team-vault-message" aria-live="polite">Загрузка Teams…</p>
       </div>
 
-      <div class="team-onboarding">
+      <div class="team-onboarding" id="team-onboarding">
         <form id="team-create-form">
           <h3>Создать Team</h3>
           <label for="team-create-name">Название</label>
@@ -364,7 +366,7 @@
           <p>Роли и ключи проверяются сервером независимо от зашифрованного содержимого.</p>
         </div>
         <div class="team-columns">
-          <div>
+          <div id="team-members-view">
             <h3>Участники</h3>
             <div class="team-members" id="team-members"></div>
             <form id="team-invite-form">
@@ -380,7 +382,7 @@
               <button type="submit">Отправить приглашение</button>
             </form>
           </div>
-          <div>
+          <div id="team-vault-directory-view">
             <h3>Shared Vaults</h3>
             <form id="team-vault-create-form">
               <label for="team-vault-create-name">Название Vault</label>

--- a/cloud/public/styles.css
+++ b/cloud/public/styles.css
@@ -83,6 +83,7 @@ body { margin:0; min-height:100vh; background:var(--body-bg); color:var(--ink); 
 .local-vault { margin:50px 0; padding:34px; border:1px solid var(--line); border-radius:22px; background:#0c1714e8; }
 .team-vault { margin:50px 0; padding:34px; border:1px solid #75e0b45c; border-radius:22px; background:linear-gradient(145deg,#0c1714f2,#102019e8); }
 .team-onboarding,.team-columns { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:18px; margin-top:26px; }
+#team-selected .team-columns { grid-template-columns:1fr; }
 .team-onboarding form,.team-columns>div { padding:20px; border:1px solid var(--line); border-radius:14px; background:#08110e; }
 .team-onboarding form,.team-columns form { display:grid; gap:10px; }
 .team-onboarding h3,.team-columns h3,.team-columns h4 { margin:0 0 8px; }

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -146,7 +146,9 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(html, /data-workspace-target="local-vault" data-record-filter="host">Хосты/u);
   assert.match(html, /data-workspace-target="local-vault" data-record-filter="snippet">Сниппеты/u);
   assert.match(html, /data-workspace-target="local-vault" data-record-filter="credential">Учётные данные/u);
-  assert.match(html, /data-workspace-target="team-vault">Команды и Team Vaults/u);
+  assert.match(html, /data-workspace-target="team-vault" data-team-view="teams">Команды/u);
+  assert.match(html, /data-workspace-target="team-vault" data-team-view="vaults">Team Vaults/u);
+  assert.match(html, /data-workspace-target="team-vault" data-team-view="hosts">Team Hosts/u);
   assert.match(html, /id="host-detail-dialog"/u);
   assert.match(html, /data-workspace-target="workspace-settings"/u);
   assert.match(html, /id="account-delete-form"/u);
@@ -165,6 +167,8 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(styles, /prefers-reduced-motion:reduce[^}]*[\s\S]*animation:none!important/u);
   assert.match(styles, /\.team-members article\s*\{[^}]*grid-template-columns:minmax\(180px,1fr\) minmax\(110px,auto\)/u);
   assert.match(application, /initializePortalNavigation/u);
+  assert.match(application, /teamUI\?\.setView\(teamView \|\| "teams"\)/u);
+  assert.match(application, /activeView !== "hosts" \|\| value\.type === "host"/u);
   assert.match(application, /hostDetail\?\.showModal\(\)/u);
   assert.match(application, /resourceTitles/u);
   assert.match(application, /client\.deleteAccount/u);

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -169,6 +169,7 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(application, /initializePortalNavigation/u);
   assert.match(application, /teamUI\?\.setView\(teamView \|\| "teams"\)/u);
   assert.match(application, /activeView !== "hosts" \|\| value\.type === "host"/u);
+  assert.match(application, /В выбранном Team Vault пока нет хостов/u);
   assert.match(application, /hostDetail\?\.showModal\(\)/u);
   assert.match(application, /resourceTitles/u);
   assert.match(application, /client\.deleteAccount/u);


### PR DESCRIPTION
## Summary
- replace the single long Team workspace entry with separate Teams, Team Vaults, and Team Hosts sidebar destinations
- preserve the selected Team and Shared Vault while switching views
- show only Host records in Team Hosts and lock the record type to Host there
- show an explicit empty state when the selected Shared Vault contains no Hosts
- keep membership/lifecycle controls in Teams and Vault creation/workspace controls in Team Vaults

## Security
- no API, ciphertext, wrapper, or authorization changes
- the browser still decrypts Shared Vault records locally
- no browser storage of plaintext or session secrets added

## Verification
- focused browser UI/auth tests: 11 passed
- full Cloud suite: 248 tests, 247 passed, 1 PostgreSQL integration test skipped without `TEST_DATABASE_URL`

`main` and staging remain unchanged pending fresh checks and exact-head approval for `7915900e20f27c99e615087ce5656c2c67283946`.