### PR TITLE
Fix loaded Team workspace status

### DIFF
--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -439,6 +439,19 @@ export function initializeTeamWorkspace({
     return ["owner", "admin", "editor"].includes(selectedTeam?.role);
   }
 
+  function updateTeamMessage() {
+    if (!selectedTeam) return;
+    if (activeView === "teams") {
+      setText(message, `Team «${selectedTeam.name}» · участников: ${teamMembers.length}.`);
+    } else if (activeView === "vaults") {
+      setText(message, `Team «${selectedTeam.name}» · хранилищ: ${vaults.length}.`);
+    } else {
+      setText(message, selectedVault
+        ? `Team «${selectedTeam.name}» · Vault «${selectedVault.name}».`
+        : `Team «${selectedTeam.name}» · выберите Vault для просмотра хостов.`);
+    }
+  }
+
   function setWorkspaceControls(disabled) {
     for (const control of recordForm.querySelectorAll("input, select, textarea, button")) {
       control.disabled = disabled || !canEdit();
@@ -707,6 +720,7 @@ export function initializeTeamWorkspace({
       renderRecords();
       setWorkspaceControls(false);
     }
+    updateTeamMessage();
   }
 
   async function openSelectedVault() {
@@ -776,6 +790,7 @@ export function initializeTeamWorkspace({
     renderMembers(teamMembers);
     vaults = sharedVaults;
     populateVaults();
+    updateTeamMessage();
   }
 
   async function loadTeams(preferredID = null) {

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -168,6 +168,9 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(styles, /\.team-members article\s*\{[^}]*grid-template-columns:minmax\(180px,1fr\) minmax\(110px,auto\)/u);
   assert.match(application, /initializePortalNavigation/u);
   assert.match(application, /teamUI\?\.setView\(teamView \|\| "teams"\)/u);
+  assert.match(application, /Team «\$\{selectedTeam\.name\}» · участников: \$\{teamMembers\.length\}/u);
+  assert.match(application, /Team «\$\{selectedTeam\.name\}» · хранилищ: \$\{vaults\.length\}/u);
+  assert.match(application, /выберите Vault для просмотра хостов/u);
   assert.match(application, /activeView !== "hosts" \|\| value\.type === "host"/u);
   assert.match(application, /В выбранном Team Vault пока нет хостов/u);
   assert.match(application, /hostDetail\?\.showModal\(\)/u);


### PR DESCRIPTION
## Что изменено
- заменено зависшее `Загрузка Teams…` на фактический статус выбранного раздела
- для Команд показывается число участников
- для Team Vaults показывается число хранилищ
- для Team Hosts подсказывается выбрать Vault, либо отображается выбранный Vault

## Проверки
- `node --test cloud/tests/*.test.mjs`: 248 тестов, 247 успешно, 1 PostgreSQL-интеграционный тест штатно пропущен без `TEST_DATABASE_URL`

API, криптография и серверные данные не изменялись.