### PR TITLE
Automate browser Team Vault sync and wrapper delivery

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -21,7 +21,11 @@ a Team- and membership-epoch-scoped admission for only the authenticated
 session's registered P-256 device; it does not grant account-wide device trust.
 Any active member device that already holds the current Vault wrapper can then
 provision missing current-generation wrappers for other active authorized Team
-devices. Owners can rename Teams,
+devices. Once a browser opens and unlocks a Team Vault, a bounded 15-second
+background cycle pulls or conditionally uploads causal revisions and
+idempotently provisions missing wrappers. Explicit conflicts and required
+rotation still stop writes; “sync now” and wrapper delivery remain recovery
+actions. Owners can rename Teams,
 atomically transfer ownership after password re-authentication, and archive a
 Team behind exact-name confirmation. Archiving immediately closes Team access,
 retires pending invitations/outbox work and rotation tasks, soft-archives its

--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -8,6 +8,7 @@ import {
 import {
   createIndexedDBTeamVaultRepository,
   createTeamVaultController,
+  provisionTeamVaultWrappers,
   rotateTeamVault,
   synchronizeTeamVault,
 } from "./team-vault-sync.js";
@@ -382,6 +383,9 @@ export function initializeTeamWorkspace({
   client,
   confirmValue = (message) => globalThis.confirm(message),
   initialInvitationToken = null,
+  setIntervalValue = globalThis.setInterval,
+  clearIntervalValue = globalThis.clearInterval,
+  backgroundSyncIntervalMilliseconds = 15_000,
 } = {}) {
   const section = documentValue.querySelector("#team-vault");
   if (!section || !client) return null;
@@ -444,6 +448,8 @@ export function initializeTeamWorkspace({
   let controller = null;
   let activeConflicts = null;
   let activeView = "teams";
+  let backgroundSyncTimer = null;
+  let vaultOperation = null;
 
   if (initialInvitationToken) acceptInvitationForm.elements.token.value = initialInvitationToken;
 
@@ -532,7 +538,7 @@ export function initializeTeamWorkspace({
           await controller.delete(record.id);
           clearConflicts();
           renderRecords();
-          setText(workspaceStatus, "Удаление зашифровано локально. Выполните синхронизацию.");
+          setText(workspaceStatus, "Удаление зашифровано локально и будет синхронизировано автоматически.");
         } catch {
           setText(workspaceStatus, "Не удалось сохранить удаление.");
           remove.disabled = !canEdit();
@@ -794,7 +800,145 @@ export function initializeTeamWorkspace({
     vaultOpen.disabled = vaults.length === 0;
   }
 
+  function stopBackgroundSync() {
+    if (backgroundSyncTimer === null) return;
+    clearIntervalValue(backgroundSyncTimer);
+    backgroundSyncTimer = null;
+  }
+
+  function startBackgroundSync() {
+    stopBackgroundSync();
+    if (!controller || selectedVault?.rotationRequired
+      || !Number.isFinite(backgroundSyncIntervalMilliseconds)
+      || backgroundSyncIntervalMilliseconds <= 0) {
+      return;
+    }
+    backgroundSyncTimer = setIntervalValue(() => {
+      void runBackgroundTeamVaultSync();
+    }, backgroundSyncIntervalMilliseconds);
+    backgroundSyncTimer?.unref?.();
+  }
+
+  async function exclusiveVaultOperation(operation) {
+    if (vaultOperation) return null;
+    const pending = Promise.resolve().then(operation);
+    vaultOperation = pending;
+    try {
+      return await pending;
+    } finally {
+      if (vaultOperation === pending) vaultOperation = null;
+    }
+  }
+
+  async function synchronizeAndProvision(
+    activeController = controller,
+    activeTeam = selectedTeam,
+    activeVault = selectedVault,
+  ) {
+    if (!activeController || !activeTeam || !activeVault) return null;
+    return exclusiveVaultOperation(async () => {
+      const result = await synchronizeTeamVault({
+        client,
+        controller: activeController,
+        role: activeTeam.role,
+      });
+      if (controller !== activeController || selectedTeam?.id !== activeTeam.id
+        || selectedVault?.id !== activeVault.id) {
+        return null;
+      }
+      let wrapperProvisioning = null;
+      let wrapperProvisioningFailed = false;
+      if (!["conflict", "remote_changed"].includes(result.status) && !activeVault.rotationRequired) {
+        try {
+          wrapperProvisioning = await provisionTeamVaultWrappers({
+            client,
+            controller: activeController,
+          });
+        } catch {
+          wrapperProvisioningFailed = true;
+        }
+      }
+      if (!["conflict", "remote_changed"].includes(result.status)) {
+        const state = await activeController.syncState();
+        selectedVault = {
+          ...selectedVault,
+          revision: result.revision ?? selectedVault.revision,
+          keyGeneration: state.keyGeneration,
+        };
+        vaults = vaults.map((value) => value.id === selectedVault.id ? selectedVault : value);
+        populateVaults();
+        vaultSelect.value = selectedVault.id;
+      }
+      return { result, wrapperProvisioning, wrapperProvisioningFailed };
+    });
+  }
+
+  function applySynchronizationOutcome(outcome, { background = false } = {}) {
+    if (!outcome) return;
+    const { result, wrapperProvisioning, wrapperProvisioningFailed } = outcome;
+    if (result.status === "conflict") {
+      renderConflicts(result);
+    } else if (result.status === "remote_changed") {
+      clearConflicts();
+      setWorkspaceControls(true);
+    } else {
+      clearConflicts();
+      renderRecords();
+    }
+    if (background && result.status === "up_to_date"
+      && !wrapperProvisioningFailed && (wrapperProvisioning?.granted ?? 0) === 0) {
+      return;
+    }
+    const messages = {
+      initialized: `Shared Vault инициализирован · ревизия ${result.revision}.`,
+      uploaded: `Зашифрованная Team-ревизия ${result.revision} загружена.`,
+      uploaded_with_new_local_changes: `Ревизия ${result.revision} загружена; новые локальные изменения останутся для следующего цикла.`,
+      downloaded: `Team-ревизия ${result.revision} загружена и объединена локально.`,
+      up_to_date: `Shared Vault синхронизирован · ревизия ${result.revision}.`,
+      remote_changed: `Team Vault изменился до ревизии ${result.remoteRevision}. Следующий цикл повторит синхронизацию.`,
+      conflict: `Обнаружено конфликтов: ${result.conflicts.length}. Выберите версии явно.`,
+    };
+    let status = messages[result.status] ?? "Синхронизация завершена.";
+    if (wrapperProvisioningFailed) {
+      status += " Автоматическая выдача wrappers не подтверждена и будет безопасно повторена.";
+    } else if ((wrapperProvisioning?.granted ?? 0) > 0) {
+      status += ` Автоматически выдано недостающих wrappers: ${wrapperProvisioning.granted}.`;
+    }
+    setText(workspaceStatus, status);
+    if (!selectedVault?.rotationRequired
+      && !["conflict", "remote_changed"].includes(result.status)) {
+      grantWrappersButton.hidden = false;
+      grantWrappersButton.disabled = false;
+    }
+  }
+
+  async function runBackgroundTeamVaultSync() {
+    if (documentValue.visibilityState === "hidden" || activeConflicts || vaultOperation
+      || !controller || !selectedTeam || !selectedVault || selectedVault.rotationRequired) {
+      return;
+    }
+    try {
+      applySynchronizationOutcome(await synchronizeAndProvision(), { background: true });
+    } catch (error) {
+      const code = String(error?.message ?? "");
+      if (code === "team_vault_rotation_required") {
+        selectedVault = { ...selectedVault, rotationRequired: true };
+        vaults = vaults.map((value) => value.id === selectedVault.id ? selectedVault : value);
+        populateVaults();
+        vaultSelect.value = selectedVault.id;
+        rotateButton.hidden = !canManage();
+        rotateButton.disabled = rotateButton.hidden;
+        grantWrappersButton.hidden = true;
+        stopBackgroundSync();
+        setText(workspaceStatus, "Фоновая запись заморожена до безопасной ротации ключа.");
+      } else if (code === "team_vault_key_unavailable") {
+        setText(workspaceStatus, "Ожидаем, пока устройство с текущим Team Vault key автоматически выдаст wrapper этому браузеру.");
+      }
+    }
+  }
+
   function lockCurrentVault() {
+    stopBackgroundSync();
     controller?.lock();
     controller = null;
     selectedVault = null;
@@ -841,22 +985,16 @@ export function initializeTeamWorkspace({
     workspace.hidden = activeView === "teams";
     rotateButton.hidden = !vault.rotationRequired || !canManage();
     rotateButton.disabled = !vault.rotationRequired || !canManage();
-    grantWrappersButton.hidden = vault.rotationRequired || !canManage();
+    grantWrappersButton.hidden = vault.rotationRequired;
     grantWrappersButton.disabled = true;
     workspaceTitle.textContent = `${selectedTeam.name} / ${vault.name}`;
     setText(workspaceStatus, "Загружаем зашифрованную Team-ревизию…");
     syncButton.disabled = true;
     try {
-      const result = await synchronizeTeamVault({ client, controller, role: selectedTeam.role });
-      renderRecords();
-      setWorkspaceControls(false);
+      const outcome = await synchronizeAndProvision();
+      applySynchronizationOutcome(outcome);
       syncButton.disabled = false;
       grantWrappersButton.disabled = grantWrappersButton.hidden;
-      setText(workspaceStatus, {
-        initialized: `Shared Vault создан и зашифрован для всех одобренных устройств · ревизия ${result.revision}.`,
-        downloaded: `Team-ревизия ${result.revision} расшифрована локально.`,
-        up_to_date: `Shared Vault синхронизирован · ревизия ${result.revision}.`,
-      }[result.status] ?? "Shared Vault открыт.");
     } catch (error) {
       const code = String(error?.message ?? "");
       setWorkspaceControls(true);
@@ -866,8 +1004,10 @@ export function initializeTeamWorkspace({
       setText(workspaceStatus, code === "team_vault_rotation_required"
         ? "Запись заморожена: после отзыва участника или устройства требуется полная ротация ключа."
         : code === "team_vault_key_unavailable"
-          ? "Для этого устройства нет wrapper ключа. Требуется одобрение существующим устройством."
+          ? "Для этого устройства пока нет wrapper ключа. Ожидаем автоматическую выдачу от любого активного участника с текущим ключом."
           : "Shared Vault не открыт; локальные данные не изменены.");
+    } finally {
+      startBackgroundSync();
     }
   }
 
@@ -1121,8 +1261,9 @@ export function initializeTeamWorkspace({
   devicesRefresh.addEventListener("click", () => loadDevices().catch(() => setText(message, "Не удалось обновить устройства.")));
   vaultOpen.addEventListener("click", () => openSelectedVault());
   rotateButton.addEventListener("click", async () => {
-    if (!controller || !selectedVault || !canManage()) return;
-    if (!confirmValue("Зашифровать полную текущую Team-ревизию новым ключом и выдать wrappers всем актуальным одобренным устройствам?")) return;
+    if (!controller || !selectedVault || !canManage() || vaultOperation) return;
+    if (!confirmValue("Зашифровать полную текущую Team-ревизию новым ключом и выдать wrappers всем актуальным авторизованным устройствам?")) return;
+    stopBackgroundSync();
     rotateButton.disabled = true;
     syncButton.disabled = true;
     lockButton.disabled = true;
@@ -1141,7 +1282,7 @@ export function initializeTeamWorkspace({
         populateVaults();
         vaultSelect.value = selectedVault.id;
         rotateButton.hidden = true;
-        grantWrappersButton.hidden = !canManage();
+        grantWrappersButton.hidden = false;
         grantWrappersButton.disabled = grantWrappersButton.hidden;
         clearConflicts();
         renderRecords();
@@ -1155,30 +1296,25 @@ export function initializeTeamWorkspace({
       syncButton.disabled = !controller || !rotateButton.hidden;
       rotateButton.disabled = rotateButton.hidden || !canManage() || Boolean(activeConflicts);
       grantWrappersButton.disabled = grantWrappersButton.hidden || Boolean(activeConflicts);
+      startBackgroundSync();
     }
   });
   grantWrappersButton.addEventListener("click", async () => {
-    if (!controller || !selectedVault || !canManage() || selectedVault.rotationRequired) return;
+    if (!controller || !selectedVault || selectedVault.rotationRequired) return;
     grantWrappersButton.disabled = true;
     try {
-      const keyDevices = await client.listTeamKeyDevices(controller.scope);
-      const missing = keyDevices.devices.filter((device) => !device.hasWrapper);
-      const state = await controller.syncState();
-      for (const recipient of missing) {
-        const wrapper = await controller.prepareWrapper(recipient);
-        await client.grantTeamVaultWrapper(
-          controller.scope,
-          { keyGeneration: state.keyGeneration, wrapper },
-          `web:team:vault:grant:${globalThis.crypto.randomUUID()}`,
-        );
-      }
-      setText(workspaceStatus, missing.length === 0
-        ? "Все актуальные одобренные устройства уже имеют wrapper этой генерации."
-        : `Выдано недостающих wrappers: ${missing.length}. Vault plaintext не покидал браузер.`);
+      const result = await exclusiveVaultOperation(() => provisionTeamVaultWrappers({
+        client,
+        controller,
+      }));
+      if (!result) return;
+      setText(workspaceStatus, result.granted === 0
+        ? "Все актуальные авторизованные устройства уже имеют wrapper этой генерации."
+        : `Автоматически выдано недостающих wrappers: ${result.granted}. Vault plaintext не покидал браузер.`);
     } catch {
-      setText(workspaceStatus, "Не все wrappers подтверждены. Обновите состояние и безопасно повторите операцию.");
+      setText(workspaceStatus, "Не все wrappers подтверждены. Автоматический цикл безопасно повторит выдачу.");
     } finally {
-      grantWrappersButton.disabled = !controller || selectedVault?.rotationRequired || !canManage();
+      grantWrappersButton.disabled = !controller || selectedVault?.rotationRequired;
     }
   });
   recordType.addEventListener("change", updateRecordLabels);
@@ -1200,7 +1336,7 @@ export function initializeTeamWorkspace({
       clearConflicts();
       rotateButton.disabled = !selectedVault?.rotationRequired || !canManage();
       renderRecords();
-      setText(workspaceStatus, "Изменение зашифровано локально. Выполните синхронизацию.");
+      setText(workspaceStatus, "Изменение зашифровано локально и будет синхронизировано автоматически.");
     } catch {
       setText(workspaceStatus, "Запись не сохранена. Проверьте поля и роль.");
     } finally {
@@ -1211,32 +1347,19 @@ export function initializeTeamWorkspace({
   syncButton.addEventListener("click", async () => {
     syncButton.disabled = true;
     try {
-      const result = await synchronizeTeamVault({ client, controller, role: selectedTeam.role });
-      if (result.status === "conflict") renderConflicts(result);
-      else {
-        clearConflicts();
-        renderRecords();
-      }
-      const messages = {
-        initialized: `Shared Vault инициализирован · ревизия ${result.revision}.`,
-        uploaded: `Зашифрованная Team-ревизия ${result.revision} загружена.`,
-        uploaded_with_new_local_changes: `Ревизия ${result.revision} загружена; остались новые локальные изменения.`,
-        downloaded: `Team-ревизия ${result.revision} загружена и объединена локально.`,
-        up_to_date: `Shared Vault синхронизирован · ревизия ${result.revision}.`,
-        remote_changed: `Team Vault изменился до ревизии ${result.remoteRevision}. Повторите синхронизацию.`,
-        conflict: `Обнаружено конфликтов: ${result.conflicts.length}. Выберите версии явно.`,
-      };
-      setText(workspaceStatus, messages[result.status] ?? "Синхронизация завершена.");
+      applySynchronizationOutcome(await synchronizeAndProvision());
     } catch (error) {
       setText(workspaceStatus, String(error?.message ?? "") === "team_vault_rotation_required"
         ? "Синхронизация заморожена до безопасной ротации ключа."
         : "Синхронизация не выполнена; локальная зашифрованная копия сохранена.");
     } finally {
       syncButton.disabled = !controller;
+      startBackgroundSync();
     }
   });
 
   lockButton.addEventListener("click", () => {
+    stopBackgroundSync();
     controller?.lock();
     records.replaceChildren();
     clearConflicts();
@@ -1265,7 +1388,7 @@ export function initializeTeamWorkspace({
       renderRecords();
       setText(workspaceStatus, selectedVault?.rotationRequired
         ? "Конфликты разрешены локально. Повторите безопасную ротацию."
-        : "Конфликты разрешены локально. Синхронизируйте условную запись.");
+        : "Конфликты разрешены локально. Условная запись будет синхронизирована автоматически.");
     } catch {
       clearConflicts();
       setText(workspaceStatus, "Набор конфликтов устарел. Запустите синхронизацию ещё раз.");

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -448,11 +448,12 @@
             <div>
               <h3 id="team-vault-workspace-title">Shared Vault</h3>
               <p id="team-vault-workspace-status" aria-live="polite">Vault заблокирован.</p>
+              <small>После открытия зашифрованные изменения и недостающие wrappers синхронизируются автоматически.</small>
             </div>
             <div class="vault-actions">
               <button type="button" class="danger" id="team-vault-rotate" hidden>Завершить ротацию</button>
-              <button type="button" class="secondary" id="team-vault-grant-wrappers" hidden>Выдать недостающие wrappers</button>
-              <button type="button" id="team-vault-sync">Синхронизировать</button>
+              <button type="button" class="secondary" id="team-vault-grant-wrappers" hidden>Повторить выдачу wrappers</button>
+              <button type="button" id="team-vault-sync">Синхронизировать сейчас</button>
               <button type="button" class="secondary" id="team-vault-lock">Заблокировать</button>
             </div>
           </div>

--- a/cloud/public/team-vault-sync.js
+++ b/cloud/public/team-vault-sync.js
@@ -727,6 +727,38 @@ async function uploadCurrent({ client, controller, scope, baseRevision }) {
   return { status: state.dirty ? "uploaded_with_new_local_changes" : "uploaded", revision: result.revision };
 }
 
+export async function provisionTeamVaultWrappers({ client, controller } = {}) {
+  if (!client?.session()) throw new Error("authentication_required");
+  if (!controller || typeof controller.prepareWrapper !== "function"
+    || typeof controller.syncState !== "function") {
+    throw new Error("invalid_team_vault_controller");
+  }
+  const scope = controller.scope;
+  const state = await controller.syncState();
+  const keyDevices = await client.listTeamKeyDevices(scope);
+  if (!keyDevices || !Array.isArray(keyDevices.devices) || keyDevices.devices.length > 1_024) {
+    throw new Error("invalid_team_key_devices");
+  }
+  const missing = keyDevices.devices.filter((device) => device.hasWrapper === false);
+  let granted = 0;
+  for (const recipient of missing) {
+    const wrapper = await controller.prepareWrapper(recipient);
+    await client.grantTeamVaultWrapper(
+      scope,
+      { keyGeneration: state.keyGeneration, wrapper },
+      `web:team:vault:grant:${globalThis.crypto.randomUUID()}`,
+    );
+    granted += 1;
+  }
+  return {
+    status: missing.length === 0 ? "up_to_date" : "provisioned",
+    keyGeneration: state.keyGeneration,
+    eligible: keyDevices.devices.length,
+    missing: missing.length,
+    granted,
+  };
+}
+
 export async function synchronizeTeamVault({ client, controller, role } = {}) {
   if (!client?.session()) throw new Error("authentication_required");
   if (!controller || typeof controller.status !== "function") throw new Error("invalid_team_vault_controller");

--- a/cloud/tests/public-team-vault-sync.test.mjs
+++ b/cloud/tests/public-team-vault-sync.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import { generateTeamDeviceIdentity } from "../public/team-vault-crypto.js";
 import {
   createTeamVaultController,
+  provisionTeamVaultWrappers,
   rotateTeamVault,
   synchronizeTeamVault,
 } from "../public/team-vault-sync.js";
@@ -51,7 +52,15 @@ function sharedServer(keyDevices) {
   function clientFor(deviceID) {
     return {
       session() { return { id: "99999999-9999-4999-8999-999999999999" }; },
-      async listTeamKeyDevices() { return { scope, devices: currentKeyDevices }; },
+      async listTeamKeyDevices() {
+        return {
+          scope,
+          devices: currentKeyDevices.map((device) => ({
+            ...device,
+            hasWrapper: wrappers.has(device.deviceID),
+          })),
+        };
+      },
       async getTeamVault() {
         return {
           scope,
@@ -84,12 +93,24 @@ function sharedServer(keyDevices) {
         rotationRequired = false;
         return { conflict: false, revision, keyGeneration, rotationCompleted: rotating };
       },
+      async grantTeamVaultWrapper(_scope, next) {
+        if (next.keyGeneration !== keyGeneration) throw new Error("invalid_key_generation");
+        wrappers.set(next.wrapper.deviceID, next.wrapper);
+        return {
+          granted: true,
+          keyGeneration,
+          deviceID: next.wrapper.deviceID,
+        };
+      },
     };
   }
   return {
     clientFor,
     revision: () => revision,
     inspect: () => ({ revision, keyGeneration, rotationRequired, envelope, wrappers: new Map(wrappers) }),
+    addKeyDevice(nextKeyDevice) {
+      currentKeyDevices = [...currentKeyDevices, nextKeyDevice];
+    },
     requireRotation(nextKeyDevices) {
       currentKeyDevices = nextKeyDevices;
       rotationRequired = true;
@@ -119,6 +140,42 @@ test("a Team Vault initializes for every approved device and persists ciphertext
   const stored = JSON.stringify(repository.inspect());
   assert.doesNotMatch(stored, /Operations|secret|"records":/u);
   assert.equal(repository.inspect().syncedLocalRevision, 1);
+});
+
+test("an unlocked member provisions missing wrappers without manager presence", async () => {
+  const a = await device(deviceA, membershipA);
+  const b = await device(deviceB, membershipB);
+  const server = sharedServer([a.keyDevice]);
+  const controllerA = createTeamVaultController({
+    repository: memoryRepository(),
+    identity: a.identity,
+    scope,
+    cryptoValue: webcrypto,
+  });
+  await synchronizeTeamVault({ client: server.clientFor(deviceA), controller: controllerA, role: "owner" });
+  server.addKeyDevice(b.keyDevice);
+
+  assert.deepEqual(
+    await provisionTeamVaultWrappers({ client: server.clientFor(deviceA), controller: controllerA }),
+    { status: "provisioned", keyGeneration: 1, eligible: 2, missing: 1, granted: 1 },
+  );
+  assert.equal(server.inspect().wrappers.has(deviceB), true);
+  assert.deepEqual(
+    await provisionTeamVaultWrappers({ client: server.clientFor(deviceA), controller: controllerA }),
+    { status: "up_to_date", keyGeneration: 1, eligible: 2, missing: 0, granted: 0 },
+  );
+
+  const controllerB = createTeamVaultController({
+    repository: memoryRepository(),
+    identity: b.identity,
+    scope,
+    cryptoValue: webcrypto,
+  });
+  assert.deepEqual(
+    await synchronizeTeamVault({ client: server.clientFor(deviceB), controller: controllerB, role: "viewer" }),
+    { status: "downloaded", revision: 1 },
+  );
+  assert.deepEqual(controllerB.document(), { schemaVersion: 1, records: [], tombstones: [] });
 });
 
 test("an interrupted first upload retries initialization with wrappers for every current device", async () => {

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -143,6 +143,9 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(html, /autocomplete="current-password"/u);
   assert.match(html, /id="team-devices"/u);
   assert.match(html, /id="team-vault-rotate"[^>]*hidden/u);
+  assert.match(html, /недостающие wrappers синхронизируются автоматически/u);
+  assert.match(html, /id="team-vault-grant-wrappers"[^>]*>Повторить выдачу wrappers/u);
+  assert.match(html, /id="team-vault-sync"[^>]*>Синхронизировать сейчас/u);
   assert.match(html, /id="team-vault-record-form"/u);
   assert.match(html, /id="team-vault-conflicts-form"/u);
   assert.match(html, /id="workspace-overview"/u);
@@ -191,6 +194,11 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(application, /synchronizeVault/u);
   assert.match(application, /ensureTeamDeviceIdentity/u);
   assert.match(application, /synchronizeTeamVault/u);
+  assert.match(application, /provisionTeamVaultWrappers/u);
+  assert.match(application, /backgroundSyncIntervalMilliseconds = 15_000/u);
+  assert.match(application, /documentValue\.visibilityState === "hidden"/u);
+  assert.match(application, /runBackgroundTeamVaultSync/u);
+  assert.match(teamSynchronization, /export async function provisionTeamVaultWrappers/u);
   assert.match(application, /rotateTeamVault/u);
   assert.match(application, /teamDevicePublicKeyFingerprint/u);
   assert.match(application, /client\.approveDeviceKey/u);

--- a/docs/cloud-v0.32-team-threat-model.md
+++ b/docs/cloud-v0.32-team-threat-model.md
@@ -180,6 +180,16 @@ provisioning by an online Editor or Viewer without giving either role
 ciphertext-write, membership or rotation authority. A client without the
 current key fails closed.
 
+For an explicitly opened and locally unlocked browser Team Vault, a bounded
+background cycle invokes the same causal synchronize primitive used by the
+manual recovery action. It conditionally uploads dirty ciphertext, merges
+dominant remote revisions, preserves explicit conflicts, stops on required
+rotation, and retries idempotent missing-wrapper publication. It skips work
+while the page is hidden and stops after explicit key lock, Team change or
+logout. The interval grants no new role capability: Viewer writes still fail at
+the client and server, while any role may provision only after current-wrapper
+proof.
+
 ## Removal and rotation
 
 Membership removal is a fail-closed state transition:


### PR DESCRIPTION
## Summary

- add a role-independent browser primitive that lists current Team key devices and idempotently wraps the already-unlocked current Vault key for every missing authorized device;
- run the existing causal Team Vault synchronize primitive on a bounded 15-second cycle while an explicitly opened Vault remains unlocked;
- automatically pull dominant revisions, conditionally upload dirty ciphertext, preserve explicit conflicts, and retry missing-wrapper publication;
- skip hidden-page work and stop the cycle on explicit key lock, Team/Vault change, logout, or required rotation;
- retain “sync now” and “retry wrapper delivery” only as recovery actions;
- prove that a key-holding member can provision a second device which then downloads the Vault as a Viewer, without an Owner/Admin client being present.

## Security boundaries

The browser never sends the Vault key or plaintext. Wrapper publication uses the exact current controller generation and the server-side proof gate introduced in #76. A client without the current wrapper fails closed. Conflicts remain explicit, rotation freezes writes, Viewer write controls remain disabled, and the server continues to enforce role permissions.

## Verification

Exact head `9baa4766dd579f8984a58627509c727b894b1a56`:

- [CI #559](https://github.com/PastFly/Selective-Remote/actions/runs/34407150476) — passed, including the new browser auto-provision/background-sync test, full Cloud/browser tests, PostgreSQL 16, Swift/macOS tests, and release build;
- [Test DMG #235](https://github.com/PastFly/Selective-Remote/actions/runs/34407150494) — passed, including ARM64 ad-hoc signed DMG build and artifact upload.

## Stack

This PR is intentionally stacked on #76 exact head `625c70cbf362dc88320f929f980b5da386106d49`. It does not change `main`.