### PR TITLE
Add private Team usernames and clear Vault access recovery

### DIFF
--- a/Sources/SelectiveRemote/CloudAPIClient.swift
+++ b/Sources/SelectiveRemote/CloudAPIClient.swift
@@ -82,6 +82,7 @@ struct SelectiveRemoteCloudMetadata: Codable, Equatable, Sendable {
 struct SelectiveRemoteCloudUser: Codable, Equatable, Sendable {
     var id: UUID
     var email: String
+    var username: String
     var displayName: String
 }
 
@@ -116,7 +117,7 @@ struct SelectiveRemoteCloudSharedVault: Codable, Equatable, Identifiable, Sendab
 struct SelectiveRemoteCloudTeamMember: Codable, Equatable, Identifiable, Sendable {
     var id: UUID
     var userID: UUID
-    var email: String
+    var username: String
     var displayName: String
     var role: SelectiveRemoteCloudTeamRole
     var epoch: Int
@@ -368,14 +369,20 @@ actor SelectiveRemoteCloudAPIClient {
     func register(
         endpoint: URL,
         displayName: String,
+        username: String,
         email: String,
         password: String,
         device: SelectiveRemoteCloudDeviceRegistration
     ) async throws {
         let normalizedDisplayName = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedUsername = username.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         let normalizedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalizedDeviceName = device.name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalizedDisplayName.isEmpty, normalizedDisplayName.count <= 120,
+              normalizedUsername.range(
+                  of: #"^[a-z0-9][a-z0-9._-]{1,30}[a-z0-9]$"#,
+                  options: .regularExpression
+              ) != nil,
               !normalizedEmail.isEmpty, normalizedEmail.count <= 254,
               password.count >= 12, password.count <= 1_024,
               !normalizedDeviceName.isEmpty, normalizedDeviceName.count <= 120,
@@ -386,6 +393,7 @@ actor SelectiveRemoteCloudAPIClient {
         let body = RegistrationRequest(
             email: normalizedEmail,
             password: password,
+            username: normalizedUsername,
             displayName: normalizedDisplayName,
             device: .init(
                 id: device.id,
@@ -712,17 +720,19 @@ actor SelectiveRemoteCloudAPIClient {
         user.id.isSelectiveRemoteCloudUUID
             && !user.email.isEmpty
             && user.email.count <= 254
+            && !user.username.isEmpty
+            && user.username.count <= 32
             && !user.displayName.isEmpty
             && user.displayName.count <= 120
     }
 
     private static func validUserObject(_ value: Any?) -> Bool {
-        exactKeys(value, expected: ["id", "email", "displayName"])
+        exactKeys(value, expected: ["id", "email", "username", "displayName"])
     }
 
     private static func validUserJSON(_ data: Data) -> Bool {
         guard let object = try? JSONSerialization.jsonObject(with: data) else { return false }
-        guard exactKeys(object, expected: ["id", "email", "displayName", "deviceID"]),
+        guard exactKeys(object, expected: ["id", "email", "username", "displayName", "deviceID"]),
               let deviceID = (object as? [String: Any])?["deviceID"] as? String,
               UUID(uuidString: deviceID)?.isSelectiveRemoteCloudUUID == true
         else { return false }
@@ -784,7 +794,7 @@ actor SelectiveRemoteCloudAPIClient {
     private static func validTeamMember(_ member: SelectiveRemoteCloudTeamMember) -> Bool {
         member.id.isSelectiveRemoteCloudUUID
             && member.userID.isSelectiveRemoteCloudUUID
-            && !member.email.isEmpty && member.email.count <= 254
+            && !member.username.isEmpty && member.username.count <= 32
             && !member.displayName.isEmpty && member.displayName.count <= 120
             && member.epoch > 0 && !member.joinedAt.isEmpty
     }
@@ -795,7 +805,7 @@ actor SelectiveRemoteCloudAPIClient {
               let members = (object as? [String: Any])?["members"] as? [Any]
         else { return false }
         return members.allSatisfy { exactKeys($0, expected: [
-            "id", "userID", "email", "displayName", "role", "epoch", "joinedAt"
+            "id", "userID", "username", "displayName", "role", "epoch", "joinedAt"
         ]) }
     }
 
@@ -973,6 +983,7 @@ private struct LoginRequest: Encodable {
 private struct RegistrationRequest: Encodable {
     var email: String
     var password: String
+    var username: String
     var displayName: String
     var device: SelectiveRemoteCloudDeviceRegistration
 }

--- a/Sources/SelectiveRemote/CloudAccountViews.swift
+++ b/Sources/SelectiveRemote/CloudAccountViews.swift
@@ -159,9 +159,10 @@ struct SelectiveRemoteCloudRegistrationView: View {
     let errorMessage: String?
     let onBack: () -> Void
     let onCancel: () -> Void
-    let onRegister: (String, String, String) -> Void
+    let onRegister: (String, String, String, String) -> Void
 
     @State private var displayName = ""
+    @State private var username = ""
     @State private var email = ""
     @State private var password = ""
     @State private var confirmation = ""
@@ -172,6 +173,9 @@ struct SelectiveRemoteCloudRegistrationView: View {
                 Section {
                     TextField(UpdateLocalization.text(ru: "Имя", en: "Display Name"), text: $displayName)
                         .textContentType(.name)
+                        .disabled(isRegistering)
+                    TextField(UpdateLocalization.text(ru: "Логин", en: "Username"), text: $username)
+                        .textContentType(.username)
                         .disabled(isRegistering)
                     TextField(UpdateLocalization.text(ru: "Электронная почта", en: "Email"), text: $email)
                         .textContentType(.emailAddress)
@@ -244,7 +248,9 @@ struct SelectiveRemoteCloudRegistrationView: View {
     private var canSubmit: Bool {
         let name = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
         let mail = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        let handle = username.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         return !name.isEmpty && name.count <= 120
+            && handle.range(of: #"^[a-z0-9][a-z0-9._-]{1,30}[a-z0-9]$"#, options: .regularExpression) != nil
             && !mail.isEmpty && mail.count <= 254
             && (12...1_024).contains(password.count)
             && password == confirmation
@@ -252,7 +258,7 @@ struct SelectiveRemoteCloudRegistrationView: View {
 
     private func submit() {
         guard canSubmit, !isRegistering else { return }
-        onRegister(displayName, email, password)
+        onRegister(displayName, username, email, password)
     }
 }
 

--- a/Sources/SelectiveRemote/CloudProfileShareView.swift
+++ b/Sources/SelectiveRemote/CloudProfileShareView.swift
@@ -33,6 +33,7 @@ struct SelectiveRemoteCloudProfileShareView: View {
     let profile: ConnectionProfile
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.openURL) private var openURL
     @AppStorage("SelectiveRemote.cloud.endpoint.v1") private var endpoint = SelectiveRemoteCloudEndpoint.production
     @AppStorage("SelectiveRemote.cloud.device-id.v1") private var storedDeviceID = ""
     @State private var teams: [SelectiveRemoteCloudTeam] = []
@@ -43,6 +44,7 @@ struct SelectiveRemoteCloudProfileShareView: View {
     @State private var isSharing = false
     @State private var message: String?
     @State private var messageIsError = false
+    @State private var needsDeviceWrapper = false
 
     private let client = SelectiveRemoteCloudAPIClient()
     private let identityManager = SelectiveRemoteTeamDeviceIdentityManager()
@@ -75,9 +77,23 @@ struct SelectiveRemoteCloudProfileShareView: View {
             .foregroundStyle(.secondary)
 
             if let message {
-                Label(message, systemImage: messageIsError ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
-                    .foregroundStyle(messageIsError ? Color.orange : Color.green)
-                    .font(.caption)
+                VStack(alignment: .leading, spacing: 10) {
+                    Label(message, systemImage: messageIsError ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
+                        .foregroundStyle(messageIsError ? Color.orange : Color.green)
+                        .font(.caption)
+                        .fixedSize(horizontal: false, vertical: true)
+                    if needsDeviceWrapper {
+                        Button(
+                            UpdateLocalization.text(
+                                ru: "Открыть Team Vaults в браузере…",
+                                en: "Open Team Vaults in Browser…"
+                            ),
+                            systemImage: "safari"
+                        ) {
+                            openCloudWorkspace()
+                        }
+                    }
+                }
             }
 
             HStack {
@@ -142,6 +158,7 @@ struct SelectiveRemoteCloudProfileShareView: View {
         else { return }
         isSharing = true
         message = nil
+        needsDeviceWrapper = false
         Task { @MainActor in
             defer { isSharing = false }
             do {
@@ -192,11 +209,21 @@ struct SelectiveRemoteCloudProfileShareView: View {
                 guard case .uploaded = outcome else { throw SelectiveRemoteCloudProfileShareError.conflict }
                 message = UpdateLocalization.text(ru: "Host зашифрован и добавлен в Team Vault.", en: "The Host was encrypted and added to the Team Vault.")
                 messageIsError = false
+            } catch SelectiveRemoteTeamVaultSyncError.missingDeviceWrapper {
+                message = SelectiveRemoteTeamVaultSyncError.missingDeviceWrapper.localizedDescription
+                messageIsError = true
+                needsDeviceWrapper = true
             } catch {
                 message = error.localizedDescription
                 messageIsError = true
             }
         }
+    }
+
+    @MainActor
+    private func openCloudWorkspace() {
+        guard let url = try? SelectiveRemoteCloudEndpoint.normalized(endpoint) else { return }
+        openURL(url)
     }
 
     @MainActor

--- a/Sources/SelectiveRemote/CloudSettingsView.swift
+++ b/Sources/SelectiveRemote/CloudSettingsView.swift
@@ -446,9 +446,10 @@ struct CloudSettingsView: View {
                             accountSheetMode = .signIn
                         },
                         onCancel: closeAccountSheet,
-                        onRegister: { displayName, email, password in
+                        onRegister: { displayName, username, email, password in
                             register(
                                 displayName: displayName,
+                                username: username,
                                 email: email,
                                 password: password,
                                 endpoint: url
@@ -515,7 +516,7 @@ struct CloudSettingsView: View {
         }
     }
 
-    private func register(displayName: String, email: String, password: String, endpoint url: URL) {
+    private func register(displayName: String, username: String, email: String, password: String, endpoint url: URL) {
         guard metadata?.registrationEnabled == true else {
             registrationErrorMessage = UpdateLocalization.text(
                 ru: "Регистрация новых аккаунтов отключена на этом сервере.",
@@ -532,6 +533,7 @@ struct CloudSettingsView: View {
                 try await client.register(
                     endpoint: url,
                     displayName: displayName,
+                    username: username,
                     email: email,
                     password: password,
                     device: .thisMac(id: deviceID, publicKey: identity.publicKey)

--- a/Sources/SelectiveRemote/CloudTeamManagementView.swift
+++ b/Sources/SelectiveRemote/CloudTeamManagementView.swift
@@ -112,7 +112,7 @@ struct SelectiveRemoteCloudTeamManagementView: View {
                     HStack {
                         VStack(alignment: .leading) {
                             Text(member.displayName).font(.headline)
-                            Text(member.email).font(.caption).foregroundStyle(.secondary)
+                            Text("@\(member.username)").font(.caption).foregroundStyle(.secondary)
                         }
                         Spacer()
                         Text(roleTitle(member.role)).foregroundStyle(.secondary)

--- a/Sources/SelectiveRemote/CloudTeamVaultSyncCoordinator.swift
+++ b/Sources/SelectiveRemote/CloudTeamVaultSyncCoordinator.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum SelectiveRemoteTeamVaultSyncError: Error, Equatable {
+enum SelectiveRemoteTeamVaultSyncError: LocalizedError, Equatable {
     case rotationRequired
     case missingDeviceWrapper
     case noLocalSnapshot
@@ -12,6 +12,61 @@ enum SelectiveRemoteTeamVaultSyncError: Error, Equatable {
     case invalidConflictResponse
     case staleConflict
     case invalidKeyDevices
+
+    var errorDescription: String? {
+        switch self {
+        case .rotationRequired:
+            UpdateLocalization.text(
+                ru: "Для Team Vault требуется ротация ключа. Завершите её в Cloud и повторите операцию.",
+                en: "The Team Vault key must be rotated. Complete the rotation in Cloud and try again."
+            )
+        case .missingDeviceWrapper:
+            UpdateLocalization.text(
+                ru: "Для этого Mac ещё не выдан ключ выбранного Team Vault. Откройте Vault в уже доверенном браузере или на другом устройстве, выдайте недостающие wrappers и повторите операцию.",
+                en: "This Mac does not have a key for the selected Team Vault yet. Open the Vault in an already trusted browser or on another device, grant the missing wrappers, and try again."
+            )
+        case .noLocalSnapshot:
+            UpdateLocalization.text(
+                ru: "Локальная копия Team Vault ещё не создана. Обновите Vault и повторите операцию.",
+                en: "The local Team Vault snapshot has not been created yet. Refresh the Vault and try again."
+            )
+        case .noLocalChanges:
+            UpdateLocalization.text(
+                ru: "В Team Vault нет локальных изменений для отправки.",
+                en: "There are no local Team Vault changes to upload."
+            )
+        case .invalidLocalSnapshot:
+            UpdateLocalization.text(
+                ru: "Локальная копия Team Vault повреждена или несовместима.",
+                en: "The local Team Vault snapshot is invalid or incompatible."
+            )
+        case .remoteRevisionRollback:
+            UpdateLocalization.text(
+                ru: "Cloud вернул более старую ревизию Team Vault. Запись остановлена для защиты данных.",
+                en: "Cloud returned an older Team Vault revision. The write was stopped to protect your data."
+            )
+        case .remoteRevisionDivergence:
+            UpdateLocalization.text(
+                ru: "Ревизия Team Vault расходится с локальной копией. Обновите Vault и разрешите конфликт.",
+                en: "The Team Vault revision diverges from the local snapshot. Refresh the Vault and resolve the conflict."
+            )
+        case .invalidWriteAcknowledgement, .invalidConflictResponse:
+            UpdateLocalization.text(
+                ru: "Cloud не подтвердил безопасную запись в Team Vault. Данные не были перезаписаны.",
+                en: "Cloud did not confirm a safe Team Vault write. No data was overwritten."
+            )
+        case .staleConflict:
+            UpdateLocalization.text(
+                ru: "Team Vault снова изменился во время разрешения конфликта. Обновите его и повторите выбор.",
+                en: "The Team Vault changed again while resolving the conflict. Refresh it and repeat your choice."
+            )
+        case .invalidKeyDevices:
+            UpdateLocalization.text(
+                ru: "Cloud вернул неполный список доверенных устройств. Инициализация Team Vault остановлена.",
+                en: "Cloud returned an incomplete trusted-device list. Team Vault initialization was stopped."
+            )
+        }
+    }
 }
 
 protocol SelectiveRemoteTeamVaultRemote: Sendable {

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -21,13 +21,13 @@ struct CloudMacOSFoundationTests {
                 #expect(object["password"] as? String == "synthetic-password")
                 return Self.response(request, status: 200, json: [
                     "token": token,
-                    "user": ["id": userID.uuidString.lowercased(), "email": "user@example.invalid", "displayName": "User"],
+                    "user": ["id": userID.uuidString.lowercased(), "email": "user@example.invalid", "username": "user", "displayName": "User"],
                     "deviceID": deviceID.uuidString.lowercased()
                 ])
             case ("GET", "/v1/me"):
                 #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer \(token)")
                 return Self.response(request, status: 200, json: [
-                    "id": userID.uuidString.lowercased(), "email": "user@example.invalid", "displayName": "User",
+                    "id": userID.uuidString.lowercased(), "email": "user@example.invalid", "username": "user", "displayName": "User",
                     "deviceID": deviceID.uuidString.lowercased()
                 ])
             case ("GET", "/v1/teams"):
@@ -60,7 +60,7 @@ struct CloudMacOSFoundationTests {
             password: "synthetic-password",
             device: .thisMac(id: deviceID, name: "Synthetic Mac")
         )
-        #expect(user == SelectiveRemoteCloudUser(id: userID, email: "user@example.invalid", displayName: "User"))
+        #expect(user == SelectiveRemoteCloudUser(id: userID, email: "user@example.invalid", username: "user", displayName: "User"))
         #expect(try store.token(for: endpoint) == token)
         let hasStoredSession = await client.hasStoredSession(endpoint: endpoint)
         #expect(hasStoredSession)
@@ -103,7 +103,7 @@ struct CloudMacOSFoundationTests {
             case ("GET", "/v1/teams/\(teamID.canonicalCloudString)/members"):
                 return Self.response(request, status: 200, json: ["members": [[
                     "id": membershipID.canonicalCloudString, "userID": userID.canonicalCloudString,
-                    "email": "owner@example.invalid", "displayName": "Owner", "role": "owner",
+                    "username": "owner", "displayName": "Owner", "role": "owner",
                     "epoch": 1, "joinedAt": "2026-09-09T00:00:00.000Z"
                 ]]])
             case ("POST", "/v1/teams/\(teamID.canonicalCloudString)/invitations"):
@@ -151,10 +151,11 @@ struct CloudMacOSFoundationTests {
             #expect(request.url?.path == "/v1/auth/register")
             let body = try #require(request.httpBody)
             let object = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
-            #expect(Set(object.keys) == ["email", "password", "displayName", "device"])
+            #expect(Set(object.keys) == ["email", "password", "username", "displayName", "device"])
             #expect(object["email"] as? String == "user@example.invalid")
             #expect(object["password"] as? String == "synthetic-password")
             #expect(object["displayName"] as? String == "User")
+            #expect(object["username"] as? String == "leonid")
             let device = try #require(object["device"] as? [String: Any])
             #expect(device["id"] as? String == deviceID.canonicalCloudString)
             #expect(device["name"] as? String == "Synthetic Mac")
@@ -169,6 +170,7 @@ struct CloudMacOSFoundationTests {
         try await client.register(
             endpoint: endpoint,
             displayName: " User ",
+            username: " Leonid ",
             email: " user@example.invalid ",
             password: "synthetic-password",
             device: .thisMac(id: deviceID, name: "Synthetic Mac")
@@ -203,6 +205,7 @@ struct CloudMacOSFoundationTests {
                 try await client.register(
                     endpoint: endpoint,
                     displayName: "User",
+                    username: "user",
                     email: "user@example.invalid",
                     password: "synthetic-password",
                     device: .thisMac(id: deviceID, name: "Synthetic Mac")

--- a/cloud/migrations/008_usernames.sql
+++ b/cloud/migrations/008_usernames.sql
@@ -1,0 +1,16 @@
+BEGIN;
+
+ALTER TABLE users ADD COLUMN username text;
+
+UPDATE users
+SET username = 'user_' || substring(replace(id::text, '-', '') FROM 1 FOR 12)
+WHERE username IS NULL;
+
+ALTER TABLE users ALTER COLUMN username SET NOT NULL;
+ALTER TABLE users ADD CONSTRAINT users_username_normalized
+    CHECK (username = lower(trim(username)));
+ALTER TABLE users ADD CONSTRAINT users_username_shape
+    CHECK (username ~ '^[a-z0-9][a-z0-9._-]{1,30}[a-z0-9]$');
+CREATE UNIQUE INDEX users_username_unique ON users (username);
+
+COMMIT;

--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -621,8 +621,8 @@ export function initializeTeamWorkspace({
       const role = documentValue.createElement("select");
       const save = documentValue.createElement("button");
       const revoke = documentValue.createElement("button");
-      name.textContent = member.displayName || member.email;
-      detail.textContent = `${member.email} · epoch ${member.epoch}`;
+      name.textContent = member.displayName || `@${member.username}`;
+      detail.textContent = `@${member.username} · epoch ${member.epoch}`;
       const editableByActor = selectedTeam.role === "owner"
         || (selectedTeam.role === "admin" && ["editor", "viewer"].includes(member.role));
       const self = member.id === selectedTeam.membershipID;
@@ -654,7 +654,7 @@ export function initializeTeamWorkspace({
       revoke.textContent = "Отозвать доступ";
       revoke.disabled = !editableByActor || self;
       revoke.addEventListener("click", async () => {
-        if (!confirmValue(`Отозвать доступ для ${member.email}? Все Shared Vaults будут заморожены до ротации ключей.`)) return;
+        if (!confirmValue(`Отозвать доступ для @${member.username}? Все Shared Vaults будут заморожены до ротации ключей.`)) return;
         revoke.disabled = true;
         try {
           const result = await client.revokeTeamMember({ teamID: selectedTeam.id, membershipID: member.id });
@@ -673,7 +673,7 @@ export function initializeTeamWorkspace({
     for (const member of values.filter((value) => value.id !== selectedTeam.membershipID)) {
       const option = documentValue.createElement("option");
       option.value = member.id;
-      option.textContent = `${member.displayName || member.email} · ${member.role}`;
+      option.textContent = `${member.displayName || `@${member.username}`} · ${member.role}`;
       transferOwnershipMember.append(option);
     }
     transferOwnershipForm.querySelector("button").disabled = transferOwnershipMember.options.length === 0;
@@ -1286,6 +1286,7 @@ export async function initializeCloudAccount({
       try { identity = await ensureTeamDeviceIdentity({ repository: teamDeviceRepository, deviceID }); } catch {}
       await client.register({
         displayName: registrationForm.elements.displayName.value,
+        username: registrationForm.elements.username.value,
         email: registrationForm.elements.email.value,
         password,
         deviceID,

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -102,6 +102,9 @@
         <form class="auth-form" id="cloud-registration-form" method="post" action="/v1/auth/register" hidden>
           <label for="cloud-registration-name">Ваше имя</label>
           <input id="cloud-registration-name" name="displayName" maxlength="120" autocomplete="name" placeholder="Как к вам обращаться" required>
+          <label for="cloud-registration-username">Логин</label>
+          <input id="cloud-registration-username" name="username" minlength="3" maxlength="32" pattern="[a-z0-9][a-z0-9._-]{1,30}[a-z0-9]" autocomplete="username" placeholder="например, leonid" required>
+          <p class="auth-note">Участники команд увидят имя и @логин. Электронная почта останется скрытой.</p>
           <label for="cloud-registration-email">Электронная почта</label>
           <input id="cloud-registration-email" name="email" type="email" maxlength="254" autocomplete="email" placeholder="На неё придёт подтверждение" required>
           <label for="cloud-registration-password">Новый пароль Selective Remote</label>

--- a/cloud/public/vault-sync.js
+++ b/cloud/public/vault-sync.js
@@ -223,7 +223,7 @@ function normalizedTeam(value) {
 }
 
 function normalizedTeamMember(value) {
-  exactKeys(value, ["displayName", "email", "epoch", "id", "joinedAt", "role", "userID"], "invalid_team_member");
+  exactKeys(value, ["displayName", "epoch", "id", "joinedAt", "role", "userID", "username"], "invalid_team_member");
   if (!["owner", "admin", "editor", "viewer"].includes(value.role)
     || !Number.isSafeInteger(value.epoch) || value.epoch < 1) {
     throw new Error("invalid_team_member");
@@ -231,7 +231,7 @@ function normalizedTeamMember(value) {
   return {
     id: normalizedUUID(value.id, "invalid_team_member"),
     userID: normalizedUUID(value.userID, "invalid_team_member"),
-    email: String(value.email ?? ""),
+    username: String(value.username ?? ""),
     displayName: String(value.displayName ?? ""),
     role: value.role,
     epoch: value.epoch,
@@ -371,17 +371,22 @@ export function createAuthenticatedVaultClient({ fetchValue = globalThis.fetch }
   }
 
   return {
-    async register({ displayName, email, password, deviceID, publicKey = null }) {
+    async register({ displayName, username, email, password, deviceID, publicKey = null }) {
       const normalizedDeviceID = String(deviceID ?? "").toLowerCase();
       if (!uuidPattern.test(normalizedDeviceID)) throw new Error("invalid_device");
       const normalizedName = String(displayName ?? "").trim();
       if (!normalizedName || normalizedName.length > 120) throw new Error("invalid_display_name");
+      const normalizedUsername = String(username ?? "").trim().toLowerCase();
+      if (!/^[a-z0-9][a-z0-9._-]{1,30}[a-z0-9]$/.test(normalizedUsername)) {
+        throw new Error("invalid_username");
+      }
       const normalizedPublicKey = publicKey === null ? null : normalizeTeamDevicePublicKey(publicKey);
       const response = await fetchValue("/v1/auth/register", {
         method: "POST",
         headers: { Accept: "application/json", "Content-Type": "application/json" },
         body: JSON.stringify({
           displayName: normalizedName,
+          username: normalizedUsername,
           email: String(email ?? "").trim(),
           password: normalizedPassword(password),
           device: {
@@ -462,6 +467,7 @@ export function createAuthenticatedVaultClient({ fetchValue = globalThis.fetch }
       user = {
         id: String(result.user.id).toLowerCase(),
         email: String(result.user.email ?? ""),
+        username: String(result.user.username ?? ""),
         displayName: String(result.user.displayName ?? ""),
       };
       return structuredClone(user);

--- a/cloud/src/postgres-store.mjs
+++ b/cloud/src/postgres-store.mjs
@@ -81,13 +81,13 @@ export class PostgresStore {
     }
   }
 
-  async createUser({ email, displayName, passwordHash, device, verificationHash, verificationExpiresAt }) {
+  async createUser({ email, username, displayName, passwordHash, device, verificationHash, verificationExpiresAt }) {
     const client = await this.pool.connect();
     try {
       await client.query("BEGIN");
       const userResult = await client.query(
-        "INSERT INTO users (email, display_name) VALUES ($1, $2) RETURNING id, email, display_name, created_at",
-        [email, displayName],
+        "INSERT INTO users (email, username, display_name) VALUES ($1, $2, $3) RETURNING id, email, username, display_name, created_at",
+        [email, username, displayName],
       );
       const user = userResult.rows[0];
       await client.query(
@@ -114,6 +114,9 @@ export class PostgresStore {
       return user;
     } catch (error) {
       await client.query("ROLLBACK");
+      if (error?.code === "23505" && error?.constraint === "users_username_unique") {
+        throw new Error("username_exists");
+      }
       if (error?.code === "23505") throw new Error("email_exists");
       throw error;
     } finally {
@@ -123,7 +126,7 @@ export class PostgresStore {
 
   async passwordIdentity(email) {
     const result = await this.pool.query(
-      `SELECT u.id, u.email, u.display_name, u.disabled_at, u.email_verified_at, i.password_hash
+      `SELECT u.id, u.email, u.username, u.display_name, u.disabled_at, u.email_verified_at, i.password_hash
        FROM users u JOIN account_identities i ON i.user_id = u.id
        WHERE i.provider = 'password' AND i.subject = $1`,
       [email],
@@ -383,7 +386,7 @@ export class PostgresStore {
 
   async session(tokenHash) {
     const result = await this.pool.query(
-      `SELECT s.id AS session_id, s.user_id, s.device_id, u.email, u.display_name
+      `SELECT s.id AS session_id, s.user_id, s.device_id, u.email, u.username, u.display_name
        FROM sessions s JOIN users u ON u.id = s.user_id JOIN devices d ON d.id = s.device_id
        WHERE s.token_hash = $1 AND s.revoked_at IS NULL AND s.expires_at > now()
          AND u.disabled_at IS NULL AND u.email_verified_at IS NOT NULL AND d.revoked_at IS NULL`,
@@ -726,14 +729,14 @@ export class PostgresStore {
   async listTeamMembers(teamID, actorUserID) {
     const result = await this.pool.query(
       `SELECT member.id, member.user_id, member.role, member.epoch,
-         member.joined_at, account.email, account.display_name
+         member.joined_at, account.username, account.display_name
        FROM team_memberships AS actor
        JOIN teams AS team ON team.id = actor.team_id AND team.archived_at IS NULL
        JOIN team_memberships AS member ON member.team_id = team.id AND member.revoked_at IS NULL
        JOIN users AS account ON account.id = member.user_id AND account.disabled_at IS NULL
        WHERE actor.team_id = $1 AND actor.user_id = $2 AND actor.revoked_at IS NULL
        ORDER BY CASE member.role WHEN 'owner' THEN 0 WHEN 'admin' THEN 1 WHEN 'editor' THEN 2 ELSE 3 END,
-         lower(account.email), member.id`,
+         lower(account.username), member.id`,
       [teamID, actorUserID],
     );
     if (result.rows.length === 0) throw new Error("team_not_found");

--- a/cloud/src/security.mjs
+++ b/cloud/src/security.mjs
@@ -24,6 +24,15 @@ export function normalizeEmail(value) {
   return email;
 }
 
+export function normalizeUsername(value) {
+  const username = String(value ?? "").trim().toLowerCase();
+  if (username.length < 3 || username.length > 32
+      || !/^[a-z0-9][a-z0-9._-]*[a-z0-9]$/.test(username)) {
+    throw new Error("invalid_username");
+  }
+  return username;
+}
+
 export function validatePassword(value) {
   const password = String(value ?? "");
   if (password.length < 12 || password.length > 1024) throw new Error("invalid_password");

--- a/cloud/src/server.mjs
+++ b/cloud/src/server.mjs
@@ -90,6 +90,7 @@ async function route(request, response) {
       return sendJSON(response, 200, {
         id: session.user_id,
         email: session.email,
+        username: session.username,
         displayName: session.display_name,
         deviceID: session.device_id,
       });

--- a/cloud/src/service-error.mjs
+++ b/cloud/src/service-error.mjs
@@ -35,6 +35,8 @@ const operationStatuses = Object.freeze({
   invalid_shared_vault: 400,
   invalid_idempotency_key: 400,
   invalid_team_invitation: 400,
+  invalid_username: 400,
+  username_exists: 409,
   team_not_found: 404,
   team_access_denied: 403,
   team_member_exists: 409,

--- a/cloud/src/service.mjs
+++ b/cloud/src/service.mjs
@@ -14,6 +14,7 @@ import {
   hashTeamInvitationToken,
   isUUID,
   normalizeEmail,
+  normalizeUsername,
   validateDevicePublicKey,
   validatePassword,
   validateTeamVaultEnvelope,
@@ -102,12 +103,16 @@ export class CloudService {
     const email = normalizeEmail(input.email);
     const password = validatePassword(input.password);
     const displayName = String(input.displayName ?? "").trim().slice(0, 120);
+    const username = input.username
+      ? normalizeUsername(input.username)
+      : `user_${randomUUID().replaceAll("-", "").slice(0, 12)}`;
     const device = this.validateDevice(input.device);
     const verificationToken = createEmailVerificationToken();
     const passwordHash = await hashPassword(password);
     try {
       await this.store.createUser({
         email,
+        username,
         displayName,
         passwordHash,
         device,
@@ -502,7 +507,13 @@ export class CloudService {
 }
 
 function publicUser(row) {
-  return { id: row.id, email: row.email, displayName: row.display_name, createdAt: row.created_at };
+  return {
+    id: row.id,
+    email: row.email,
+    username: row.username,
+    displayName: row.display_name,
+    createdAt: row.created_at,
+  };
 }
 
 function publicTeam(row) {
@@ -521,7 +532,7 @@ function publicTeamMember(row) {
   return {
     id: row.id,
     userID: row.user_id,
-    email: row.email,
+    username: row.username,
     displayName: row.display_name,
     role: row.role,
     epoch: Number(row.epoch),

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -77,9 +77,10 @@ test("macOS Team Vault coordinator preserves causal dirty and conflict state", a
 });
 
 test("Host context menu opens a real encrypted Team Vault share flow", async () => {
-  const [content, sharing] = await Promise.all([
+  const [content, sharing, coordinator] = await Promise.all([
     readFile(new URL("ContentView.swift", sourceRoot), "utf8"),
     readFile(new URL("CloudProfileShareView.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudTeamVaultSyncCoordinator.swift", sourceRoot), "utf8"),
   ]);
   assert.match(content, /Share with Team/);
   assert.match(content, /SelectiveRemoteCloudProfileShareView/);
@@ -88,6 +89,11 @@ test("Host context menu opens a real encrypted Team Vault share flow", async () 
   assert.match(sharing, /coordinator\.stage/);
   assert.match(sharing, /coordinator\.push/);
   assert.match(sharing, /without its saved password/);
+  assert.match(coordinator, /enum SelectiveRemoteTeamVaultSyncError: LocalizedError, Equatable/);
+  assert.match(coordinator, /case \.missingDeviceWrapper:[\s\S]*?не выдан ключ выбранного Team Vault/);
+  assert.match(sharing, /catch SelectiveRemoteTeamVaultSyncError\.missingDeviceWrapper/);
+  assert.match(sharing, /needsDeviceWrapper = true/);
+  assert.match(sharing, /Открыть Team Vaults в браузере/);
 });
 
 test("macOS Team Vault record workflow mirrors the bounded browser causal model", async () => {

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -155,6 +155,8 @@ test("macOS Cloud settings expose device-bound sign-in and native Team managemen
   assert.match(teamManagement, /client\.inviteTeamMember/);
   assert.match(teamManagement, /client\.createSharedVault/);
   assert.match(teamManagement, /Team Hosts/);
+  assert.match(teamManagement, /@\\\(member\.username\)/);
+  assert.doesNotMatch(teamManagement, /Text\(member\.email\)/);
   assert.match(client, /v1\/auth\/register/);
   assert.match(client, /verificationRequired/);
   assert.match(client, /validLoginJSON/);

--- a/cloud/tests/migrations.test.mjs
+++ b/cloud/tests/migrations.test.mjs
@@ -15,8 +15,18 @@ test("numbered migrations have stable checksums", async () => {
     { version: 5, name: "005_team_foundation.sql" },
     { version: 6, name: "006_team_vault_crypto.sql" },
     { version: 7, name: "007_account_deletion.sql" },
+    { version: 8, name: "008_usernames.sql" },
   ]);
   for (const migration of migrations) assert.match(migration.checksum, /^[0-9a-f]{64}$/);
+});
+
+test("usernames are unique public handles and existing accounts receive a stable fallback", async () => {
+  const migrations = await loadMigrations(migrationsDirectory);
+  const usernames = migrations.find(({ version }) => version === 8);
+  assert.match(usernames.sql, /ADD COLUMN username text/);
+  assert.match(usernames.sql, /users_username_unique/);
+  assert.match(usernames.sql, /users_username_shape/);
+  assert.doesNotMatch(usernames.sql, /email.*DROP|DROP.*email/iu);
 });
 
 test("account deletion preserves Team history while removing account-owned secrets", async () => {

--- a/cloud/tests/public-auth.test.mjs
+++ b/cloud/tests/public-auth.test.mjs
@@ -16,6 +16,7 @@ test("browser registration sends JSON without persisting or returning a password
 
   const result = await client.register({
     displayName: "Leonid",
+    username: "leonid",
     email: "owner@example.com",
     password: "a sufficiently long password",
     deviceID,
@@ -27,6 +28,7 @@ test("browser registration sends JSON without persisting or returning a password
   assert.equal(request[1].cache, "no-store");
   const body = JSON.parse(request[1].body);
   assert.equal(body.email, "owner@example.com");
+  assert.equal(body.username, "leonid");
   assert.equal(body.device.id, deviceID);
   assert.equal("password" in result, false);
 });
@@ -36,7 +38,7 @@ test("browser surfaces bounded registration and login errors", async () => {
     fetchValue: async () => ({ ok: false, status: 403, async json() { return { error: "registration_disabled" }; } }),
   });
   await assert.rejects(
-    registrationClient.register({ displayName: "Owner", email: "owner@example.com", password: "a sufficiently long password", deviceID }),
+    registrationClient.register({ displayName: "Owner", username: "owner", email: "owner@example.com", password: "a sufficiently long password", deviceID }),
     /registration_disabled/,
   );
 
@@ -68,7 +70,7 @@ test("authenticated account deletion clears the in-memory session", async () => 
   const client = createAuthenticatedVaultClient({ fetchValue: async (path, options = {}) => {
     calls.push([path, options]);
     if (path === "/v1/auth/login") return new Response(JSON.stringify({
-      token: "t".repeat(43), user: { id: deviceID, email: "owner@example.com", displayName: "Owner" }, deviceID,
+      token: "t".repeat(43), user: { id: deviceID, email: "owner@example.com", username: "owner", displayName: "Owner" }, deviceID,
     }), { status: 200, headers: { "Content-Type": "application/json" } });
     if (path === "/v1/me" && options.method === "DELETE") {
       return new Response(JSON.stringify({ deleted: true }), { status: 200, headers: { "Content-Type": "application/json" } });

--- a/cloud/tests/public-team-vault-client.test.mjs
+++ b/cloud/tests/public-team-vault-client.test.mjs
@@ -52,7 +52,7 @@ test("authenticated browser client registers its public key and keeps Team reque
     if (path === "/v1/auth/login") {
       return jsonResponse(200, {
         token,
-        user: { id: userID, email: "user@example.invalid", displayName: "User" },
+        user: { id: userID, email: "user@example.invalid", username: "user", displayName: "User" },
         deviceID,
       });
     }
@@ -89,7 +89,7 @@ test("authenticated browser client registers its public key and keeps Team reque
   const client = createAuthenticatedVaultClient({ fetchValue });
 
   await client.login({
-    email: "user@example.invalid",
+    username: "user",
     password: "synthetic-password",
     deviceID,
     publicKey: identity.publicKey,
@@ -119,7 +119,7 @@ test("account device transport normalizes approval metadata and revokes without 
     fetchValue: async (path, options = {}) => {
       calls.push({ path, options });
       if (path === "/v1/auth/login") return jsonResponse(200, {
-        token: "t".repeat(43), user: { id: userID, email: "user@example.invalid", displayName: "User" }, deviceID,
+        token: "t".repeat(43), user: { id: userID, email: "user@example.invalid", username: "user", displayName: "User" }, deviceID,
       });
       if (path === "/v1/devices") return jsonResponse(200, { devices: [{
         id: otherDeviceID,
@@ -164,7 +164,7 @@ test("Team writes carry idempotency and distinguish conflict from committed rota
       if (path === "/v1/auth/login") {
         return jsonResponse(200, {
           token: "t".repeat(43),
-          user: { id: userID, email: "user@example.invalid", displayName: "User" },
+          user: { id: userID, email: "user@example.invalid", username: "user", displayName: "User" },
           deviceID,
         });
       }
@@ -267,7 +267,7 @@ test("browser Team management covers lifecycle, members, invitations and shared 
   const member = {
     id: membershipID,
     userID,
-    email: "user@example.invalid",
+    username: "user",
     displayName: "User",
     role: "owner",
     epoch: 1,
@@ -286,7 +286,7 @@ test("browser Team management covers lifecycle, members, invitations and shared 
     fetchValue: async (path, options = {}) => {
       calls.push({ path, options });
       if (path === "/v1/auth/login") return jsonResponse(200, {
-        token: "t".repeat(43), user: { id: userID, email: "user@example.invalid", displayName: "User" }, deviceID,
+        token: "t".repeat(43), user: { id: userID, email: "user@example.invalid", username: "user", displayName: "User" }, deviceID,
       });
       if (path === "/v1/teams" && !options.method) return jsonResponse(200, { teams: [team] });
       if (path === "/v1/teams" && options.method === "POST") return jsonResponse(201, { team });

--- a/cloud/tests/public-vault-sync.test.mjs
+++ b/cloud/tests/public-vault-sync.test.mjs
@@ -75,7 +75,7 @@ test("authenticated client keeps its bearer token in memory and uses only the pe
       if (path === "/v1/auth/login") {
         return jsonResponse(200, {
           token,
-          user: { id: userID, email: "user@example.invalid", displayName: "User" },
+          user: { id: userID, email: "user@example.invalid", username: "user", displayName: "User" },
           deviceID: deviceA,
         });
       }
@@ -88,7 +88,7 @@ test("authenticated client keeps its bearer token in memory and uses only the pe
   });
 
   const user = await client.login({ email: " user@example.invalid ", password: "synthetic-password", deviceID: deviceA });
-  assert.deepEqual(user, { id: userID, email: "user@example.invalid", displayName: "User" });
+  assert.deepEqual(user, { id: userID, email: "user@example.invalid", username: "user", displayName: "User" });
   assert.equal(JSON.stringify(client.session()).includes(token), false);
 
   await assert.rejects(
@@ -112,7 +112,7 @@ test("a 401 response clears the in-memory browser session", async () => {
       if (path === "/v1/auth/login") {
         return jsonResponse(200, {
           token: "t".repeat(43),
-          user: { id: userID, email: "user@example.invalid", displayName: "User" },
+          user: { id: userID, email: "user@example.invalid", username: "user", displayName: "User" },
           deviceID: deviceA,
         });
       }

--- a/cloud/tests/security.test.mjs
+++ b/cloud/tests/security.test.mjs
@@ -13,6 +13,7 @@ import {
   hashSessionToken,
   hashTeamInvitationToken,
   normalizeEmail,
+  normalizeUsername,
   teamVaultWrapperContextHash,
   validateDevicePublicKey,
   validateTeamVaultEnvelope,
@@ -23,6 +24,13 @@ import {
 test("email normalization is deterministic", () => {
   assert.equal(normalizeEmail("  User@Example.COM "), "user@example.com");
   assert.throws(() => normalizeEmail("not-an-email"), /invalid_email/);
+});
+
+test("usernames are normalized, bounded and safe for public display", () => {
+  assert.equal(normalizeUsername("  Leonid.Kadaev_1 "), "leonid.kadaev_1");
+  assert.throws(() => normalizeUsername("ab"), /invalid_username/);
+  assert.throws(() => normalizeUsername("mail@example.com"), /invalid_username/);
+  assert.throws(() => normalizeUsername("-starts-with-separator"), /invalid_username/);
 });
 
 test("password hashes are salted and verifiable", async () => {

--- a/cloud/tests/team-postgres-integration.test.mjs
+++ b/cloud/tests/team-postgres-integration.test.mjs
@@ -41,12 +41,12 @@ test("real PostgreSQL serializes Team authorization, invitations and revocation"
   try {
     await applyMigrations(pool, migrationsDirectory, { info() {} });
     const users = await pool.query(
-      `INSERT INTO users (email, display_name, email_verified_at) VALUES
-         ('owner@example.com', 'Owner', now()),
-         ('admin@example.com', 'Admin', now()),
-         ('viewer@example.com', 'Viewer', now()),
-         ('other@example.com', 'Other', now()),
-         ('legacy@example.com', 'Legacy', now())
+      `INSERT INTO users (email, username, display_name, email_verified_at) VALUES
+         ('owner@example.com', 'owner', 'Owner', now()),
+         ('admin@example.com', 'admin', 'Admin', now()),
+         ('viewer@example.com', 'viewer', 'Viewer', now()),
+         ('other@example.com', 'other', 'Other', now()),
+         ('legacy@example.com', 'legacy', 'Legacy', now())
        RETURNING id, email`,
     );
     const byEmail = Object.fromEntries(users.rows.map((row) => [row.email, row.id]));


### PR DESCRIPTION
## Что входит

- понятная обработка отсутствующего Team Vault wrapper вместо внутреннего номера ошибки;
- переход из окна публикации Host в Cloud для восстановления доступа;
- уникальный публичный `@username` для новых аккаунтов;
- безопасный временный username для существующих аккаунтов;
- email удалён из Team member API и больше не показывается участникам;
- поля username добавлены в регистрацию Web и macOS;
- строгая нормализация и уникальность username закреплены миграцией PostgreSQL.

## Проверки

- полный Cloud suite: 250 тестов, 249 успешно, 1 PostgreSQL integration штатно пропущен без TEST_DATABASE_URL;
- `git diff --check` — успешно.

Следующим PR/этапом будут приглашения по username и одноразовой ссылке, затем автоматическая выдача ключей и фоновая Team Host sync.

`main` этим PR не изменён.