### PR TITLE
Add native macOS Team management workspace

### DIFF
--- a/Sources/SelectiveRemote/CloudAPIClient.swift
+++ b/Sources/SelectiveRemote/CloudAPIClient.swift
@@ -85,7 +85,7 @@ struct SelectiveRemoteCloudUser: Codable, Equatable, Sendable {
     var displayName: String
 }
 
-enum SelectiveRemoteCloudTeamRole: String, Codable, Equatable, Sendable {
+enum SelectiveRemoteCloudTeamRole: String, Codable, Equatable, Hashable, Sendable {
     case owner
     case admin
     case editor
@@ -111,6 +111,26 @@ struct SelectiveRemoteCloudSharedVault: Codable, Equatable, Identifiable, Sendab
     var rotationRequired: Bool
     var createdAt: String
     var updatedAt: String
+}
+
+struct SelectiveRemoteCloudTeamMember: Codable, Equatable, Identifiable, Sendable {
+    var id: UUID
+    var userID: UUID
+    var email: String
+    var displayName: String
+    var role: SelectiveRemoteCloudTeamRole
+    var epoch: Int
+    var joinedAt: String
+}
+
+struct SelectiveRemoteCloudTeamInvitation: Codable, Equatable, Identifiable, Sendable {
+    var id: UUID
+    var teamID: UUID
+    var email: String
+    var role: SelectiveRemoteCloudTeamRole
+    var status: String
+    var createdAt: String
+    var expiresAt: String
 }
 
 struct SelectiveRemoteCloudTeamKeyDevice: Codable, Equatable, Sendable {
@@ -425,6 +445,68 @@ actor SelectiveRemoteCloudAPIClient {
         return result.teams
     }
 
+    func createTeam(endpoint: URL, name: String) async throws -> SelectiveRemoteCloudTeam {
+        let normalizedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedName.isEmpty, normalizedName.count <= 120 else {
+            throw SelectiveRemoteCloudError.invalidRequest
+        }
+        let (data, http) = try await authorizedResponse(
+            endpoint: endpoint,
+            path: "v1/teams",
+            method: "POST",
+            body: try encoder.encode(TeamNameRequest(name: normalizedName)),
+            headers: ["Idempotency-Key": Self.idempotencyKey("team-create")]
+        )
+        guard http.statusCode == 201 else { throw serviceError(status: http.statusCode, data: data) }
+        guard Self.validSingleTeamJSON(data),
+              let result = try? decoder.decode(TeamResponse.self, from: data),
+              Self.validTeam(result.team)
+        else { throw SelectiveRemoteCloudError.invalidResponse }
+        return result.team
+    }
+
+    func teamMembers(endpoint: URL, teamID: UUID) async throws -> [SelectiveRemoteCloudTeamMember] {
+        guard teamID.isSelectiveRemoteCloudUUID else { throw SelectiveRemoteCloudError.invalidRequest }
+        let data = try await authorizedData(
+            endpoint: endpoint,
+            path: "v1/teams/\(teamID.canonicalCloudString)/members"
+        )
+        guard Self.validTeamMembersJSON(data),
+              let result = try? decoder.decode(TeamMembersResponse.self, from: data),
+              result.members.count <= 10_000,
+              result.members.allSatisfy(Self.validTeamMember),
+              Set(result.members.map(\.id)).count == result.members.count
+        else { throw SelectiveRemoteCloudError.invalidResponse }
+        return result.members
+    }
+
+    func inviteTeamMember(
+        endpoint: URL,
+        teamID: UUID,
+        email: String,
+        role: SelectiveRemoteCloudTeamRole
+    ) async throws -> SelectiveRemoteCloudTeamInvitation {
+        let normalizedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard teamID.isSelectiveRemoteCloudUUID,
+              !normalizedEmail.isEmpty,
+              normalizedEmail.count <= 254,
+              role != .owner
+        else { throw SelectiveRemoteCloudError.invalidRequest }
+        let (data, http) = try await authorizedResponse(
+            endpoint: endpoint,
+            path: "v1/teams/\(teamID.canonicalCloudString)/invitations",
+            method: "POST",
+            body: try encoder.encode(TeamInvitationRequest(email: normalizedEmail, role: role)),
+            headers: ["Idempotency-Key": Self.idempotencyKey("team-invite")]
+        )
+        guard http.statusCode == 201 else { throw serviceError(status: http.statusCode, data: data) }
+        guard Self.validTeamInvitationJSON(data),
+              let result = try? decoder.decode(TeamInvitationResponse.self, from: data),
+              Self.validTeamInvitation(result.invitation, teamID: teamID)
+        else { throw SelectiveRemoteCloudError.invalidResponse }
+        return result.invitation
+    }
+
     func sharedVaults(endpoint: URL, teamID: UUID) async throws -> [SelectiveRemoteCloudSharedVault] {
         guard teamID.isSelectiveRemoteCloudUUID else { throw SelectiveRemoteCloudError.invalidRequest }
         let data = try await authorizedData(
@@ -438,6 +520,31 @@ actor SelectiveRemoteCloudAPIClient {
               Set(result.vaults.map(\.id)).count == result.vaults.count
         else { throw SelectiveRemoteCloudError.invalidResponse }
         return result.vaults
+    }
+
+    func createSharedVault(
+        endpoint: URL,
+        teamID: UUID,
+        name: String
+    ) async throws -> SelectiveRemoteCloudSharedVault {
+        let normalizedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard teamID.isSelectiveRemoteCloudUUID,
+              !normalizedName.isEmpty,
+              normalizedName.count <= 120
+        else { throw SelectiveRemoteCloudError.invalidRequest }
+        let (data, http) = try await authorizedResponse(
+            endpoint: endpoint,
+            path: "v1/teams/\(teamID.canonicalCloudString)/vaults",
+            method: "POST",
+            body: try encoder.encode(TeamNameRequest(name: normalizedName)),
+            headers: ["Idempotency-Key": Self.idempotencyKey("vault-create")]
+        )
+        guard http.statusCode == 201 else { throw serviceError(status: http.statusCode, data: data) }
+        guard Self.validSingleSharedVaultJSON(data),
+              let result = try? decoder.decode(SharedVaultResponse.self, from: data),
+              Self.validSharedVault(result.vault, teamID: teamID)
+        else { throw SelectiveRemoteCloudError.invalidResponse }
+        return result.vault
     }
 
     func teamKeyDevices(
@@ -615,7 +722,11 @@ actor SelectiveRemoteCloudAPIClient {
 
     private static func validUserJSON(_ data: Data) -> Bool {
         guard let object = try? JSONSerialization.jsonObject(with: data) else { return false }
-        return validUserObject(object)
+        guard exactKeys(object, expected: ["id", "email", "displayName", "deviceID"]),
+              let deviceID = (object as? [String: Any])?["deviceID"] as? String,
+              UUID(uuidString: deviceID)?.isSelectiveRemoteCloudUUID == true
+        else { return false }
+        return true
     }
 
     private static func validLoginJSON(_ data: Data) -> Bool {
@@ -648,6 +759,82 @@ actor SelectiveRemoteCloudAPIClient {
             "createdAt", "updatedAt"
         ]
         return teams.allSatisfy { exactKeys($0, expected: keys) }
+    }
+
+    private static func validTeam(_ team: SelectiveRemoteCloudTeam) -> Bool {
+        team.id.isSelectiveRemoteCloudUUID
+            && team.membershipID.isSelectiveRemoteCloudUUID
+            && team.membershipEpoch > 0
+            && !team.name.isEmpty
+            && team.name.count <= 120
+            && !team.createdAt.isEmpty
+            && !team.updatedAt.isEmpty
+    }
+
+    private static func validSingleTeamJSON(_ data: Data) -> Bool {
+        guard let object = try? JSONSerialization.jsonObject(with: data),
+              exactKeys(object, expected: ["team"]),
+              let team = (object as? [String: Any])?["team"]
+        else { return false }
+        return exactKeys(team, expected: [
+            "id", "name", "membershipID", "role", "membershipEpoch", "createdAt", "updatedAt"
+        ])
+    }
+
+    private static func validTeamMember(_ member: SelectiveRemoteCloudTeamMember) -> Bool {
+        member.id.isSelectiveRemoteCloudUUID
+            && member.userID.isSelectiveRemoteCloudUUID
+            && !member.email.isEmpty && member.email.count <= 254
+            && !member.displayName.isEmpty && member.displayName.count <= 120
+            && member.epoch > 0 && !member.joinedAt.isEmpty
+    }
+
+    private static func validTeamMembersJSON(_ data: Data) -> Bool {
+        guard let object = try? JSONSerialization.jsonObject(with: data),
+              exactKeys(object, expected: ["members"]),
+              let members = (object as? [String: Any])?["members"] as? [Any]
+        else { return false }
+        return members.allSatisfy { exactKeys($0, expected: [
+            "id", "userID", "email", "displayName", "role", "epoch", "joinedAt"
+        ]) }
+    }
+
+    private static func validTeamInvitationJSON(_ data: Data) -> Bool {
+        guard let object = try? JSONSerialization.jsonObject(with: data),
+              exactKeys(object, expected: ["invitation"]),
+              let invitation = (object as? [String: Any])?["invitation"]
+        else { return false }
+        return exactKeys(invitation, expected: [
+            "id", "teamID", "email", "role", "status", "createdAt", "expiresAt"
+        ])
+    }
+
+    private static func validTeamInvitation(
+        _ invitation: SelectiveRemoteCloudTeamInvitation,
+        teamID: UUID
+    ) -> Bool {
+        invitation.id.isSelectiveRemoteCloudUUID
+            && invitation.teamID == teamID
+            && !invitation.email.isEmpty && invitation.email.count <= 254
+            && invitation.role != .owner
+            && invitation.status == "pending"
+            && !invitation.createdAt.isEmpty
+            && !invitation.expiresAt.isEmpty
+    }
+
+    private static func validSingleSharedVaultJSON(_ data: Data) -> Bool {
+        guard let object = try? JSONSerialization.jsonObject(with: data),
+              exactKeys(object, expected: ["vault"]),
+              let vault = (object as? [String: Any])?["vault"]
+        else { return false }
+        return exactKeys(vault, expected: [
+            "id", "teamID", "name", "revision", "keyGeneration", "rotationRequired",
+            "createdAt", "updatedAt"
+        ])
+    }
+
+    private static func idempotencyKey(_ scope: String) -> String {
+        "macos:\(scope):\(UUID().uuidString.lowercased())"
     }
 
     private static func validTeamKeyDevicesJSON(_ data: Data) -> Bool {
@@ -802,6 +989,31 @@ private struct LoginResponse: Decodable {
 
 private struct TeamsResponse: Decodable {
     var teams: [SelectiveRemoteCloudTeam]
+}
+
+private struct TeamResponse: Decodable {
+    var team: SelectiveRemoteCloudTeam
+}
+
+private struct TeamMembersResponse: Decodable {
+    var members: [SelectiveRemoteCloudTeamMember]
+}
+
+private struct TeamInvitationResponse: Decodable {
+    var invitation: SelectiveRemoteCloudTeamInvitation
+}
+
+private struct SharedVaultResponse: Decodable {
+    var vault: SelectiveRemoteCloudSharedVault
+}
+
+private struct TeamNameRequest: Encodable {
+    var name: String
+}
+
+private struct TeamInvitationRequest: Encodable {
+    var email: String
+    var role: SelectiveRemoteCloudTeamRole
 }
 
 private struct SharedVaultsResponse: Decodable {

--- a/Sources/SelectiveRemote/CloudAccountViews.swift
+++ b/Sources/SelectiveRemote/CloudAccountViews.swift
@@ -289,6 +289,7 @@ struct SelectiveRemoteCloudTeamInventoryView: View {
     let isRefreshing: Bool
     let errorMessage: String?
     let onRefresh: () -> Void
+    let onManage: () -> Void
 
     var body: some View {
         Section(UpdateLocalization.text(ru: "Teams и общие Vaults", en: "Teams & Shared Vaults")) {
@@ -304,6 +305,10 @@ struct SelectiveRemoteCloudTeamInventoryView: View {
                 }
                 Button(UpdateLocalization.text(ru: "Обновить", en: "Refresh"), systemImage: "arrow.clockwise") {
                     onRefresh()
+                }
+                .disabled(isRefreshing)
+                Button(UpdateLocalization.text(ru: "Управлять…", en: "Manage…"), systemImage: "slider.horizontal.3") {
+                    onManage()
                 }
                 .disabled(isRefreshing)
             }

--- a/Sources/SelectiveRemote/CloudSettingsView.swift
+++ b/Sources/SelectiveRemote/CloudSettingsView.swift
@@ -31,6 +31,7 @@ struct CloudSettingsView: View {
     @State private var personalVaultMessageIsError = false
     @State private var personalVaultUploading = false
     @State private var showsPersonalVaultUpload = false
+    @State private var showsTeamManagement = false
     @State private var personalVaultRecoveryPhrase = ""
     @State private var personalVaultRecoveryConfirmation = ""
     @State private var includePersonalVaultCredentials = false
@@ -247,7 +248,8 @@ struct CloudSettingsView: View {
                     vaultsByTeam: vaultsByTeam,
                     isRefreshing: accountPhase == .refreshing,
                     errorMessage: inventoryErrorMessage,
-                    onRefresh: refreshInventory
+                    onRefresh: refreshInventory,
+                    onManage: { showsTeamManagement = true }
                 )
             }
 
@@ -307,6 +309,15 @@ struct CloudSettingsView: View {
         }
         .sheet(isPresented: $showsPersonalVaultUpload) {
             personalVaultUploadSheet
+        }
+        .sheet(isPresented: $showsTeamManagement) {
+            if let url = try? SelectiveRemoteCloudEndpoint.normalized(endpoint) {
+                SelectiveRemoteCloudTeamManagementView(
+                    endpoint: url,
+                    client: client,
+                    onInventoryChanged: refreshInventory
+                )
+            }
         }
     }
 

--- a/Sources/SelectiveRemote/CloudTeamManagementView.swift
+++ b/Sources/SelectiveRemote/CloudTeamManagementView.swift
@@ -1,0 +1,303 @@
+import SwiftUI
+
+struct SelectiveRemoteCloudTeamManagementView: View {
+    let endpoint: URL
+    let client: SelectiveRemoteCloudAPIClient
+    let onInventoryChanged: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var teams: [SelectiveRemoteCloudTeam] = []
+    @State private var selectedTeamID: UUID?
+    @State private var members: [SelectiveRemoteCloudTeamMember] = []
+    @State private var vaults: [SelectiveRemoteCloudSharedVault] = []
+    @State private var newTeamName = ""
+    @State private var invitationEmail = ""
+    @State private var invitationRole = SelectiveRemoteCloudTeamRole.viewer
+    @State private var newVaultName = ""
+    @State private var isBusy = false
+    @State private var statusMessage: String?
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationSplitView {
+            List(selection: $selectedTeamID) {
+                Section(UpdateLocalization.text(ru: "Команды", en: "Teams")) {
+                    ForEach(teams) { team in
+                        Label(team.name, systemImage: "person.3.fill")
+                            .tag(team.id)
+                    }
+                }
+
+                Section(UpdateLocalization.text(ru: "Новая команда", en: "New Team")) {
+                    TextField(UpdateLocalization.text(ru: "Название", en: "Name"), text: $newTeamName)
+                    Button(UpdateLocalization.text(ru: "Создать Team", en: "Create Team"), systemImage: "plus") {
+                        createTeam()
+                    }
+                    .disabled(isBusy || normalized(newTeamName).isEmpty)
+                }
+            }
+            .navigationTitle(UpdateLocalization.text(ru: "Cloud Workspace", en: "Cloud Workspace"))
+        } detail: {
+            if let team = selectedTeam {
+                teamDetail(team)
+            } else {
+                ContentUnavailableView(
+                    UpdateLocalization.text(ru: "Выберите команду", en: "Select a Team"),
+                    systemImage: "person.3"
+                )
+            }
+        }
+        .frame(minWidth: 820, minHeight: 600)
+        .toolbar {
+            ToolbarItem(placement: .automatic) {
+                Button(UpdateLocalization.text(ru: "Обновить", en: "Refresh"), systemImage: "arrow.clockwise") {
+                    reload()
+                }
+                .disabled(isBusy)
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button(UpdateLocalization.text(ru: "Готово", en: "Done")) { dismiss() }
+            }
+        }
+        .task { await loadTeams() }
+        .onChange(of: selectedTeamID) { _, _ in
+            Task { await loadSelectedTeam() }
+        }
+    }
+
+    private var selectedTeam: SelectiveRemoteCloudTeam? {
+        teams.first { $0.id == selectedTeamID }
+    }
+
+    @ViewBuilder
+    private func teamDetail(_ team: SelectiveRemoteCloudTeam) -> some View {
+        VStack(spacing: 0) {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(team.name).font(.title2.bold())
+                    Text(roleTitle(team.role)).foregroundStyle(.secondary)
+                }
+                Spacer()
+                if isBusy { ProgressView().controlSize(.small) }
+            }
+            .padding()
+
+            if let statusMessage {
+                Label(statusMessage, systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                    .padding(.horizontal)
+            }
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .padding(.horizontal)
+            }
+
+            TabView {
+                membersView(team)
+                    .tabItem { Label(UpdateLocalization.text(ru: "Участники", en: "Members"), systemImage: "person.2") }
+                vaultsView(team)
+                    .tabItem { Label("Team Vaults", systemImage: "lock.square.stack") }
+                hostsView
+                    .tabItem { Label("Team Hosts", systemImage: "server.rack") }
+            }
+            .padding()
+        }
+    }
+
+    private func membersView(_ team: SelectiveRemoteCloudTeam) -> some View {
+        Form {
+            Section(UpdateLocalization.text(ru: "Участники", en: "Members")) {
+                ForEach(members) { member in
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text(member.displayName).font(.headline)
+                            Text(member.email).font(.caption).foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Text(roleTitle(member.role)).foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            if team.role == .owner || team.role == .admin {
+                Section(UpdateLocalization.text(ru: "Пригласить на 48 часов", en: "Invite for 48 Hours")) {
+                    TextField("Email", text: $invitationEmail)
+                    Picker(UpdateLocalization.text(ru: "Роль", en: "Role"), selection: $invitationRole) {
+                        Text(roleTitle(.viewer)).tag(SelectiveRemoteCloudTeamRole.viewer)
+                        Text(roleTitle(.editor)).tag(SelectiveRemoteCloudTeamRole.editor)
+                        if team.role == .owner {
+                            Text(roleTitle(.admin)).tag(SelectiveRemoteCloudTeamRole.admin)
+                        }
+                    }
+                    Button(UpdateLocalization.text(ru: "Отправить приглашение", en: "Send Invitation")) {
+                        invite(team)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(isBusy || normalized(invitationEmail).isEmpty)
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    private func vaultsView(_ team: SelectiveRemoteCloudTeam) -> some View {
+        Form {
+            Section("Team Vaults") {
+                ForEach(vaults) { vault in
+                    HStack {
+                        Label(vault.name, systemImage: "lock.square.stack.fill")
+                        Spacer()
+                        Text("r\(vault.revision) · k\(vault.keyGeneration)")
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            if team.role == .owner || team.role == .admin {
+                Section(UpdateLocalization.text(ru: "Новое хранилище", en: "New Shared Vault")) {
+                    TextField(UpdateLocalization.text(ru: "Название Vault", en: "Vault Name"), text: $newVaultName)
+                    Button(UpdateLocalization.text(ru: "Создать Vault", en: "Create Vault")) {
+                        createVault(team)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(isBusy || normalized(newVaultName).isEmpty)
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    private var hostsView: some View {
+        ContentUnavailableView {
+            Label("Team Hosts", systemImage: "server.rack")
+        } description: {
+            Text(UpdateLocalization.text(
+                ru: "Хосты добавляются из контекстного меню основного списка: «Поделиться с командой…». Просмотр и редактирование Team Hosts появятся здесь следующим этапом.",
+                en: "Add hosts from the main list context menu using Share with Team. Team Host browsing and editing will be added here next."
+            ))
+        }
+    }
+
+    private func reload() {
+        Task { await loadTeams(preferredID: selectedTeamID) }
+    }
+
+    @MainActor
+    private func loadTeams(preferredID: UUID? = nil) async {
+        isBusy = true
+        errorMessage = nil
+        do {
+            teams = try await client.teams(endpoint: endpoint)
+                .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+            selectedTeamID = preferredID.flatMap { id in teams.contains { $0.id == id } ? id : nil }
+                ?? teams.first?.id
+            await loadSelectedTeam()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isBusy = false
+    }
+
+    @MainActor
+    private func loadSelectedTeam() async {
+        guard let team = selectedTeam else {
+            members = []
+            vaults = []
+            return
+        }
+        isBusy = true
+        errorMessage = nil
+        do {
+            async let loadedMembers = client.teamMembers(endpoint: endpoint, teamID: team.id)
+            async let loadedVaults = client.sharedVaults(endpoint: endpoint, teamID: team.id)
+            let (memberResult, vaultResult) = try await (loadedMembers, loadedVaults)
+            members = memberResult.sorted {
+                $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+            }
+            vaults = vaultResult.sorted {
+                $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isBusy = false
+    }
+
+    private func createTeam() {
+        let name = normalized(newTeamName)
+        guard !name.isEmpty else { return }
+        Task { @MainActor in
+            isBusy = true
+            errorMessage = nil
+            do {
+                let team = try await client.createTeam(endpoint: endpoint, name: name)
+                newTeamName = ""
+                statusMessage = UpdateLocalization.text(ru: "Team создана.", en: "Team created.")
+                onInventoryChanged()
+                await loadTeams(preferredID: team.id)
+            } catch {
+                errorMessage = error.localizedDescription
+                isBusy = false
+            }
+        }
+    }
+
+    private func invite(_ team: SelectiveRemoteCloudTeam) {
+        let email = normalized(invitationEmail)
+        guard !email.isEmpty else { return }
+        Task { @MainActor in
+            isBusy = true
+            errorMessage = nil
+            do {
+                _ = try await client.inviteTeamMember(
+                    endpoint: endpoint,
+                    teamID: team.id,
+                    email: email,
+                    role: invitationRole
+                )
+                invitationEmail = ""
+                statusMessage = UpdateLocalization.text(
+                    ru: "Приглашение отправлено на 48 часов.",
+                    en: "Invitation sent for 48 hours."
+                )
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+            isBusy = false
+        }
+    }
+
+    private func createVault(_ team: SelectiveRemoteCloudTeam) {
+        let name = normalized(newVaultName)
+        guard !name.isEmpty else { return }
+        Task { @MainActor in
+            isBusy = true
+            errorMessage = nil
+            do {
+                _ = try await client.createSharedVault(endpoint: endpoint, teamID: team.id, name: name)
+                newVaultName = ""
+                statusMessage = UpdateLocalization.text(ru: "Shared Vault создан.", en: "Shared Vault created.")
+                onInventoryChanged()
+                await loadSelectedTeam()
+            } catch {
+                errorMessage = error.localizedDescription
+                isBusy = false
+            }
+        }
+    }
+
+    private func normalized(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func roleTitle(_ role: SelectiveRemoteCloudTeamRole) -> String {
+        switch role {
+        case .owner: UpdateLocalization.text(ru: "Владелец", en: "Owner")
+        case .admin: UpdateLocalization.text(ru: "Администратор", en: "Admin")
+        case .editor: UpdateLocalization.text(ru: "Редактор", en: "Editor")
+        case .viewer: UpdateLocalization.text(ru: "Читатель", en: "Viewer")
+        }
+    }
+}

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -83,18 +83,17 @@ struct CloudMacOSFoundationTests {
         let vaultID = try #require(UUID(uuidString: "22222222-2222-4222-8222-222222222222"))
         let store = SelectiveRemoteCloudMemoryTokenStore()
         try store.saveToken(String(repeating: "t", count: 43), for: endpoint)
-        let team: [String: Any] = [
-            "id": teamID.canonicalCloudString, "name": "Platform",
-            "membershipID": membershipID.canonicalCloudString, "role": "owner", "membershipEpoch": 1,
-            "createdAt": "2026-09-09T00:00:00.000Z", "updatedAt": "2026-09-09T00:00:00.000Z"
-        ]
         let stub = CloudHTTPStub { request in
             #expect(request.value(forHTTPHeaderField: "Idempotency-Key")?.hasPrefix("macos:") == true
                 || request.httpMethod == "GET")
             switch (request.httpMethod, request.url?.path) {
             case ("POST", "/v1/teams"):
                 #expect(Self.stringBodyValue(request, key: "name") == "Platform")
-                return Self.response(request, status: 201, json: ["team": team])
+                return Self.response(request, status: 201, json: ["team": [
+                    "id": teamID.canonicalCloudString, "name": "Platform",
+                    "membershipID": membershipID.canonicalCloudString, "role": "owner", "membershipEpoch": 1,
+                    "createdAt": "2026-09-09T00:00:00.000Z", "updatedAt": "2026-09-09T00:00:00.000Z"
+                ]])
             case ("GET", "/v1/teams/\(teamID.canonicalCloudString)/members"):
                 return Self.response(request, status: 200, json: ["members": [[
                     "id": membershipID.canonicalCloudString, "userID": userID.canonicalCloudString,

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -27,7 +27,8 @@ struct CloudMacOSFoundationTests {
             case ("GET", "/v1/me"):
                 #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer \(token)")
                 return Self.response(request, status: 200, json: [
-                    "id": userID.uuidString.lowercased(), "email": "user@example.invalid", "displayName": "User"
+                    "id": userID.uuidString.lowercased(), "email": "user@example.invalid", "displayName": "User",
+                    "deviceID": deviceID.uuidString.lowercased()
                 ])
             case ("GET", "/v1/teams"):
                 #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer \(token)")
@@ -70,6 +71,69 @@ struct CloudMacOSFoundationTests {
         #expect(teams[0].membershipEpoch == 3)
         try await client.logout(endpoint: endpoint)
         #expect(try store.token(for: endpoint) == nil)
+    }
+
+    @Test("native Team management creates Teams, invitations and Shared Vaults")
+    func nativeTeamManagement() async throws {
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized("https://cloud.example.invalid")
+        let teamID = try #require(UUID(uuidString: "11111111-1111-4111-8111-111111111111"))
+        let membershipID = try #require(UUID(uuidString: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"))
+        let userID = try #require(UUID(uuidString: "66666666-6666-4666-8666-666666666666"))
+        let invitationID = try #require(UUID(uuidString: "77777777-7777-4777-8777-777777777777"))
+        let vaultID = try #require(UUID(uuidString: "22222222-2222-4222-8222-222222222222"))
+        let store = SelectiveRemoteCloudMemoryTokenStore()
+        try store.saveToken(String(repeating: "t", count: 43), for: endpoint)
+        let team: [String: Any] = [
+            "id": teamID.canonicalCloudString, "name": "Platform",
+            "membershipID": membershipID.canonicalCloudString, "role": "owner", "membershipEpoch": 1,
+            "createdAt": "2026-09-09T00:00:00.000Z", "updatedAt": "2026-09-09T00:00:00.000Z"
+        ]
+        let stub = CloudHTTPStub { request in
+            #expect(request.value(forHTTPHeaderField: "Idempotency-Key")?.hasPrefix("macos:") == true
+                || request.httpMethod == "GET")
+            switch (request.httpMethod, request.url?.path) {
+            case ("POST", "/v1/teams"):
+                #expect(Self.stringBodyValue(request, key: "name") == "Platform")
+                return Self.response(request, status: 201, json: ["team": team])
+            case ("GET", "/v1/teams/\(teamID.canonicalCloudString)/members"):
+                return Self.response(request, status: 200, json: ["members": [[
+                    "id": membershipID.canonicalCloudString, "userID": userID.canonicalCloudString,
+                    "email": "owner@example.invalid", "displayName": "Owner", "role": "owner",
+                    "epoch": 1, "joinedAt": "2026-09-09T00:00:00.000Z"
+                ]]])
+            case ("POST", "/v1/teams/\(teamID.canonicalCloudString)/invitations"):
+                #expect(Self.stringBodyValue(request, key: "email") == "viewer@example.invalid")
+                #expect(Self.stringBodyValue(request, key: "role") == "viewer")
+                return Self.response(request, status: 201, json: ["invitation": [
+                    "id": invitationID.canonicalCloudString, "teamID": teamID.canonicalCloudString,
+                    "email": "viewer@example.invalid", "role": "viewer", "status": "pending",
+                    "createdAt": "2026-09-09T00:00:00.000Z", "expiresAt": "2026-09-11T00:00:00.000Z"
+                ]])
+            case ("POST", "/v1/teams/\(teamID.canonicalCloudString)/vaults"):
+                #expect(Self.stringBodyValue(request, key: "name") == "Production")
+                return Self.response(request, status: 201, json: ["vault": [
+                    "id": vaultID.canonicalCloudString, "teamID": teamID.canonicalCloudString,
+                    "name": "Production", "revision": 0, "keyGeneration": 1,
+                    "rotationRequired": false, "createdAt": "2026-09-09T00:00:00.000Z",
+                    "updatedAt": "2026-09-09T00:00:00.000Z"
+                ]])
+            default:
+                Issue.record("Unexpected Team management request")
+                return Self.response(request, status: 500, json: ["error": "unexpected_request"])
+            }
+        }
+        let client = SelectiveRemoteCloudAPIClient(tokenStore: store, dataLoader: { request in
+            try stub.data(for: request)
+        })
+
+        #expect(try await client.createTeam(endpoint: endpoint, name: " Platform ").name == "Platform")
+        #expect(try await client.teamMembers(endpoint: endpoint, teamID: teamID).first?.role == .owner)
+        #expect(try await client.inviteTeamMember(
+            endpoint: endpoint, teamID: teamID, email: " VIEWER@example.invalid ", role: .viewer
+        ).email == "viewer@example.invalid")
+        #expect(try await client.createSharedVault(
+            endpoint: endpoint, teamID: teamID, name: " Production "
+        ).id == vaultID)
     }
 
     @Test("registration sends the device public identity and requires exact verification response")
@@ -1086,6 +1150,14 @@ struct CloudMacOSFoundationTests {
             createdAt: "2026-09-06T00:00:00.000Z",
             updatedAt: "2026-09-06T00:00:00.000Z"
         )
+    }
+
+    private static func stringBodyValue(_ request: URLRequest, key: String) -> String? {
+        guard let body = request.httpBody,
+              let value = try? JSONSerialization.jsonObject(with: body),
+              let object = value as? [String: Any]
+        else { return nil }
+        return object[key] as? String
     }
 
     private static func response(

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -69,7 +69,13 @@ struct CloudMacOSFoundationTests {
         #expect(teams.count == 1)
         #expect(teams[0].role == .owner)
         #expect(teams[0].membershipEpoch == 3)
-        try await client.logout(endpoint: endpoint)
+        let restoredClient = SelectiveRemoteCloudAPIClient(
+            tokenStore: store,
+            dataLoader: { request in try stub.data(for: request) }
+        )
+        #expect(await restoredClient.hasStoredSession(endpoint: endpoint))
+        #expect(try await restoredClient.currentUser(endpoint: endpoint) == user)
+        try await restoredClient.logout(endpoint: endpoint)
         #expect(try store.token(for: endpoint) == nil)
     }
 

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -118,10 +118,11 @@ test("macOS exposes a complete-choice conflict review without rendering secrets"
   assert.match(settings, /sends nothing to Cloud/);
 });
 
-test("macOS Cloud settings expose real device-bound sign-in and read-only Team inventory", async () => {
-  const [settings, accountViews, client, sessions] = await Promise.all([
+test("macOS Cloud settings expose device-bound sign-in and native Team management", async () => {
+  const [settings, accountViews, teamManagement, client, sessions] = await Promise.all([
     readFile(new URL("CloudSettingsView.swift", sourceRoot), "utf8"),
     readFile(new URL("CloudAccountViews.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudTeamManagementView.swift", sourceRoot), "utf8"),
     readFile(new URL("CloudAPIClient.swift", sourceRoot), "utf8"),
     readFile(new URL("CloudSessionStore.swift", sourceRoot), "utf8"),
   ]);
@@ -139,12 +140,21 @@ test("macOS Cloud settings expose real device-bound sign-in and read-only Team i
   assert.match(settings, /client\.sharedVaults/);
   assert.match(settings, /client\.logout/);
   assert.match(settings, /client\.register/);
+  assert.match(settings, /SelectiveRemoteCloudTeamManagementView/);
   assert.match(settings, /metadata\?\.registrationEnabled == true/);
   assert.match(accountViews, /Teams & Shared Vaults/);
+  assert.match(teamManagement, /NavigationSplitView/);
+  assert.match(teamManagement, /client\.createTeam/);
+  assert.match(teamManagement, /client\.teamMembers/);
+  assert.match(teamManagement, /client\.inviteTeamMember/);
+  assert.match(teamManagement, /client\.createSharedVault/);
+  assert.match(teamManagement, /Team Hosts/);
   assert.match(client, /v1\/auth\/register/);
   assert.match(client, /verificationRequired/);
   assert.match(client, /validLoginJSON/);
   assert.match(client, /validTeamsJSON/);
+  assert.match(client, /validTeamMembersJSON/);
+  assert.match(client, /deviceID/);
   assert.match(sessions, /kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly/);
   assert.doesNotMatch(sessions, /UserDefaults/);
 });


### PR DESCRIPTION
## Что изменено
- добавлено отдельное нативное окно Cloud Workspace в macOS-приложении
- слева выбирается Team, справа доступны вкладки Участники, Team Vaults и Team Hosts
- Owner/Admin могут отправить приглашение с допустимой ролью и создать Shared Vault
- любой авторизованный пользователь может просматривать участников и доступные Vaults согласно серверным разрешениям
- исправлен контракт `GET /v1/me`: клиент теперь принимает обязательный `deviceID`, из-за которого появлялось «Cloud вернул некорректный ответ» и не заполнялся диалог публикации Host
- операции используют Bearer-сессию из Keychain и отдельные idempotency keys; пароли и открытые Vault-данные не добавлялись

## Проверки
- полный Cloud suite: 248 тестов, 247 успешно, 1 PostgreSQL-тест штатно пропущен без TEST_DATABASE_URL
- macOS source contracts: 11/11
- добавлен Swift HTTP-контракт создания Team, приглашения, чтения участников и создания Shared Vault

Нативную Swift-компиляцию и DMG проверит GitHub Actions на macOS.