### PR TITLE
Automate Team device admission and key provisioning

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -16,8 +16,11 @@ ECDH/HKDF/AES-GCM wrappers, scope-bound shared payload envelopes, strict Team
 API calls, Team/member/shared-Vault UI and causal shared-record synchronization.
 The portal also lists account devices, shows canonical SHA-256 public-key
 fingerprints, approves a matching new key only from an approved device, revokes
-other devices, lets Owner/Admin grant missing current-generation wrappers from
-an unlocked Vault and completes required rotations. Owners can rename Teams,
+other devices, and completes required rotations. Invitation acceptance
+atomically approves only that authenticated session's registered P-256 device.
+Any active member device that already holds the current Vault wrapper can then
+provision missing current-generation wrappers for other active approved Team
+devices. Owners can rename Teams,
 atomically transfer ownership after password re-authentication, and archive a
 Team behind exact-name confirmation. Archiving immediately closes Team access,
 retires pending invitations/outbox work and rotation tasks, soft-archives its
@@ -88,7 +91,9 @@ the database stores and replays the committed response atomically.
 - `DELETE /v1/teams/{teamID}/invitations/{invitationID}` cancels a pending
   invitation, retires any undelivered legacy outbox job and invalidates a link.
 - `POST /v1/team-invitations/accept` accepts either an account-bound invitation
-  ID or an opaque link token once and creates the next membership epoch.
+  ID or an opaque link token once, creates the next membership epoch and
+  atomically approves only the accepting authenticated session device after
+  verifying its registered P-256 public key.
 - `PATCH|DELETE /v1/teams/{teamID}/members/{membershipID}` changes a role or
   revokes membership under a transactionally locked role check. Self-mutation,
   Admin escalation and removal of the last Owner fail closed.
@@ -102,12 +107,16 @@ the database stores and replays the committed response atomically.
   approve only the current registered key and only while the account has zero
   approved devices. The user row serializes competing first-device attempts.
 - `GET /v1/teams/{teamID}/vaults/{vaultID}/key-devices` returns the exact
-  active approved device set to Owner/Admin clients preparing wrappers.
+  active approved device set to Owner/Admin clients or to any active member
+  whose current session device already has a wrapper for this Vault generation.
 - `GET|PUT /v1/teams/{teamID}/vaults/{vaultID}` downloads the current opaque
   envelope/current-device wrapper or conditionally writes a ciphertext
   revision. Viewer writes are rejected.
-- `POST /v1/teams/{teamID}/vaults/{vaultID}/wrappers` grants a current-
-  generation wrapper to one newly authorized device under Owner/Admin checks.
+- `POST /v1/teams/{teamID}/vaults/{vaultID}/wrappers` idempotently grants a
+  current-generation wrapper to one active approved Team device. The actor's
+  current session device must itself be approved, active in the exact
+  membership epoch and already hold this Vault generation's wrapper. Vault
+  initialization and rotation remain Owner/Admin-only.
 
 The invitation table stores only an HMAC token hash plus the public target
 account ID for `@username` invitations. A link's recoverable token is held only

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -16,10 +16,11 @@ ECDH/HKDF/AES-GCM wrappers, scope-bound shared payload envelopes, strict Team
 API calls, Team/member/shared-Vault UI and causal shared-record synchronization.
 The portal also lists account devices, shows canonical SHA-256 public-key
 fingerprints, approves a matching new key only from an approved device, revokes
-other devices, and completes required rotations. Invitation acceptance
-atomically approves only that authenticated session's registered P-256 device.
+other devices, and completes required rotations. Invitation acceptance records
+a Team- and membership-epoch-scoped admission for only the authenticated
+session's registered P-256 device; it does not grant account-wide device trust.
 Any active member device that already holds the current Vault wrapper can then
-provision missing current-generation wrappers for other active approved Team
+provision missing current-generation wrappers for other active authorized Team
 devices. Owners can rename Teams,
 atomically transfer ownership after password re-authentication, and archive a
 Team behind exact-name confirmation. Archiving immediately closes Team access,
@@ -92,8 +93,9 @@ the database stores and replays the committed response atomically.
   invitation, retires any undelivered legacy outbox job and invalidates a link.
 - `POST /v1/team-invitations/accept` accepts either an account-bound invitation
   ID or an opaque link token once, creates the next membership epoch and
-  atomically approves only the accepting authenticated session device after
-  verifying its registered P-256 public key.
+  atomically admits only the accepting authenticated session device to that
+  exact membership epoch after verifying its registered P-256 public key.
+  Account-wide device approval remains unchanged.
 - `PATCH|DELETE /v1/teams/{teamID}/members/{membershipID}` changes a role or
   revokes membership under a transactionally locked role check. Self-mutation,
   Admin escalation and removal of the last Owner fail closed.
@@ -107,14 +109,15 @@ the database stores and replays the committed response atomically.
   approve only the current registered key and only while the account has zero
   approved devices. The user row serializes competing first-device attempts.
 - `GET /v1/teams/{teamID}/vaults/{vaultID}/key-devices` returns the exact
-  active approved device set to Owner/Admin clients or to any active member
-  whose current session device already has a wrapper for this Vault generation.
+  active authorized device set (account-approved or admitted to the exact
+  membership epoch) to Owner/Admin clients or to any active member whose
+  current session device already has a wrapper for this Vault generation.
 - `GET|PUT /v1/teams/{teamID}/vaults/{vaultID}` downloads the current opaque
   envelope/current-device wrapper or conditionally writes a ciphertext
   revision. Viewer writes are rejected.
 - `POST /v1/teams/{teamID}/vaults/{vaultID}/wrappers` idempotently grants a
-  current-generation wrapper to one active approved Team device. The actor's
-  current session device must itself be approved, active in the exact
+  current-generation wrapper to one active authorized Team device. The actor's
+  current session device must itself be authorized, active in the exact
   membership epoch and already hold this Vault generation's wrapper. Vault
   initialization and rotation remain Owner/Admin-only.
 

--- a/cloud/migrations/010_team_membership_device_admissions.sql
+++ b/cloud/migrations/010_team_membership_device_admissions.sql
@@ -1,0 +1,13 @@
+CREATE TABLE team_membership_device_admissions (
+    membership_id uuid NOT NULL,
+    membership_epoch bigint NOT NULL CHECK (membership_epoch > 0),
+    device_id uuid NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+    invitation_id uuid REFERENCES team_invitations(id) ON DELETE SET NULL,
+    admitted_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (membership_id, membership_epoch, device_id),
+    FOREIGN KEY (membership_id, membership_epoch)
+        REFERENCES team_memberships(id, epoch) ON DELETE CASCADE
+);
+
+CREATE INDEX team_membership_device_admissions_device
+    ON team_membership_device_admissions (device_id, membership_id, membership_epoch);

--- a/cloud/src/postgres-store.mjs
+++ b/cloud/src/postgres-store.mjs
@@ -901,7 +901,14 @@ export class PostgresStore {
     });
   }
 
-  async acceptTeamInvitation({ actorUserID, actorEmail, invitationID, tokenHash, idempotencyKey }) {
+  async acceptTeamInvitation({
+    actorUserID,
+    actorDeviceID,
+    actorEmail,
+    invitationID,
+    tokenHash,
+    idempotencyKey,
+  }) {
     return this.withTeamMutation(actorUserID, "team.invitation.accept", idempotencyKey, async (client) => {
       const invitationResult = await client.query(
         `SELECT invitation.id, invitation.team_id, invitation.invitation_type, invitation.role,
@@ -926,6 +933,26 @@ export class PostgresStore {
       );
       const invitation = invitationResult.rows[0];
       if (!invitation) throw new Error("invalid_team_invitation");
+
+      const deviceResult = await client.query(
+        `SELECT id, key_approved_at FROM devices
+         WHERE id = $1 AND user_id = $2 AND revoked_at IS NULL
+           AND public_key IS NOT NULL AND public_key_algorithm = 'p256-ecdh-v1'
+         FOR UPDATE`,
+        [actorDeviceID, actorUserID],
+      );
+      const acceptingDevice = deviceResult.rows[0];
+      if (!acceptingDevice) throw new Error("device_approval_required");
+      const deviceAutoApproved = !acceptingDevice.key_approved_at;
+      if (deviceAutoApproved) {
+        await client.query(
+          `UPDATE devices SET key_approved_at = now(), key_approved_by_device_id = NULL
+           WHERE id = $1 AND user_id = $2 AND revoked_at IS NULL
+             AND public_key IS NOT NULL AND public_key_algorithm = 'p256-ecdh-v1'
+             AND key_approved_at IS NULL`,
+          [actorDeviceID, actorUserID],
+        );
+      }
 
       const priorResult = await client.query(
         `SELECT id, epoch, revoked_at FROM team_memberships
@@ -965,7 +992,12 @@ export class PostgresStore {
         action: "team.invitation_accepted",
         targetUserID: actorUserID,
         targetMembershipID: membership.id,
-        metadata: { role: membership.role, epoch: nextEpoch },
+        metadata: {
+          role: membership.role,
+          epoch: nextEpoch,
+          acceptingDeviceID: actorDeviceID,
+          deviceAutoApproved,
+        },
       });
       return { membership };
     });
@@ -1122,18 +1154,34 @@ export class PostgresStore {
     });
   }
 
-  async listTeamKeyDevices(teamID, vaultID, actorUserID) {
+  async listTeamKeyDevices(teamID, vaultID, actorUserID, actorDeviceID) {
     const access = await this.pool.query(
-      `SELECT membership.role
+      `SELECT membership.role, device.key_approved_at,
+         actor_wrapper.device_id IS NOT NULL AS actor_has_wrapper
        FROM team_memberships AS membership
        JOIN teams AS team ON team.id = membership.team_id AND team.archived_at IS NULL
        JOIN shared_vaults AS vault ON vault.team_id = team.id AND vault.archived_at IS NULL
+       JOIN devices AS device ON device.id = $4 AND device.user_id = membership.user_id
+         AND device.revoked_at IS NULL
+       LEFT JOIN shared_vault_key_wrappers AS actor_wrapper
+         ON actor_wrapper.vault_id = vault.id
+        AND actor_wrapper.key_generation = vault.key_generation
+        AND actor_wrapper.membership_id = membership.id
+        AND actor_wrapper.membership_epoch = membership.epoch
+        AND actor_wrapper.device_id = device.id
        WHERE membership.team_id = $1 AND vault.id = $2 AND membership.user_id = $3
          AND membership.revoked_at IS NULL`,
-      [teamID, vaultID, actorUserID],
+      [teamID, vaultID, actorUserID, actorDeviceID],
     );
     if (!access.rows[0]) throw new Error("team_not_found");
-    requireTeamPermission(access.rows[0].role, "manage_vault_keys");
+    if (!access.rows[0].key_approved_at) throw new Error("device_approval_required");
+    if (!access.rows[0].actor_has_wrapper) {
+      try {
+        requireTeamPermission(access.rows[0].role, "manage_vault_keys");
+      } catch {
+        throw new Error("team_vault_key_unavailable");
+      }
+    }
     const result = await this.pool.query(
       `SELECT membership.id AS membership_id, membership.epoch AS membership_epoch,
          device.id AS device_id, device.public_key_algorithm, device.public_key,
@@ -1287,11 +1335,18 @@ export class PostgresStore {
       const context = await lockSharedVaultActor(client, teamID, vaultID, actorUserID, actorDeviceID);
       if (!context) throw new Error("team_not_found");
       if (!context.key_approved_at) throw new Error("device_approval_required");
-      requireTeamPermission(context.role, "manage_vault_keys");
       if (!Number.isSafeInteger(keyGeneration) || keyGeneration !== Number(context.key_generation)
         || Number(context.revision) === 0 || context.rotation_required === true) {
         throw new Error("invalid_key_generation");
       }
+      const actorWrapper = await client.query(
+        `SELECT 1 FROM shared_vault_key_wrappers
+         WHERE vault_id = $1 AND key_generation = $2 AND membership_id = $3
+           AND membership_epoch = $4 AND device_id = $5
+         FOR UPDATE`,
+        [vaultID, keyGeneration, context.membership_id, context.epoch, actorDeviceID],
+      );
+      if (!actorWrapper.rows[0]) throw new Error("team_vault_key_unavailable");
       const eligible = await lockEligibleTeamDevices(client, teamID);
       const target = eligible.find((row) => row.device_id === wrapper.deviceID);
       if (!target || target.membership_id !== wrapper.membershipID
@@ -1299,11 +1354,15 @@ export class PostgresStore {
         throw new Error("team_not_found");
       }
       requireWrapperContextHashes(teamID, vaultID, keyGeneration, [wrapper]);
-      try {
-        await insertSharedVaultWrappers(client, vaultID, keyGeneration, actorDeviceID, [wrapper]);
-      } catch (error) {
-        if (error?.code === "23505") throw new Error("shared_vault_wrapper_exists");
-        throw error;
+      const inserted = await insertSharedVaultWrapperIdempotently(
+        client,
+        vaultID,
+        keyGeneration,
+        actorDeviceID,
+        wrapper,
+      );
+      if (!inserted) {
+        return { granted: true, keyGeneration, deviceID: wrapper.deviceID };
       }
       await writeTeamAudit(client, {
         teamID,
@@ -1473,6 +1532,28 @@ function requireWrapperContextHashes(teamID, vaultID, keyGeneration, wrappers) {
     });
     if (wrapper.contextHash !== expected) throw new Error("invalid_team_vault_wrapper_context");
   }
+}
+
+async function insertSharedVaultWrapperIdempotently(
+  client,
+  vaultID,
+  keyGeneration,
+  actorDeviceID,
+  wrapper,
+) {
+  const result = await client.query(
+    `INSERT INTO shared_vault_key_wrappers
+      (vault_id, key_generation, membership_id, membership_epoch, device_id,
+       wrapper_version, ephemeral_public_key, ciphertext, nonce, auth_tag,
+       context_hash, created_by_device_id)
+     VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb,$8,$9,$10,$11,$12)
+     ON CONFLICT (vault_id, key_generation, device_id) DO NOTHING
+     RETURNING device_id`,
+    [vaultID, keyGeneration, wrapper.membershipID, wrapper.membershipEpoch,
+      wrapper.deviceID, wrapper.wrapperVersion, JSON.stringify(wrapper.ephemeralPublicKey),
+      wrapper.ciphertext, wrapper.nonce, wrapper.authTag, wrapper.contextHash, actorDeviceID],
+  );
+  return Boolean(result.rows[0]);
 }
 
 async function insertSharedVaultWrappers(client, vaultID, keyGeneration, actorDeviceID, wrappers) {

--- a/cloud/src/postgres-store.mjs
+++ b/cloud/src/postgres-store.mjs
@@ -443,7 +443,11 @@ export class PostgresStore {
         "UPDATE sessions SET revoked_at = now() WHERE user_id = $1 AND device_id = $2 AND revoked_at IS NULL",
         [userID, deviceID],
       );
-      if (result.rows[0].key_approved_at) {
+      const wrapper = await client.query(
+        "SELECT 1 FROM shared_vault_key_wrappers WHERE device_id = $1 LIMIT 1",
+        [deviceID],
+      );
+      if (result.rows[0].key_approved_at || wrapper.rows[0]) {
         await client.query(
           `WITH affected AS (
              UPDATE shared_vaults AS vault SET rotation_required = true, updated_at = now()
@@ -935,24 +939,13 @@ export class PostgresStore {
       if (!invitation) throw new Error("invalid_team_invitation");
 
       const deviceResult = await client.query(
-        `SELECT id, key_approved_at FROM devices
+        `SELECT id FROM devices
          WHERE id = $1 AND user_id = $2 AND revoked_at IS NULL
            AND public_key IS NOT NULL AND public_key_algorithm = 'p256-ecdh-v1'
          FOR UPDATE`,
         [actorDeviceID, actorUserID],
       );
-      const acceptingDevice = deviceResult.rows[0];
-      if (!acceptingDevice) throw new Error("device_approval_required");
-      const deviceAutoApproved = !acceptingDevice.key_approved_at;
-      if (deviceAutoApproved) {
-        await client.query(
-          `UPDATE devices SET key_approved_at = now(), key_approved_by_device_id = NULL
-           WHERE id = $1 AND user_id = $2 AND revoked_at IS NULL
-             AND public_key IS NOT NULL AND public_key_algorithm = 'p256-ecdh-v1'
-             AND key_approved_at IS NULL`,
-          [actorDeviceID, actorUserID],
-        );
-      }
+      if (!deviceResult.rows[0]) throw new Error("device_approval_required");
 
       const priorResult = await client.query(
         `SELECT id, epoch, revoked_at FROM team_memberships
@@ -975,6 +968,12 @@ export class PostgresStore {
         username: invitation.username,
         display_name: invitation.display_name,
       };
+      await client.query(
+        `INSERT INTO team_membership_device_admissions
+          (membership_id, membership_epoch, device_id, invitation_id)
+         VALUES ($1, $2, $3, $4)`,
+        [membership.id, nextEpoch, actorDeviceID, invitation.id],
+      );
       const accepted = await client.query(
         `UPDATE team_invitations SET accepted_at = now(), accepted_by_user_id = $2
          WHERE id = $1 AND accepted_at IS NULL AND cancelled_at IS NULL
@@ -996,7 +995,7 @@ export class PostgresStore {
           role: membership.role,
           epoch: nextEpoch,
           acceptingDeviceID: actorDeviceID,
-          deviceAutoApproved,
+          deviceAdmittedByInvitation: true,
         },
       });
       return { membership };
@@ -1156,13 +1155,20 @@ export class PostgresStore {
 
   async listTeamKeyDevices(teamID, vaultID, actorUserID, actorDeviceID) {
     const access = await this.pool.query(
-      `SELECT membership.role, device.key_approved_at,
+      `SELECT membership.role,
+         (device.key_approved_at IS NOT NULL OR actor_admission.device_id IS NOT NULL)
+           AS actor_key_authorized,
          actor_wrapper.device_id IS NOT NULL AS actor_has_wrapper
        FROM team_memberships AS membership
        JOIN teams AS team ON team.id = membership.team_id AND team.archived_at IS NULL
        JOIN shared_vaults AS vault ON vault.team_id = team.id AND vault.archived_at IS NULL
        JOIN devices AS device ON device.id = $4 AND device.user_id = membership.user_id
          AND device.revoked_at IS NULL
+         AND device.public_key IS NOT NULL AND device.public_key_algorithm = 'p256-ecdh-v1'
+       LEFT JOIN team_membership_device_admissions AS actor_admission
+         ON actor_admission.membership_id = membership.id
+        AND actor_admission.membership_epoch = membership.epoch
+        AND actor_admission.device_id = device.id
        LEFT JOIN shared_vault_key_wrappers AS actor_wrapper
          ON actor_wrapper.vault_id = vault.id
         AND actor_wrapper.key_generation = vault.key_generation
@@ -1174,7 +1180,7 @@ export class PostgresStore {
       [teamID, vaultID, actorUserID, actorDeviceID],
     );
     if (!access.rows[0]) throw new Error("team_not_found");
-    if (!access.rows[0].key_approved_at) throw new Error("device_approval_required");
+    if (!access.rows[0].actor_key_authorized) throw new Error("device_approval_required");
     if (!access.rows[0].actor_has_wrapper) {
       try {
         requireTeamPermission(access.rows[0].role, "manage_vault_keys");
@@ -1188,6 +1194,10 @@ export class PostgresStore {
          wrapper.device_id IS NOT NULL AS has_wrapper
        FROM team_memberships AS membership
        JOIN devices AS device ON device.user_id = membership.user_id
+       LEFT JOIN team_membership_device_admissions AS admission
+         ON admission.membership_id = membership.id
+        AND admission.membership_epoch = membership.epoch
+        AND admission.device_id = device.id
        JOIN shared_vaults AS vault ON vault.id = $2 AND vault.team_id = membership.team_id
          AND vault.archived_at IS NULL
        LEFT JOIN shared_vault_key_wrappers AS wrapper
@@ -1195,8 +1205,9 @@ export class PostgresStore {
          AND wrapper.membership_id = membership.id AND wrapper.membership_epoch = membership.epoch
          AND wrapper.device_id = device.id
        WHERE membership.team_id = $1 AND membership.revoked_at IS NULL
-         AND device.revoked_at IS NULL AND device.key_approved_at IS NOT NULL
-         AND device.public_key IS NOT NULL
+         AND device.revoked_at IS NULL
+         AND (device.key_approved_at IS NOT NULL OR admission.device_id IS NOT NULL)
+         AND device.public_key IS NOT NULL AND device.public_key_algorithm = 'p256-ecdh-v1'
        ORDER BY membership.id, device.id`,
       [teamID, vaultID],
     );
@@ -1209,7 +1220,9 @@ export class PostgresStore {
          vault.rotation_required, vault.envelope_version, vault.ciphertext, vault.nonce,
          vault.auth_tag, vault.content_hash, vault.created_at, vault.updated_at,
          membership.id AS membership_id, membership.epoch AS membership_epoch,
-         device.id AS device_id, device.key_approved_at,
+         device.id AS device_id,
+         (device.key_approved_at IS NOT NULL OR actor_admission.device_id IS NOT NULL)
+           AS device_key_authorized,
          wrapper.wrapper_version, wrapper.ephemeral_public_key,
          wrapper.ciphertext AS wrapper_ciphertext, wrapper.nonce AS wrapper_nonce,
          wrapper.auth_tag AS wrapper_auth_tag, wrapper.context_hash
@@ -1218,6 +1231,11 @@ export class PostgresStore {
        JOIN shared_vaults AS vault ON vault.team_id = team.id AND vault.archived_at IS NULL
        JOIN devices AS device ON device.id = $4 AND device.user_id = membership.user_id
          AND device.revoked_at IS NULL
+         AND device.public_key IS NOT NULL AND device.public_key_algorithm = 'p256-ecdh-v1'
+       LEFT JOIN team_membership_device_admissions AS actor_admission
+         ON actor_admission.membership_id = membership.id
+        AND actor_admission.membership_epoch = membership.epoch
+        AND actor_admission.device_id = device.id
        LEFT JOIN shared_vault_key_wrappers AS wrapper
          ON wrapper.vault_id = vault.id AND wrapper.key_generation = vault.key_generation
          AND wrapper.membership_id = membership.id AND wrapper.membership_epoch = membership.epoch
@@ -1228,7 +1246,7 @@ export class PostgresStore {
     );
     const row = result.rows[0];
     if (!row) throw new Error("team_not_found");
-    if (!row.key_approved_at) throw new Error("device_approval_required");
+    if (!row.device_key_authorized) throw new Error("device_approval_required");
     return row;
   }
 
@@ -1243,7 +1261,7 @@ export class PostgresStore {
     return this.withTeamMutation(actorUserID, "team.vault.put", idempotencyKey, async (client) => {
       const context = await lockSharedVaultActor(client, teamID, vaultID, actorUserID, actorDeviceID);
       if (!context) throw new Error("team_not_found");
-      if (!context.key_approved_at) throw new Error("device_approval_required");
+      if (!context.device_key_authorized) throw new Error("device_approval_required");
       requireTeamPermission(context.role, "write_vault");
       const currentRevision = Number(context.revision);
       const currentGeneration = Number(context.key_generation);
@@ -1334,7 +1352,7 @@ export class PostgresStore {
     return this.withTeamMutation(actorUserID, "team.vault.wrapper.grant", idempotencyKey, async (client) => {
       const context = await lockSharedVaultActor(client, teamID, vaultID, actorUserID, actorDeviceID);
       if (!context) throw new Error("team_not_found");
-      if (!context.key_approved_at) throw new Error("device_approval_required");
+      if (!context.device_key_authorized) throw new Error("device_approval_required");
       if (!Number.isSafeInteger(keyGeneration) || keyGeneration !== Number(context.key_generation)
         || Number(context.revision) === 0 || context.rotation_required === true) {
         throw new Error("invalid_key_generation");
@@ -1476,12 +1494,19 @@ async function lockTeamMembership(client, teamID, membershipID) {
 async function lockSharedVaultActor(client, teamID, vaultID, actorUserID, actorDeviceID) {
   const result = await client.query(
     `SELECT membership.id AS membership_id, membership.role, membership.epoch,
-       device.key_approved_at, vault.revision, vault.key_generation, vault.rotation_required
+       (device.key_approved_at IS NOT NULL OR actor_admission.device_id IS NOT NULL)
+         AS device_key_authorized,
+       vault.revision, vault.key_generation, vault.rotation_required
      FROM team_memberships AS membership
      JOIN teams AS team ON team.id = membership.team_id AND team.archived_at IS NULL
      JOIN shared_vaults AS vault ON vault.team_id = team.id AND vault.archived_at IS NULL
      JOIN devices AS device ON device.id = $4 AND device.user_id = membership.user_id
        AND device.revoked_at IS NULL
+       AND device.public_key IS NOT NULL AND device.public_key_algorithm = 'p256-ecdh-v1'
+     LEFT JOIN team_membership_device_admissions AS actor_admission
+       ON actor_admission.membership_id = membership.id
+      AND actor_admission.membership_epoch = membership.epoch
+      AND actor_admission.device_id = device.id
      WHERE membership.team_id = $1 AND vault.id = $2 AND membership.user_id = $3
        AND membership.revoked_at IS NULL
      FOR UPDATE OF membership, team, vault, device`,
@@ -1496,9 +1521,14 @@ async function lockEligibleTeamDevices(client, teamID) {
        device.id AS device_id
      FROM team_memberships AS membership
      JOIN devices AS device ON device.user_id = membership.user_id
+     LEFT JOIN team_membership_device_admissions AS admission
+       ON admission.membership_id = membership.id
+      AND admission.membership_epoch = membership.epoch
+      AND admission.device_id = device.id
      WHERE membership.team_id = $1 AND membership.revoked_at IS NULL
-       AND device.revoked_at IS NULL AND device.key_approved_at IS NOT NULL
-       AND device.public_key IS NOT NULL
+       AND device.revoked_at IS NULL
+       AND (device.key_approved_at IS NOT NULL OR admission.device_id IS NOT NULL)
+       AND device.public_key IS NOT NULL AND device.public_key_algorithm = 'p256-ecdh-v1'
      ORDER BY membership.id, device.id
      FOR UPDATE OF membership, device`,
     [teamID],

--- a/cloud/src/service.mjs
+++ b/cloud/src/service.mjs
@@ -418,6 +418,7 @@ export class CloudService {
     if (hasInvitationID && !invitationID) throw new Error("invalid_team_invitation");
     const result = await this.store.acceptTeamInvitation({
       actorUserID: session.user_id,
+      actorDeviceID: session.device_id,
       actorEmail: session.email,
       invitationID,
       tokenHash: hasToken
@@ -505,7 +506,12 @@ export class CloudService {
   }
 
   async listTeamKeyDevices(session, teamID, vaultID) {
-    const rows = await this.store.listTeamKeyDevices(teamID, vaultID, session.user_id);
+    const rows = await this.store.listTeamKeyDevices(
+      teamID,
+      vaultID,
+      session.user_id,
+      session.device_id,
+    );
     return { devices: rows.map(publicTeamKeyDevice) };
   }
 

--- a/cloud/tests/migrations.test.mjs
+++ b/cloud/tests/migrations.test.mjs
@@ -17,6 +17,7 @@ test("numbered migrations have stable checksums", async () => {
     { version: 7, name: "007_account_deletion.sql" },
     { version: 8, name: "008_usernames.sql" },
     { version: 9, name: "009_team_invitation_modes.sql" },
+    { version: 10, name: "010_team_membership_device_admissions.sql" },
   ]);
   for (const migration of migrations) assert.match(migration.checksum, /^[0-9a-f]{64}$/);
 });
@@ -40,6 +41,19 @@ test("Team invitation modes bind usernames and seal revocable single-use links",
   assert.match(invitations.sql, /CREATE TABLE team_invitation_link_secrets/u);
   assert.match(invitations.sql, /payload_ciphertext text NOT NULL/u);
   assert.doesNotMatch(invitations.sql, /\btoken\s+text\b|\bplaintext\b|\bvault_key\b/u);
+});
+
+test("Team invitation admission is scoped to one membership epoch and device", async () => {
+  const migrations = await loadMigrations(migrationsDirectory);
+  const admission = migrations.find(({ version }) => version === 10);
+
+  assert.match(admission.sql, /CREATE TABLE team_membership_device_admissions/u);
+  assert.match(admission.sql, /PRIMARY KEY \(membership_id, membership_epoch, device_id\)/u);
+  assert.match(admission.sql, /FOREIGN KEY \(membership_id, membership_epoch\)[\s\S]*REFERENCES team_memberships\(id, epoch\) ON DELETE CASCADE/u);
+  assert.match(admission.sql, /device_id uuid NOT NULL REFERENCES devices\(id\) ON DELETE CASCADE/u);
+  assert.match(admission.sql, /invitation_id uuid REFERENCES team_invitations\(id\) ON DELETE SET NULL/u);
+  assert.match(admission.sql, /CREATE INDEX team_membership_device_admissions_device/u);
+  assert.doesNotMatch(admission.sql, /key_approved_at|private_key|vault_key/u);
 });
 
 test("account deletion preserves Team history while removing account-owned secrets", async () => {

--- a/cloud/tests/team-postgres-integration.test.mjs
+++ b/cloud/tests/team-postgres-integration.test.mjs
@@ -156,12 +156,22 @@ test("real PostgreSQL serializes Team authorization, invitations and revocation"
     assert.equal(accepted.membership.username, "admin");
     assert.equal(accepted.membership.display_name, "Admin");
     assert.equal(Number(accepted.membership.epoch), 1);
-    const approvedAdminDevice = await pool.query(
+    const admittedAdminDevice = await pool.query(
       "SELECT key_approved_at, key_approved_by_device_id FROM devices WHERE id = $1",
       [adminDeviceID],
     );
-    assert.ok(approvedAdminDevice.rows[0].key_approved_at);
-    assert.equal(approvedAdminDevice.rows[0].key_approved_by_device_id, null);
+    assert.equal(admittedAdminDevice.rows[0].key_approved_at, null);
+    assert.equal(admittedAdminDevice.rows[0].key_approved_by_device_id, null);
+    const scopedAdmission = await pool.query(
+      `SELECT membership_id, membership_epoch, device_id, invitation_id
+       FROM team_membership_device_admissions
+       WHERE membership_id = $1 AND membership_epoch = $2 AND device_id = $3`,
+      [accepted.membership.id, accepted.membership.epoch, adminDeviceID],
+    );
+    assert.equal(scopedAdmission.rows[0].membership_id, accepted.membership.id);
+    assert.equal(Number(scopedAdmission.rows[0].membership_epoch), 1);
+    assert.equal(scopedAdmission.rows[0].device_id, adminDeviceID);
+    assert.equal(scopedAdmission.rows[0].invitation_id, adminInvite.invitation.id);
     await assert.rejects(store.acceptTeamInvitation({
       actorUserID: byEmail["admin@example.com"],
       actorDeviceID: adminDeviceID,

--- a/cloud/tests/team-postgres-integration.test.mjs
+++ b/cloud/tests/team-postgres-integration.test.mjs
@@ -9,7 +9,9 @@ import { teamVaultWrapperContextHash } from "../src/security.mjs";
 const databaseURL = process.env.TEST_DATABASE_URL;
 const migrationsDirectory = fileURLToPath(new URL("../migrations/", import.meta.url));
 const ownerDeviceID = "33cc880e-084a-4d9a-b1ea-f99d2ff86032";
+const adminDeviceID = "e5cb5666-8db7-4fd8-88f7-0a3b0a8df156";
 const viewerDeviceID = "aef6452c-1ad8-48bb-b4b5-ea9c207b707b";
+const viewerSecondDeviceID = "5a5bcf31-01d0-40d5-95ae-7d041553b5d9";
 const legacyDeviceID = "c9afe150-1081-49dc-ad2e-ea67c59a4a25";
 const legacySecondDeviceID = "dab87dc1-99fd-43f4-aa31-cba26c207cff";
 
@@ -65,9 +67,11 @@ test("real PostgreSQL serializes Team authorization, invitations and revocation"
         (id, user_id, name, platform, public_key, public_key_algorithm,
          key_registered_at, key_approved_at)
        VALUES ($1, $2, 'Owner browser', 'web', $3, 'p256-ecdh-v1', now(), now()),
-              ($4, $5, 'Viewer browser', 'web', $3, 'p256-ecdh-v1', now(), now())`,
+              ($4, $5, 'Viewer browser', 'web', $3, 'p256-ecdh-v1', now(), now()),
+              ($6, $7, 'Admin browser', 'web', $3, 'p256-ecdh-v1', now(), NULL)`,
       [ownerDeviceID, byEmail["owner@example.com"], publicKey,
-        viewerDeviceID, byEmail["viewer@example.com"]],
+        viewerDeviceID, byEmail["viewer@example.com"],
+        adminDeviceID, byEmail["admin@example.com"]],
     );
     await pool.query(
       `INSERT INTO devices
@@ -142,6 +146,7 @@ test("real PostgreSQL serializes Team authorization, invitations and revocation"
     assert.equal(pendingAdminInvitations[0].target_username, "admin");
     const accepted = await store.acceptTeamInvitation({
       actorUserID: byEmail["admin@example.com"],
+      actorDeviceID: adminDeviceID,
       actorEmail: "admin@example.com",
       invitationID: adminInvite.invitation.id,
       tokenHash: null,
@@ -151,8 +156,15 @@ test("real PostgreSQL serializes Team authorization, invitations and revocation"
     assert.equal(accepted.membership.username, "admin");
     assert.equal(accepted.membership.display_name, "Admin");
     assert.equal(Number(accepted.membership.epoch), 1);
+    const approvedAdminDevice = await pool.query(
+      "SELECT key_approved_at, key_approved_by_device_id FROM devices WHERE id = $1",
+      [adminDeviceID],
+    );
+    assert.ok(approvedAdminDevice.rows[0].key_approved_at);
+    assert.equal(approvedAdminDevice.rows[0].key_approved_by_device_id, null);
     await assert.rejects(store.acceptTeamInvitation({
       actorUserID: byEmail["admin@example.com"],
+      actorDeviceID: adminDeviceID,
       actorEmail: "admin@example.com",
       invitationID: adminInvite.invitation.id,
       tokenHash: null,
@@ -189,6 +201,7 @@ test("real PostgreSQL serializes Team authorization, invitations and revocation"
     });
     await assert.rejects(store.acceptTeamInvitation({
       actorUserID: byEmail["other@example.com"],
+      actorDeviceID: ownerDeviceID,
       actorEmail: "other@example.com",
       invitationID: null,
       tokenHash: viewerTokenHash,
@@ -196,6 +209,7 @@ test("real PostgreSQL serializes Team authorization, invitations and revocation"
     }), /invalid_team_invitation/);
     const viewer = await store.acceptTeamInvitation({
       actorUserID: byEmail["viewer@example.com"],
+      actorDeviceID: viewerDeviceID,
       actorEmail: "viewer@example.com",
       invitationID: null,
       tokenHash: viewerTokenHash,
@@ -205,8 +219,9 @@ test("real PostgreSQL serializes Team authorization, invitations and revocation"
       created.team.id,
       shared.vault.id,
       byEmail["owner@example.com"],
+      ownerDeviceID,
     );
-    assert.equal(keyDevices.length, 2);
+    assert.equal(keyDevices.length, 3);
     await store.grantSharedVaultWrapper({
       actorUserID: byEmail["owner@example.com"],
       actorDeviceID: ownerDeviceID,
@@ -326,6 +341,41 @@ test("real PostgreSQL serializes Team authorization, invitations and revocation"
       [shared.vault.id],
     );
     assert.deepEqual(completed.rows[0], { rotation_required: false, key_generation: "2" });
+
+    await pool.query(
+      `INSERT INTO devices
+        (id, user_id, name, platform, public_key, public_key_algorithm,
+         key_registered_at, key_approved_at)
+       VALUES ($1, $2, 'Viewer second browser', 'web', $3, 'p256-ecdh-v1', now(), now())`,
+      [viewerSecondDeviceID, byEmail["viewer@example.com"], publicKey],
+    );
+    const viewerVisibleDevices = await store.listTeamKeyDevices(
+      created.team.id,
+      shared.vault.id,
+      byEmail["viewer@example.com"],
+      viewerDeviceID,
+    );
+    assert.ok(viewerVisibleDevices.some((device) => device.device_id === viewerSecondDeviceID
+      && device.has_wrapper === false));
+    assert.deepEqual(await store.grantSharedVaultWrapper({
+      actorUserID: byEmail["viewer@example.com"],
+      actorDeviceID: viewerDeviceID,
+      teamID: created.team.id,
+      vaultID: shared.vault.id,
+      wrapper: integrationWrapper(
+        viewer.membership, viewerSecondDeviceID, "Y", created.team.id, shared.vault.id, 2,
+      ),
+      keyGeneration: 2,
+      idempotencyKey: "integration:viewer-wrapper-second-device-01",
+    }), { granted: true, keyGeneration: 2, deviceID: viewerSecondDeviceID });
+    const secondViewerVault = await store.getSharedVault(
+      created.team.id,
+      shared.vault.id,
+      byEmail["viewer@example.com"],
+      viewerSecondDeviceID,
+    );
+    assert.equal(secondViewerVault.wrapper_ciphertext, "Y".repeat(43));
+
     const stale = await store.putSharedVault({
       actorUserID: byEmail["owner@example.com"],
       actorDeviceID: ownerDeviceID,

--- a/cloud/tests/team-postgres-store.test.mjs
+++ b/cloud/tests/team-postgres-store.test.mjs
@@ -452,10 +452,9 @@ test("invitation acceptance locks one token and advances a revoked membership ep
         username: "member", display_name: "Member",
       }] };
     }
-    if (sql.includes("SELECT id, key_approved_at FROM devices")) {
-      return { rows: [{ id: deviceID, key_approved_at: null }] };
+    if (sql.includes("SELECT id FROM devices")) {
+      return { rows: [{ id: deviceID }] };
     }
-    if (sql.includes("UPDATE devices SET key_approved_at = now()")) return { rows: [], rowCount: 1 };
     if (sql.includes("ORDER BY epoch DESC")) return { rows: [{ id: "old", epoch: 2, revoked_at: new Date() }] };
     if (sql.includes("INSERT INTO team_memberships")) return { rows: [acceptedMembership] };
     if (sql.includes("UPDATE team_invitations SET accepted_at")) return { rows: [{ id: "invite-1" }] };
@@ -476,13 +475,15 @@ test("invitation acceptance locks one token and advances a revoked membership ep
   assert.equal(membershipInsert.parameters[3], 3);
   const invitationLock = f.queries.find(({ sql }) => sql.includes("FOR UPDATE OF invitation, team"));
   assert.deepEqual(invitationLock.parameters, ["c".repeat(64), null, "member@example.com", actorUserID]);
-  const deviceLock = f.queries.find(({ sql }) => sql.includes("SELECT id, key_approved_at FROM devices"));
+  const deviceLock = f.queries.find(({ sql }) => sql.includes("SELECT id FROM devices"));
   assert.deepEqual(deviceLock.parameters, [deviceID, actorUserID]);
   assert.match(deviceLock.sql, /public_key_algorithm = 'p256-ecdh-v1'/u);
-  assert.ok(f.queries.some(({ sql }) => sql.includes("UPDATE devices SET key_approved_at = now()")));
+  assert.equal(f.queries.some(({ sql }) => sql.includes("UPDATE devices SET key_approved_at")), false);
+  const admission = f.queries.find(({ sql }) => sql.includes("INSERT INTO team_membership_device_admissions"));
+  assert.deepEqual(admission.parameters, [membershipID, 3, deviceID, "invite-1"]);
   const audit = f.queries.find(({ sql }) => sql.includes("INSERT INTO team_audit_events"));
   assert.match(audit.parameters.at(-1), /"acceptingDeviceID":"33cc880e-084a-4d9a-b1ea-f99d2ff86032"/u);
-  assert.match(audit.parameters.at(-1), /"deviceAutoApproved":true/u);
+  assert.match(audit.parameters.at(-1), /"deviceAdmittedByInvitation":true/u);
   assert.ok(f.queries.some(({ sql }) => sql.includes("DELETE FROM team_invitation_link_secrets")));
   assert.equal(f.queries.at(-2).sql, "COMMIT");
 });
@@ -507,8 +508,8 @@ test("username invitation acceptance is bound to the authenticated target user I
         username: "member", display_name: "Member",
       }] };
     }
-    if (sql.includes("SELECT id, key_approved_at FROM devices")) {
-      return { rows: [{ id: deviceID, key_approved_at: new Date() }] };
+    if (sql.includes("SELECT id FROM devices")) {
+      return { rows: [{ id: deviceID }] };
     }
     if (sql.includes("ORDER BY epoch DESC")) return { rows: [] };
     if (sql.includes("INSERT INTO team_memberships")) return { rows: [acceptedMembership] };
@@ -528,7 +529,9 @@ test("username invitation acceptance is bound to the authenticated target user I
   const invitationLock = f.queries.find(({ sql }) => sql.includes("FOR UPDATE OF invitation, team"));
   assert.deepEqual(invitationLock.parameters, [null, invitationID, "private@example.invalid", actorUserID]);
   assert.match(invitationLock.sql, /invitation\.target_user_id = \$4/u);
-  assert.equal(f.queries.some(({ sql }) => sql.includes("UPDATE devices SET key_approved_at = now()")), false);
+  const admission = f.queries.find(({ sql }) => sql.includes("INSERT INTO team_membership_device_admissions"));
+  assert.deepEqual(admission.parameters, [membershipID, 1, deviceID, invitationID]);
+  assert.equal(f.queries.some(({ sql }) => sql.includes("UPDATE devices SET key_approved_at")), false);
 });
 
 test("invitation acceptance refuses a session device without a registered Team key", async () => {
@@ -600,7 +603,7 @@ test("outbox claim uses multi-replica-safe SKIP LOCKED leasing", async () => {
 test("Team key-device listing binds both scope and the actor's current wrapper", async () => {
   const f = fixture((sql) => {
     if (sql.includes("SELECT membership.role")) {
-      return { rows: [{ role: "viewer", key_approved_at: new Date(), actor_has_wrapper: true }] };
+      return { rows: [{ role: "viewer", actor_key_authorized: true, actor_has_wrapper: true }] };
     }
     if (sql.includes("wrapper.device_id IS NOT NULL AS has_wrapper")) {
       return { rows: [{ membership_id: membershipID, device_id: deviceID, has_wrapper: true }] };
@@ -614,12 +617,14 @@ test("Team key-device listing binds both scope and the actor's current wrapper",
   );
   assert.deepEqual(f.queries[0].parameters, [teamID, vaultID, actorUserID, deviceID]);
   assert.match(f.queries[0].sql, /actor_wrapper\.device_id IS NOT NULL AS actor_has_wrapper/u);
+  assert.match(f.queries[0].sql, /actor_admission\.membership_epoch = membership\.epoch/u);
+  assert.match(f.queries[1].sql, /admission\.membership_epoch = membership\.epoch/u);
   assert.deepEqual(f.queries[1].parameters, [teamID, vaultID]);
 });
 
 test("a non-manager without the current wrapper cannot enumerate Team key devices", async () => {
   const f = fixture((sql) => sql.includes("SELECT membership.role")
-    ? { rows: [{ role: "editor", key_approved_at: new Date(), actor_has_wrapper: false }] }
+    ? { rows: [{ role: "editor", actor_key_authorized: true, actor_has_wrapper: false }] }
     : { rows: [] });
 
   await assert.rejects(
@@ -637,7 +642,7 @@ test("an active Viewer with a current wrapper may provision another eligible dev
     if (reservation) return reservation;
     if (sql.includes("FOR UPDATE OF membership, team, vault, device")) {
       return { rows: [{
-        membership_id: membershipID, role: "viewer", epoch: 1, key_approved_at: new Date(),
+        membership_id: membershipID, role: "viewer", epoch: 1, device_key_authorized: true,
         revision: 2, key_generation: 1, rotation_required: false,
       }] };
     }
@@ -674,7 +679,7 @@ test("wrapper provisioning fails closed when the actor does not hold the current
     if (reservation) return reservation;
     if (sql.includes("FOR UPDATE OF membership, team, vault, device")) {
       return { rows: [{
-        membership_id: membershipID, role: "owner", epoch: 1, key_approved_at: new Date(),
+        membership_id: membershipID, role: "owner", epoch: 1, device_key_authorized: true,
         revision: 2, key_generation: 1, rotation_required: false,
       }] };
     }
@@ -699,7 +704,7 @@ test("initial shared ciphertext and the complete device wrapper set commit atomi
     if (reservation) return reservation;
     if (sql.includes("FOR UPDATE OF membership, team, vault, device")) {
       return { rows: [{
-        membership_id: membershipID, role: "owner", epoch: 1, key_approved_at: new Date(),
+        membership_id: membershipID, role: "owner", epoch: 1, device_key_authorized: true,
         revision: 0, key_generation: 1, rotation_required: false,
       }] };
     }
@@ -729,7 +734,7 @@ test("initial shared Vault write rejects a partial wrapper set before ciphertext
     if (reservation) return reservation;
     if (sql.includes("FOR UPDATE OF membership, team, vault, device")) {
       return { rows: [{
-        membership_id: membershipID, role: "owner", epoch: 1, key_approved_at: new Date(),
+        membership_id: membershipID, role: "owner", epoch: 1, device_key_authorized: true,
         revision: 0, key_generation: 1, rotation_required: false,
       }] };
     }
@@ -760,7 +765,7 @@ test("a wrapper replayed under another authorization context is rejected", async
     if (reservation) return reservation;
     if (sql.includes("FOR UPDATE OF membership, team, vault, device")) {
       return { rows: [{
-        membership_id: membershipID, role: "owner", epoch: 1, key_approved_at: new Date(),
+        membership_id: membershipID, role: "owner", epoch: 1, device_key_authorized: true,
         revision: 0, key_generation: 1, rotation_required: false,
       }] };
     }
@@ -788,7 +793,7 @@ test("rotation advances the generation and completes pending work in one transac
     if (reservation) return reservation;
     if (sql.includes("FOR UPDATE OF membership, team, vault, device")) {
       return { rows: [{
-        membership_id: membershipID, role: "admin", epoch: 1, key_approved_at: new Date(),
+        membership_id: membershipID, role: "admin", epoch: 1, device_key_authorized: true,
         revision: 4, key_generation: 2, rotation_required: true,
       }] };
     }
@@ -820,7 +825,7 @@ test("Viewer writes and unapproved-device reads fail before ciphertext access", 
     if (reservation) return reservation;
     if (sql.includes("FOR UPDATE OF membership, team, vault, device")) {
       return { rows: [{
-        membership_id: membershipID, role: "viewer", epoch: 1, key_approved_at: new Date(),
+        membership_id: membershipID, role: "viewer", epoch: 1, device_key_authorized: true,
         revision: 1, key_generation: 1, rotation_required: false,
       }] };
     }
@@ -836,7 +841,7 @@ test("Viewer writes and unapproved-device reads fail before ciphertext access", 
   }), /team_access_denied/);
 
   const read = fixture((sql) => sql.includes("LEFT JOIN shared_vault_key_wrappers")
-    ? { rows: [{ id: vaultID, key_approved_at: null }] }
+    ? { rows: [{ id: vaultID, device_key_authorized: false }] }
     : { rows: [] });
   await assert.rejects(
     read.store.getSharedVault(teamID, vaultID, actorUserID, deviceID),
@@ -912,6 +917,31 @@ test("an unapproved session device cannot revoke another account device", async 
   assert.equal(f.queries.some(({ sql }) => sql.includes("UPDATE devices SET revoked_at")), false);
   assert.equal(f.queries.at(-2).sql, "ROLLBACK");
   assert.equal(f.queries.at(-1).sql, "RELEASE");
+});
+
+test("revoking a scoped-admission device with a Vault wrapper schedules rotation", async () => {
+  const targetDeviceID = "aef6452c-1ad8-48bb-b4b5-ea9c207b707b";
+  const f = fixture((sql) => {
+    if (sql.includes("SELECT id FROM devices") && sql.includes("key_approved_at IS NOT NULL")) {
+      return { rows: [{ id: deviceID }] };
+    }
+    if (sql.includes("UPDATE devices SET revoked_at")) {
+      return { rows: [{ id: targetDeviceID, key_approved_at: null }], rowCount: 1 };
+    }
+    if (sql.includes("SELECT 1 FROM shared_vault_key_wrappers WHERE device_id")) {
+      return { rows: [{ "?column?": 1 }] };
+    }
+    return { rows: [], rowCount: 1 };
+  });
+
+  assert.equal(await f.store.revokeDevice(actorUserID, targetDeviceID, deviceID), true);
+  const wrapperProof = f.queries.find(({ sql }) => sql.includes(
+    "SELECT 1 FROM shared_vault_key_wrappers WHERE device_id",
+  ));
+  assert.deepEqual(wrapperProof.parameters, [targetDeviceID]);
+  assert.ok(f.queries.some(({ sql }) => sql.includes("rotation_required = true")));
+  assert.ok(f.queries.some(({ sql }) => sql.includes("INSERT INTO shared_vault_rotation_tasks")));
+  assert.equal(f.queries.at(-2).sql, "COMMIT");
 });
 
 test("legacy accounts can atomically bootstrap only their first approved Team device", async () => {

--- a/cloud/tests/team-postgres-store.test.mjs
+++ b/cloud/tests/team-postgres-store.test.mjs
@@ -452,6 +452,10 @@ test("invitation acceptance locks one token and advances a revoked membership ep
         username: "member", display_name: "Member",
       }] };
     }
+    if (sql.includes("SELECT id, key_approved_at FROM devices")) {
+      return { rows: [{ id: deviceID, key_approved_at: null }] };
+    }
+    if (sql.includes("UPDATE devices SET key_approved_at = now()")) return { rows: [], rowCount: 1 };
     if (sql.includes("ORDER BY epoch DESC")) return { rows: [{ id: "old", epoch: 2, revoked_at: new Date() }] };
     if (sql.includes("INSERT INTO team_memberships")) return { rows: [acceptedMembership] };
     if (sql.includes("UPDATE team_invitations SET accepted_at")) return { rows: [{ id: "invite-1" }] };
@@ -460,6 +464,7 @@ test("invitation acceptance locks one token and advances a revoked membership ep
 
   const result = await f.store.acceptTeamInvitation({
     actorUserID,
+    actorDeviceID: deviceID,
     actorEmail: "member@example.com",
     invitationID: null,
     tokenHash: "c".repeat(64),
@@ -471,6 +476,13 @@ test("invitation acceptance locks one token and advances a revoked membership ep
   assert.equal(membershipInsert.parameters[3], 3);
   const invitationLock = f.queries.find(({ sql }) => sql.includes("FOR UPDATE OF invitation, team"));
   assert.deepEqual(invitationLock.parameters, ["c".repeat(64), null, "member@example.com", actorUserID]);
+  const deviceLock = f.queries.find(({ sql }) => sql.includes("SELECT id, key_approved_at FROM devices"));
+  assert.deepEqual(deviceLock.parameters, [deviceID, actorUserID]);
+  assert.match(deviceLock.sql, /public_key_algorithm = 'p256-ecdh-v1'/u);
+  assert.ok(f.queries.some(({ sql }) => sql.includes("UPDATE devices SET key_approved_at = now()")));
+  const audit = f.queries.find(({ sql }) => sql.includes("INSERT INTO team_audit_events"));
+  assert.match(audit.parameters.at(-1), /"acceptingDeviceID":"33cc880e-084a-4d9a-b1ea-f99d2ff86032"/u);
+  assert.match(audit.parameters.at(-1), /"deviceAutoApproved":true/u);
   assert.ok(f.queries.some(({ sql }) => sql.includes("DELETE FROM team_invitation_link_secrets")));
   assert.equal(f.queries.at(-2).sql, "COMMIT");
 });
@@ -495,6 +507,9 @@ test("username invitation acceptance is bound to the authenticated target user I
         username: "member", display_name: "Member",
       }] };
     }
+    if (sql.includes("SELECT id, key_approved_at FROM devices")) {
+      return { rows: [{ id: deviceID, key_approved_at: new Date() }] };
+    }
     if (sql.includes("ORDER BY epoch DESC")) return { rows: [] };
     if (sql.includes("INSERT INTO team_memberships")) return { rows: [acceptedMembership] };
     if (sql.includes("UPDATE team_invitations SET accepted_at")) return { rows: [{ id: invitationID }] };
@@ -503,6 +518,7 @@ test("username invitation acceptance is bound to the authenticated target user I
 
   await f.store.acceptTeamInvitation({
     actorUserID,
+    actorDeviceID: deviceID,
     actorEmail: "private@example.invalid",
     invitationID,
     tokenHash: null,
@@ -512,6 +528,32 @@ test("username invitation acceptance is bound to the authenticated target user I
   const invitationLock = f.queries.find(({ sql }) => sql.includes("FOR UPDATE OF invitation, team"));
   assert.deepEqual(invitationLock.parameters, [null, invitationID, "private@example.invalid", actorUserID]);
   assert.match(invitationLock.sql, /invitation\.target_user_id = \$4/u);
+  assert.equal(f.queries.some(({ sql }) => sql.includes("UPDATE devices SET key_approved_at = now()")), false);
+});
+
+test("invitation acceptance refuses a session device without a registered Team key", async () => {
+  const f = fixture((sql) => {
+    const reservation = mutationReservation(sql);
+    if (reservation) return reservation;
+    if (sql.includes("FROM team_invitations AS invitation")) {
+      return { rows: [{
+        id: "invite-1", team_id: teamID, invitation_type: "link", role: "viewer",
+        username: "member", display_name: "Member",
+      }] };
+    }
+    return { rows: [], rowCount: 0 };
+  });
+
+  await assert.rejects(f.store.acceptTeamInvitation({
+    actorUserID,
+    actorDeviceID: deviceID,
+    actorEmail: "member@example.com",
+    invitationID: null,
+    tokenHash: "c".repeat(64),
+    idempotencyKey: "request:team-accept-no-key-01",
+  }), /device_approval_required/u);
+  assert.equal(f.queries.some(({ sql }) => sql.includes("INSERT INTO team_memberships")), false);
+  assert.equal(f.queries.at(-2).sql, "ROLLBACK");
 });
 
 test("membership revocation immediately freezes every active shared Vault", async () => {
@@ -555,9 +597,11 @@ test("outbox claim uses multi-replica-safe SKIP LOCKED leasing", async () => {
   assert.deepEqual(f.queries[0].parameters, ["claim-owner"]);
 });
 
-test("Team key-device listing binds both the Team and Vault scope", async () => {
+test("Team key-device listing binds both scope and the actor's current wrapper", async () => {
   const f = fixture((sql) => {
-    if (sql.includes("SELECT membership.role")) return { rows: [{ role: "owner" }] };
+    if (sql.includes("SELECT membership.role")) {
+      return { rows: [{ role: "viewer", key_approved_at: new Date(), actor_has_wrapper: true }] };
+    }
     if (sql.includes("wrapper.device_id IS NOT NULL AS has_wrapper")) {
       return { rows: [{ membership_id: membershipID, device_id: deviceID, has_wrapper: true }] };
     }
@@ -565,11 +609,88 @@ test("Team key-device listing binds both the Team and Vault scope", async () => 
   });
 
   assert.deepEqual(
-    await f.store.listTeamKeyDevices(teamID, vaultID, actorUserID),
+    await f.store.listTeamKeyDevices(teamID, vaultID, actorUserID, deviceID),
     [{ membership_id: membershipID, device_id: deviceID, has_wrapper: true }],
   );
-  assert.deepEqual(f.queries[0].parameters, [teamID, vaultID, actorUserID]);
+  assert.deepEqual(f.queries[0].parameters, [teamID, vaultID, actorUserID, deviceID]);
+  assert.match(f.queries[0].sql, /actor_wrapper\.device_id IS NOT NULL AS actor_has_wrapper/u);
   assert.deepEqual(f.queries[1].parameters, [teamID, vaultID]);
+});
+
+test("a non-manager without the current wrapper cannot enumerate Team key devices", async () => {
+  const f = fixture((sql) => sql.includes("SELECT membership.role")
+    ? { rows: [{ role: "editor", key_approved_at: new Date(), actor_has_wrapper: false }] }
+    : { rows: [] });
+
+  await assert.rejects(
+    f.store.listTeamKeyDevices(teamID, vaultID, actorUserID, deviceID),
+    /team_vault_key_unavailable/u,
+  );
+  assert.equal(f.queries.length, 1);
+});
+
+test("an active Viewer with a current wrapper may provision another eligible device", async () => {
+  const recipientDeviceID = "aef6452c-1ad8-48bb-b4b5-ea9c207b707b";
+  const wrapper = teamWrapper({ deviceID: recipientDeviceID });
+  const f = fixture((sql) => {
+    const reservation = mutationReservation(sql);
+    if (reservation) return reservation;
+    if (sql.includes("FOR UPDATE OF membership, team, vault, device")) {
+      return { rows: [{
+        membership_id: membershipID, role: "viewer", epoch: 1, key_approved_at: new Date(),
+        revision: 2, key_generation: 1, rotation_required: false,
+      }] };
+    }
+    if (sql.includes("SELECT 1 FROM shared_vault_key_wrappers")) {
+      return { rows: [{ proof: true }] };
+    }
+    if (sql.includes("ORDER BY membership.id, device.id") && sql.includes("FOR UPDATE")) {
+      return { rows: [{
+        membership_id: membershipID, membership_epoch: 1, device_id: recipientDeviceID,
+      }] };
+    }
+    if (sql.includes("ON CONFLICT (vault_id, key_generation, device_id) DO NOTHING")) {
+      return { rows: [{ device_id: recipientDeviceID }], rowCount: 1 };
+    }
+    return { rows: [], rowCount: 1 };
+  });
+
+  assert.deepEqual(await f.store.grantSharedVaultWrapper({
+    actorUserID,
+    actorDeviceID: deviceID,
+    teamID,
+    vaultID,
+    wrapper,
+    keyGeneration: 1,
+    idempotencyKey: "request:viewer-wrapper-grant-01",
+  }), { granted: true, keyGeneration: 1, deviceID: recipientDeviceID });
+  assert.ok(f.queries.some(({ sql }) => sql.includes("INSERT INTO shared_vault_key_wrappers")));
+  assert.ok(f.queries.some(({ parameters }) => parameters.includes("team.vault_wrapper_granted")));
+});
+
+test("wrapper provisioning fails closed when the actor does not hold the current Vault key", async () => {
+  const f = fixture((sql) => {
+    const reservation = mutationReservation(sql);
+    if (reservation) return reservation;
+    if (sql.includes("FOR UPDATE OF membership, team, vault, device")) {
+      return { rows: [{
+        membership_id: membershipID, role: "owner", epoch: 1, key_approved_at: new Date(),
+        revision: 2, key_generation: 1, rotation_required: false,
+      }] };
+    }
+    return { rows: [], rowCount: 0 };
+  });
+
+  await assert.rejects(f.store.grantSharedVaultWrapper({
+    actorUserID,
+    actorDeviceID: deviceID,
+    teamID,
+    vaultID,
+    wrapper: teamWrapper({ deviceID: "aef6452c-1ad8-48bb-b4b5-ea9c207b707b" }),
+    keyGeneration: 1,
+    idempotencyKey: "request:wrapper-without-key-01",
+  }), /team_vault_key_unavailable/u);
+  assert.equal(f.queries.some(({ sql }) => sql.includes("INSERT INTO shared_vault_key_wrappers")), false);
 });
 
 test("initial shared ciphertext and the complete device wrapper set commit atomically", async () => {

--- a/cloud/tests/team-service.test.mjs
+++ b/cloud/tests/team-service.test.mjs
@@ -180,8 +180,8 @@ class TeamStore {
     return { approved: true, deviceID: input.actorDeviceID, bootstrapped: true };
   }
 
-  async listTeamKeyDevices(team, vault, actor) {
-    this.calls.push(["listTeamKeyDevices", team, vault, actor]);
+  async listTeamKeyDevices(team, vault, actor, device) {
+    this.calls.push(["listTeamKeyDevices", team, vault, actor, device]);
     return [{
       membership_id: membershipID,
       membership_epoch: 1,
@@ -414,6 +414,7 @@ test("invitation acceptance binds email links or a username invitation ID to the
   const stored = store.calls[0][1];
 
   assert.equal(stored.actorUserID, "user-1");
+  assert.equal(stored.actorDeviceID, deviceID);
   assert.equal(stored.actorEmail, "owner@example.com");
   assert.equal(stored.invitationID, null);
   assert.match(stored.tokenHash, /^[0-9a-f]{64}$/);
@@ -428,6 +429,7 @@ test("invitation acceptance binds email links or a username invitation ID to the
   );
   const usernameStored = store.calls[1][1];
   assert.equal(usernameStored.actorUserID, "user-1");
+  assert.equal(usernameStored.actorDeviceID, deviceID);
   assert.equal(usernameStored.invitationID, "471c3424-b6aa-41a0-959f-aeaa1e3ef79d");
   assert.equal(usernameStored.tokenHash, null);
   await assert.rejects(
@@ -528,6 +530,10 @@ test("Team ciphertext service binds session device, generation and wrapper conte
 
   assert.equal(devices.devices[0].publicKey.crv, "P-256");
   assert.equal(devices.devices[0].hasWrapper, true);
+  assert.deepEqual(
+    store.calls.find(([name]) => name === "listTeamKeyDevices").slice(1),
+    [teamID, vaultID, session.user_id, deviceID],
+  );
   assert.equal(vault.wrapper.membershipEpoch, 1);
   for (const call of store.calls.filter(([name]) => [
     "approveDeviceKey", "putSharedVault", "grantSharedVaultWrapper",

--- a/docs/cloud-v0.32-team-threat-model.md
+++ b/docs/cloud-v0.32-team-threat-model.md
@@ -113,10 +113,11 @@ or history, and all ordinary Team joins exclude archived Teams immediately.
 5. Cancellation and expiry make the token unusable immediately. Re-inviting
    creates a new token and does not revive an old one.
 6. The same acceptance transaction locks the authenticated session device,
-   requires its registered P-256 public key and approves only that device while
-   creating membership. It never approves another account device and does not
-   fabricate a Vault key. Each shared Vault remains unavailable until an
-   authorized key-holding client publishes a context-bound wrapper.
+   requires its registered P-256 public key and records an admission bound to
+   the new membership ID and epoch. It leaves account-wide device approval
+   unchanged, cannot authorize the device in another Team or membership epoch,
+   and does not fabricate a Vault key. Each shared Vault remains unavailable
+   until an authorized key-holding client publishes a context-bound wrapper.
 
 Invitation endpoints use uniform public errors and rate limits. Manager and
 pending-account lists expose only public handles and bounded Team metadata.
@@ -159,20 +160,25 @@ approval from an existing authorized account device. A legacy account with zero
 approved devices may bootstrap only its current registered key after password
 re-verification, user/IP rate limiting and an account-row lock that permits
 exactly one winner. Invitation acceptance is the narrow admission exception:
-the one authenticated accepting session device must already have a registered
-P-256 public key, and its key approval commits atomically with the new
-membership. Password login alone still cannot approve a device or grant old
-shared-Vault keys. Device revocation invalidates its sessions and excludes it
-from all later wrapper sets.
+the accepting session device must already have a registered P-256 public key,
+and a row keyed by membership ID, membership epoch and device ID commits
+atomically with the membership. It does not set `devices.key_approved_at`.
+Consequently, possession of an arbitrary Team link cannot turn a stolen session
+into an account-wide trusted device or authorize another Team. Password login
+alone still cannot approve a device or grant old shared-Vault keys. Device
+revocation invalidates its sessions; a scoped device that held any wrapper also
+forces rotation and is excluded from all later wrapper sets.
 
 After a Vault is initialized, wrapper provisioning is capability-gated rather
-than manager-presence-gated. Any active member's approved current session
+than manager-presence-gated. Any active member's authorized current session
 device may list eligible public keys and publish a wrapper only when the server
 also finds its own wrapper for the exact Vault, key generation, membership and
-membership epoch. The target must be an active approved Team device and the API
-recomputes the target context hash. This permits background provisioning by an
-online Editor or Viewer without giving either role ciphertext-write, membership
-or rotation authority. A client without the current key fails closed.
+membership epoch. A device is authorized here only by account-wide approval or
+by an admission matching this exact membership epoch. The target must satisfy
+the same rule and the API recomputes its context hash. This permits background
+provisioning by an online Editor or Viewer without giving either role
+ciphertext-write, membership or rotation authority. A client without the
+current key fails closed.
 
 ## Removal and rotation
 

--- a/docs/cloud-v0.32-team-threat-model.md
+++ b/docs/cloud-v0.32-team-threat-model.md
@@ -76,6 +76,7 @@ Cloud 0.32 uses four roles. A custom-role system is out of scope for 0.32.
 | Remove/demote Admin | Yes | No | No | No |
 | Assign/remove Owner | Yes | No | No | No |
 | Transfer ownership/delete Team | Yes | No | No | No |
+| Provision a missing current-generation wrapper while holding that key | Yes | Yes | Yes | Yes |
 | Start/complete key rotation | Yes | Yes | No | No |
 
 An actor cannot change their own role, remove themselves as the last Owner or
@@ -111,9 +112,11 @@ or history, and all ordinary Team joins exclude archived Teams immediately.
    requests cannot accept it twice.
 5. Cancellation and expiry make the token unusable immediately. Re-inviting
    creates a new token and does not revive an old one.
-6. Acceptance creates membership but does not fabricate a Vault key. Each
-   shared Vault remains unavailable until an authorized client publishes a
-   wrapper for an authorized device.
+6. The same acceptance transaction locks the authenticated session device,
+   requires its registered P-256 public key and approves only that device while
+   creating membership. It never approves another account device and does not
+   fabricate a Vault key. Each shared Vault remains unavailable until an
+   authorized key-holding client publishes a context-bound wrapper.
 
 Invitation endpoints use uniform public errors and rate limits. Manager and
 pending-account lists expose only public handles and bounded Team metadata.
@@ -151,13 +154,25 @@ the ciphertext, public metadata and wrappers but never the Vault key or ECDH
 shared secret. A wrapper for one Team/Vault/generation/device must fail when
 replayed in any other context.
 
-A newly registered device requires approval from an existing authorized
-device. A legacy account with zero approved devices may bootstrap only its
-current registered key after password re-verification, user/IP rate limiting
-and an account-row lock that permits exactly one winner. Once any device is
-approved, password login and bootstrap cannot approve another device or grant
-old shared-Vault keys. Device revocation invalidates its sessions and excludes
-it from all later wrapper sets.
+Outside Team invitation acceptance, a newly registered device requires
+approval from an existing authorized account device. A legacy account with zero
+approved devices may bootstrap only its current registered key after password
+re-verification, user/IP rate limiting and an account-row lock that permits
+exactly one winner. Invitation acceptance is the narrow admission exception:
+the one authenticated accepting session device must already have a registered
+P-256 public key, and its key approval commits atomically with the new
+membership. Password login alone still cannot approve a device or grant old
+shared-Vault keys. Device revocation invalidates its sessions and excludes it
+from all later wrapper sets.
+
+After a Vault is initialized, wrapper provisioning is capability-gated rather
+than manager-presence-gated. Any active member's approved current session
+device may list eligible public keys and publish a wrapper only when the server
+also finds its own wrapper for the exact Vault, key generation, membership and
+membership epoch. The target must be an active approved Team device and the API
+recomputes the target context hash. This permits background provisioning by an
+online Editor or Viewer without giving either role ciphertext-write, membership
+or rotation authority. A client without the current key fails closed.
 
 ## Removal and rotation
 


### PR DESCRIPTION
## Summary

- require the authenticated invitation-accepting session device to have a registered P-256 key;
- atomically record that device in `team_membership_device_admissions`, keyed to the newly created membership ID and epoch;
- leave account-wide `devices.key_approved_at` unchanged, so an arbitrary bearer Team link cannot promote a stolen session into a globally trusted device;
- treat either account-wide approval or an exact membership-epoch admission as Team-key authorization;
- let any active Team member provision a missing current-generation wrapper only when the server proves that exact actor device already owns a wrapper for the same Team/Vault/generation/membership epoch;
- keep initialization, rotation, membership management, account-device management, and Viewer ciphertext writes under their existing restrictions;
- make repeated/concurrent wrapper publication idempotent with `ON CONFLICT DO NOTHING`;
- force rotation when a revoked scoped-admission device has held a Vault wrapper.

## Security boundaries

Invitation possession still grants membership only through the existing account-bound or single-use-token checks. Acceptance locks the current session device, verifies its registered P-256 public key, and creates a narrowly scoped admission in the same transaction as the membership. The admission cannot authorize another Team or a later membership epoch and grants no account-device-management capability.

Wrapper provisioning remains fail-closed. The actor session must be active and Team-key-authorized in the exact membership epoch, and it must already hold the current Vault wrapper. The target must be active and authorized in its own exact membership epoch, and the server recomputes the wrapper context hash. The server never receives the plaintext Vault key.

## Verification

Exact head `625c70cbf362dc88320f929f980b5da386106d49`:

- [CI #558](https://github.com/PastFly/Selective-Remote/actions/runs/34404150775) — passed, including PostgreSQL 16 migrations/unit/integration coverage, Swift tests, browser/Cloud tests, and release build;
- [Test DMG #234](https://github.com/PastFly/Selective-Remote/actions/runs/34404150906) — passed, including ARM64 ad-hoc signed DMG build and artifact upload.

## Stack

This PR is intentionally stacked on #75 exact head `b2a60d08f90ffae44876de43c033e8a66c7bf7c2`. It does not change `main`.