### PR TITLE
Automate macOS Team Vault sync and wrapper delivery

### DIFF
--- a/Sources/SelectiveRemote/CloudAPIClient.swift
+++ b/Sources/SelectiveRemote/CloudAPIClient.swift
@@ -220,6 +220,12 @@ struct SelectiveRemoteCloudTeamVaultWriteResult: Equatable, Sendable {
     var rotationCompleted: Bool?
 }
 
+struct SelectiveRemoteCloudTeamVaultWrapperGrant: Equatable, Sendable {
+    var granted: Bool
+    var keyGeneration: Int
+    var deviceID: UUID
+}
+
 struct SelectiveRemoteCloudDeviceRegistration: Codable, Equatable, Sendable {
     var id: UUID
     var name: String
@@ -695,6 +701,53 @@ actor SelectiveRemoteCloudAPIClient {
         return result.devices
     }
 
+    func grantSharedVaultWrapper(
+        endpoint: URL,
+        teamID: UUID,
+        vaultID: UUID,
+        keyGeneration: Int,
+        wrapper: SelectiveRemoteTeamVaultKeyWrapper,
+        idempotencyKey: String
+    ) async throws -> SelectiveRemoteCloudTeamVaultWrapperGrant {
+        let wrapperIsValid = (try? Self.validWrapper(
+            wrapper,
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: keyGeneration
+        )) == true
+        guard teamID.isSelectiveRemoteCloudUUID,
+              vaultID.isSelectiveRemoteCloudUUID,
+              keyGeneration > 0,
+              Self.validIdempotencyKey(idempotencyKey),
+              wrapperIsValid
+        else { throw SelectiveRemoteCloudError.invalidRequest }
+
+        let (data, http) = try await authorizedResponse(
+            endpoint: endpoint,
+            path: "v1/teams/\(teamID.canonicalCloudString)/vaults/\(vaultID.canonicalCloudString)/wrappers",
+            method: "POST",
+            body: try encoder.encode(TeamVaultWrapperGrantRequest(
+                keyGeneration: keyGeneration,
+                wrapper: wrapper
+            )),
+            headers: ["Idempotency-Key": idempotencyKey]
+        )
+        guard http.statusCode == 201 else {
+            throw serviceError(status: http.statusCode, data: data)
+        }
+        guard Self.validTeamVaultWrapperGrantJSON(data),
+              let response = try? decoder.decode(TeamVaultWrapperGrantResponse.self, from: data),
+              response.granted,
+              response.keyGeneration == keyGeneration,
+              response.deviceID == wrapper.deviceID
+        else { throw SelectiveRemoteCloudError.invalidResponse }
+        return .init(
+            granted: true,
+            keyGeneration: response.keyGeneration,
+            deviceID: response.deviceID
+        )
+    }
+
     func sharedVault(
         endpoint: URL,
         teamID: UUID,
@@ -1047,6 +1100,11 @@ actor SelectiveRemoteCloudAPIClient {
         return devices.allSatisfy { exactKeys($0, expected: keys) }
     }
 
+    private static func validTeamVaultWrapperGrantJSON(_ data: Data) -> Bool {
+        guard let object = try? JSONSerialization.jsonObject(with: data) else { return false }
+        return exactKeys(object, expected: ["granted", "keyGeneration", "deviceID"])
+    }
+
     private static func validSharedVaultEnvelopeJSON(_ data: Data) -> Bool {
         guard let object = try? JSONSerialization.jsonObject(with: data) else { return false }
         return exactKeys(object, expected: [
@@ -1098,6 +1156,23 @@ actor SelectiveRemoteCloudAPIClient {
             && value.range(of: "^[A-Za-z0-9._:-]+$", options: .regularExpression) != nil
     }
 
+    private static func validWrapper(
+        _ wrapper: SelectiveRemoteTeamVaultKeyWrapper,
+        teamID: UUID,
+        vaultID: UUID,
+        keyGeneration: Int
+    ) throws -> Bool {
+        let context = try SelectiveRemoteTeamWrapperContext(
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: keyGeneration,
+            membershipID: wrapper.membershipID,
+            membershipEpoch: wrapper.membershipEpoch,
+            deviceID: wrapper.deviceID
+        )
+        return wrapper.contextHash == SelectiveRemoteTeamVaultCrypto.wrapperContextHash(context)
+    }
+
     private static func validUpload(
         _ upload: SelectiveRemoteCloudTeamVaultUpload,
         teamID: UUID,
@@ -1108,16 +1183,13 @@ actor SelectiveRemoteCloudAPIClient {
               wrappers.count <= 1_024,
               Set(wrappers.map(\.deviceID)).count == wrappers.count
         else { return false }
-        return try wrappers.allSatisfy { wrapper in
-            let context = try SelectiveRemoteTeamWrapperContext(
+        return try wrappers.allSatisfy {
+            try validWrapper(
+                $0,
                 teamID: teamID,
                 vaultID: vaultID,
-                keyGeneration: upload.envelope.keyGeneration,
-                membershipID: wrapper.membershipID,
-                membershipEpoch: wrapper.membershipEpoch,
-                deviceID: wrapper.deviceID
+                keyGeneration: upload.envelope.keyGeneration
             )
-            return wrapper.contextHash == SelectiveRemoteTeamVaultCrypto.wrapperContextHash(context)
         }
     }
 
@@ -1238,6 +1310,17 @@ private struct SharedVaultsResponse: Decodable {
 
 private struct TeamKeyDevicesResponse: Decodable {
     var devices: [SelectiveRemoteCloudTeamKeyDevice]
+}
+
+private struct TeamVaultWrapperGrantRequest: Encodable {
+    var keyGeneration: Int
+    var wrapper: SelectiveRemoteTeamVaultKeyWrapper
+}
+
+private struct TeamVaultWrapperGrantResponse: Decodable {
+    var granted: Bool
+    var keyGeneration: Int
+    var deviceID: UUID
 }
 
 private struct TeamVaultWriteResponse: Decodable {

--- a/Sources/SelectiveRemote/CloudTeamVaultAutoSync.swift
+++ b/Sources/SelectiveRemote/CloudTeamVaultAutoSync.swift
@@ -1,0 +1,177 @@
+import Foundation
+
+protocol SelectiveRemoteTeamVaultAutoSyncRemote: SelectiveRemoteTeamVaultRemote {
+    func hasStoredSession(endpoint: URL) async -> Bool
+    func teams(endpoint: URL) async throws -> [SelectiveRemoteCloudTeam]
+    func sharedVaults(endpoint: URL, teamID: UUID) async throws -> [SelectiveRemoteCloudSharedVault]
+}
+
+extension SelectiveRemoteCloudAPIClient: SelectiveRemoteTeamVaultAutoSyncRemote {}
+
+struct SelectiveRemoteTeamVaultAutoSyncReport: Equatable, Sendable {
+    var scannedVaults = 0
+    var synchronizedVaults = 0
+    var uploadedVaults = 0
+    var emptyVaults = 0
+    var conflicts = 0
+    var pendingWrappers = 0
+    var wrappersGranted = 0
+    var rotations = 0
+    var failures = 0
+}
+
+typealias SelectiveRemoteTeamVaultSnapshotStoreFactory =
+    @Sendable () throws -> any SelectiveRemoteTeamVaultSnapshotStore
+
+actor SelectiveRemoteTeamVaultAutoSync {
+    private let remote: any SelectiveRemoteTeamVaultAutoSyncRemote
+    private let identityManager: SelectiveRemoteTeamDeviceIdentityManager
+    private let snapshotStore: SelectiveRemoteTeamVaultSnapshotStoreFactory
+    private let pollInterval: Duration
+    private var cycle: Task<Void, Never>?
+
+    init(
+        remote: any SelectiveRemoteTeamVaultAutoSyncRemote = SelectiveRemoteCloudAPIClient(),
+        identityManager: SelectiveRemoteTeamDeviceIdentityManager = .init(),
+        snapshotStore: @escaping SelectiveRemoteTeamVaultSnapshotStoreFactory = {
+            try SelectiveRemoteTeamVaultFileSnapshotStore()
+        },
+        pollInterval: Duration = .seconds(15)
+    ) {
+        self.remote = remote
+        self.identityManager = identityManager
+        self.snapshotStore = snapshotStore
+        self.pollInterval = pollInterval
+    }
+
+    func start() {
+        guard cycle == nil else { return }
+        cycle = Task { [weak self] in
+            await self?.runLoop()
+        }
+    }
+
+    func stop() {
+        cycle?.cancel()
+        cycle = nil
+    }
+
+    func synchronizeOnce(
+        endpoint: URL,
+        deviceID: UUID
+    ) async throws -> SelectiveRemoteTeamVaultAutoSyncReport {
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized(endpoint.absoluteString)
+        guard deviceID.isSelectiveRemoteCloudUUID else {
+            throw SelectiveRemoteCloudError.invalidRequest
+        }
+        var report = SelectiveRemoteTeamVaultAutoSyncReport()
+        guard await remote.hasStoredSession(endpoint: endpoint) else { return report }
+
+        let identity = try await identityManager.identity(endpoint: endpoint, deviceID: deviceID)
+        let teams = try await remote.teams(endpoint: endpoint)
+        for team in teams {
+            try Task.checkCancellation()
+            let vaults: [SelectiveRemoteCloudSharedVault]
+            do {
+                vaults = try await remote.sharedVaults(endpoint: endpoint, teamID: team.id)
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                report.failures += 1
+                continue
+            }
+
+            for vault in vaults {
+                try Task.checkCancellation()
+                report.scannedVaults += 1
+                guard !vault.rotationRequired else {
+                    report.rotations += 1
+                    continue
+                }
+                do {
+                    let coordinator = try SelectiveRemoteTeamVaultSyncCoordinator(
+                        endpoint: endpoint,
+                        remote: remote,
+                        snapshots: try snapshotStore()
+                    )
+                    report.wrappersGranted += try await coordinator.provisionMissingWrappers(
+                        teamID: team.id,
+                        vaultID: vault.id,
+                        identity: identity
+                    )
+                    try Task.checkCancellation()
+                    let refreshed = try await coordinator.refresh(
+                        teamID: team.id,
+                        vaultID: vault.id,
+                        identity: identity
+                    )
+                    switch refreshed {
+                    case .empty:
+                        report.emptyVaults += 1
+                    case .synchronized:
+                        report.synchronizedVaults += 1
+                    case .localChanges:
+                        let pushed = try await coordinator.push(
+                            teamID: team.id,
+                            vaultID: vault.id,
+                            identity: identity
+                        )
+                        switch pushed {
+                        case .uploaded:
+                            report.uploadedVaults += 1
+                        case .conflict:
+                            report.conflicts += 1
+                        }
+                    case .conflict:
+                        report.conflicts += 1
+                    }
+                } catch is CancellationError {
+                    throw CancellationError()
+                } catch SelectiveRemoteTeamVaultSyncError.missingDeviceWrapper {
+                    report.pendingWrappers += 1
+                } catch SelectiveRemoteTeamVaultSyncError.rotationRequired {
+                    report.rotations += 1
+                } catch {
+                    report.failures += 1
+                }
+            }
+        }
+        return report
+    }
+
+    private func runLoop() async {
+        while !Task.isCancelled {
+            do {
+                if let account = configuredAccount() {
+                    _ = try await synchronizeOnce(
+                        endpoint: account.endpoint,
+                        deviceID: account.deviceID
+                    )
+                }
+                try await Task.sleep(for: pollInterval)
+            } catch is CancellationError {
+                return
+            } catch {
+                do {
+                    try await Task.sleep(for: pollInterval)
+                } catch {
+                    return
+                }
+            }
+        }
+    }
+
+    private func configuredAccount() -> (endpoint: URL, deviceID: UUID)? {
+        guard let endpointText = UserDefaults.standard.string(
+                  forKey: "SelectiveRemote.cloud.endpoint.v1"
+              ),
+              let endpoint = try? SelectiveRemoteCloudEndpoint.normalized(endpointText),
+              let deviceText = UserDefaults.standard.string(
+                  forKey: "SelectiveRemote.cloud.device-id.v1"
+              ),
+              let deviceID = UUID(uuidString: deviceText),
+              deviceID.isSelectiveRemoteCloudUUID
+        else { return nil }
+        return (endpoint, deviceID)
+    }
+}

--- a/Sources/SelectiveRemote/CloudTeamVaultSyncCoordinator.swift
+++ b/Sources/SelectiveRemote/CloudTeamVaultSyncCoordinator.swift
@@ -9,6 +9,7 @@ enum SelectiveRemoteTeamVaultSyncError: LocalizedError, Equatable {
     case remoteRevisionRollback
     case remoteRevisionDivergence
     case invalidWriteAcknowledgement
+    case invalidWrapperGrantAcknowledgement
     case invalidConflictResponse
     case staleConflict
     case invalidKeyDevices
@@ -55,6 +56,11 @@ enum SelectiveRemoteTeamVaultSyncError: LocalizedError, Equatable {
                 ru: "Cloud не подтвердил безопасную запись в Team Vault. Данные не были перезаписаны.",
                 en: "Cloud did not confirm a safe Team Vault write. No data was overwritten."
             )
+        case .invalidWrapperGrantAcknowledgement:
+            UpdateLocalization.text(
+                ru: "Cloud не подтвердил безопасную выдачу ключа Team Vault этому устройству.",
+                en: "Cloud did not confirm the Team Vault key grant to this device."
+            )
         case .staleConflict:
             UpdateLocalization.text(
                 ru: "Team Vault снова изменился во время разрешения конфликта. Обновите его и повторите выбор.",
@@ -70,6 +76,21 @@ enum SelectiveRemoteTeamVaultSyncError: LocalizedError, Equatable {
 }
 
 protocol SelectiveRemoteTeamVaultRemote: Sendable {
+    func teamKeyDevices(
+        endpoint: URL,
+        teamID: UUID,
+        vaultID: UUID
+    ) async throws -> [SelectiveRemoteCloudTeamKeyDevice]
+
+    func grantSharedVaultWrapper(
+        endpoint: URL,
+        teamID: UUID,
+        vaultID: UUID,
+        keyGeneration: Int,
+        wrapper: SelectiveRemoteTeamVaultKeyWrapper,
+        idempotencyKey: String
+    ) async throws -> SelectiveRemoteCloudTeamVaultWrapperGrant
+
     func sharedVault(
         endpoint: URL,
         teamID: UUID,
@@ -130,6 +151,88 @@ actor SelectiveRemoteTeamVaultSyncCoordinator {
         self.endpoint = try SelectiveRemoteCloudEndpoint.normalized(endpoint.absoluteString)
         self.remote = remote
         self.snapshots = snapshots
+    }
+
+    func provisionMissingWrappers(
+        teamID: UUID,
+        vaultID: UUID,
+        identity: SelectiveRemoteTeamDeviceIdentity
+    ) async throws -> Int {
+        let remoteEnvelope = try await remote.sharedVault(
+            endpoint: endpoint,
+            teamID: teamID,
+            vaultID: vaultID
+        )
+        guard !remoteEnvelope.rotationRequired else {
+            throw SelectiveRemoteTeamVaultSyncError.rotationRequired
+        }
+        guard remoteEnvelope.revision > 0 else { return 0 }
+
+        let remoteVersion = try decryptedRemoteVersion(
+            remoteEnvelope,
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
+        let devices = try await remote.teamKeyDevices(
+            endpoint: endpoint,
+            teamID: teamID,
+            vaultID: vaultID
+        )
+        guard !devices.isEmpty,
+              devices.count <= 1_024,
+              Set(devices.map(\.deviceID)).count == devices.count,
+              devices.allSatisfy({
+                  $0.membershipID.isSelectiveRemoteCloudUUID
+                      && $0.membershipEpoch > 0
+                      && $0.deviceID.isSelectiveRemoteCloudUUID
+                      && $0.publicKeyAlgorithm == "p256-ecdh-v1"
+              }),
+              let actor = devices.first(where: { $0.deviceID == identity.deviceID }),
+              actor.hasWrapper,
+              actor.membershipID == remoteVersion.wrapper.membershipID,
+              actor.membershipEpoch == remoteVersion.wrapper.membershipEpoch
+        else { throw SelectiveRemoteTeamVaultSyncError.invalidKeyDevices }
+
+        let vaultKey = try SelectiveRemoteTeamVaultCrypto.unwrapVaultKey(
+            remoteVersion.wrapper,
+            with: identity,
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: remoteVersion.keyGeneration
+        )
+        var granted = 0
+        for recipient in devices where !recipient.hasWrapper {
+            try Task.checkCancellation()
+            let wrapper = try SelectiveRemoteTeamVaultCrypto.wrapVaultKey(
+                vaultKey,
+                for: recipient.publicKey,
+                context: SelectiveRemoteTeamWrapperContext(
+                    teamID: teamID,
+                    vaultID: vaultID,
+                    keyGeneration: remoteVersion.keyGeneration,
+                    membershipID: recipient.membershipID,
+                    membershipEpoch: recipient.membershipEpoch,
+                    deviceID: recipient.deviceID
+                )
+            )
+            let acknowledgement = try await remote.grantSharedVaultWrapper(
+                endpoint: endpoint,
+                teamID: teamID,
+                vaultID: vaultID,
+                keyGeneration: remoteVersion.keyGeneration,
+                wrapper: wrapper,
+                idempotencyKey: "macos:team-vault:grant:\(UUID().canonicalCloudString)"
+            )
+            guard acknowledgement.granted,
+                  acknowledgement.keyGeneration == remoteVersion.keyGeneration,
+                  acknowledgement.deviceID == recipient.deviceID
+            else {
+                throw SelectiveRemoteTeamVaultSyncError.invalidWrapperGrantAcknowledgement
+            }
+            granted += 1
+        }
+        return granted
     }
 
     func initialize(

--- a/Sources/SelectiveRemote/SelectiveRemoteApp.swift
+++ b/Sources/SelectiveRemote/SelectiveRemoteApp.swift
@@ -131,6 +131,7 @@ struct SelectiveRemoteApp: App {
     @StateObject private var appAppearance = AppAppearanceStore.shared
     @StateObject private var appLock = AppLockStore()
     private let personalVaultAutoSync = SelectiveRemotePersonalVaultAutoSync()
+    private let teamVaultAutoSync = SelectiveRemoteTeamVaultAutoSync()
 
     private var menuBarSystemImage: String {
         if appLock.isLocked { return "lock.fill" }
@@ -156,12 +157,16 @@ struct SelectiveRemoteApp: App {
                     .onAppear {
                         model.presentWhatsNewAfterUpgradeIfNeeded()
                         schedulePersonalVaultAutoSync()
+                        updateTeamVaultAutoSync()
                     }
                     .onChange(of: model.profiles) { _, _ in schedulePersonalVaultAutoSync() }
                     .onChange(of: model.independentPortForwards) { _, _ in schedulePersonalVaultAutoSync() }
                     .onReceive(TerminalCommandHistoryStore.shared.$snippetRevision) { _ in
                         schedulePersonalVaultAutoSync()
                     }
+            }
+            .onChange(of: appLock.isLocked) { _, _ in
+                updateTeamVaultAutoSync()
             }
         }
         .windowResizability(.contentMinSize)
@@ -393,6 +398,17 @@ struct SelectiveRemoteApp: App {
         }
         .menuBarExtraStyle(.menu)
         .environment(\.locale, language.locale)
+    }
+
+    private func updateTeamVaultAutoSync() {
+        let shouldRun = !appLock.isLocked
+        Task {
+            if shouldRun {
+                await teamVaultAutoSync.start()
+            } else {
+                await teamVaultAutoSync.stop()
+            }
+        }
     }
 
     private func schedulePersonalVaultAutoSync() {

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -471,6 +471,11 @@ struct CloudMacOSFoundationTests {
         let deviceID = try #require(UUID(uuidString: "44444444-4444-4444-8444-444444444444"))
         let membershipID = try #require(UUID(uuidString: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"))
         let fixture = try Self.fixture()
+        let identity = try SelectiveRemoteTeamDeviceIdentity(
+            deviceID: deviceID,
+            privateKeyRepresentation: try fixture.keyWrap.recipientPrivateScalar.base64URLData
+        )
+        let wrapper = try Self.fixtureWrapper(fixture, identity: identity)
         let token = String(repeating: "t", count: 43)
         let store = SelectiveRemoteCloudMemoryTokenStore()
         try store.saveToken(token, for: endpoint)
@@ -518,6 +523,19 @@ struct CloudMacOSFoundationTests {
                     "createdAt": "2026-09-06T00:00:00.000Z",
                     "updatedAt": "2026-09-06T00:00:00.000Z"
                 ])
+            case ("POST", "/v1/teams/\(teamID.canonicalCloudString)/vaults/\(vaultID.canonicalCloudString)/wrappers"):
+                #expect(request.value(forHTTPHeaderField: "Idempotency-Key") == "macos:team:vault:grant-1")
+                let body = try #require(request.httpBody)
+                let object = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+                #expect(Set(object.keys) == ["keyGeneration", "wrapper"])
+                #expect(object["keyGeneration"] as? Int == 7)
+                let encodedWrapper = try #require(object["wrapper"] as? [String: Any])
+                #expect(encodedWrapper["deviceID"] as? String == deviceID.canonicalCloudString)
+                return Self.response(request, status: 201, json: [
+                    "granted": true,
+                    "keyGeneration": 7,
+                    "deviceID": deviceID.canonicalCloudString
+                ])
             case ("PUT", "/v1/teams/\(teamID.canonicalCloudString)/vaults/\(vaultID.canonicalCloudString)"):
                 #expect(request.value(forHTTPHeaderField: "Idempotency-Key") == "macos:team:vault:synthetic-1")
                 #expect(request.httpBody.map { String(decoding: $0, as: UTF8.self) }?.contains("schemaVersion") == false)
@@ -539,6 +557,15 @@ struct CloudMacOSFoundationTests {
             teamID: teamID,
             vaultID: vaultID
         ).map(\.deviceID) == [deviceID])
+        let grant = try await client.grantSharedVaultWrapper(
+            endpoint: endpoint,
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: 7,
+            wrapper: wrapper,
+            idempotencyKey: "macos:team:vault:grant-1"
+        )
+        #expect(grant == .init(granted: true, keyGeneration: 7, deviceID: deviceID))
         let remote = try await client.sharedVault(endpoint: endpoint, teamID: teamID, vaultID: vaultID)
         let downloadedEnvelope = try remote.payloadEnvelope
         let envelope = try #require(downloadedEnvelope)
@@ -551,6 +578,176 @@ struct CloudMacOSFoundationTests {
             idempotencyKey: "macos:team:vault:synthetic-1"
         )
         #expect(result == .init(conflict: true, revision: 6, keyGeneration: 7, rotationCompleted: nil))
+    }
+
+    @Test("current macOS key holder provisions another admitted device")
+    func teamVaultWrapperProvisioning() async throws {
+        let fixture = try Self.fixture()
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized("https://cloud.example.invalid")
+        let teamID = try fixture.wrapper.teamID.uuid
+        let vaultID = try fixture.wrapper.vaultID.uuid
+        let deviceID = try fixture.wrapper.deviceID.uuid
+        let membershipID = try fixture.wrapper.membershipID.uuid
+        let recipientID = try #require(UUID(uuidString: "55555555-5555-4555-8555-555555555555"))
+        let recipientMembershipID = try #require(
+            UUID(uuidString: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+        )
+        let identity = try SelectiveRemoteTeamDeviceIdentity(
+            deviceID: deviceID,
+            privateKeyRepresentation: try fixture.keyWrap.recipientPrivateScalar.base64URLData
+        )
+        let recipient = try SelectiveRemoteTeamDeviceIdentity(
+            deviceID: recipientID,
+            privateKeyRepresentation: Data(repeating: 0x03, count: 32)
+        )
+        let actorWrapper = try Self.fixtureWrapper(fixture, identity: identity)
+        let keyDevices: [SelectiveRemoteCloudTeamKeyDevice] = [
+            .init(
+                membershipID: membershipID,
+                membershipEpoch: fixture.wrapper.membershipEpoch,
+                deviceID: deviceID,
+                publicKeyAlgorithm: "p256-ecdh-v1",
+                publicKey: identity.publicKey,
+                hasWrapper: true
+            ),
+            .init(
+                membershipID: recipientMembershipID,
+                membershipEpoch: 1,
+                deviceID: recipientID,
+                publicKeyAlgorithm: "p256-ecdh-v1",
+                publicKey: recipient.publicKey,
+                hasWrapper: false
+            )
+        ]
+        let remote = TeamVaultRemoteStub(
+            envelope: Self.remoteEnvelope(fixture, wrapper: actorWrapper),
+            writeResult: .init(
+                conflict: false,
+                revision: 6,
+                keyGeneration: fixture.wrapper.keyGeneration,
+                rotationCompleted: false
+            ),
+            keyDevices: keyDevices
+        )
+        let coordinator = try SelectiveRemoteTeamVaultSyncCoordinator(
+            endpoint: endpoint,
+            remote: remote,
+            snapshots: SelectiveRemoteTeamVaultMemorySnapshotStore()
+        )
+
+        #expect(try await coordinator.provisionMissingWrappers(
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        ) == 1)
+        let grants = await remote.recordedGrants()
+        let grantedWrapper = try #require(grants.first?.wrapper)
+        #expect(grants.count == 1)
+        #expect(grants.first?.keyGeneration == fixture.wrapper.keyGeneration)
+        #expect(grants.first?.idempotencyKey.hasPrefix("macos:team-vault:grant:") == true)
+        #expect(try SelectiveRemoteTeamVaultCrypto.unwrapVaultKey(
+            grantedWrapper,
+            with: recipient,
+            teamID: teamID,
+            vaultID: vaultID,
+            keyGeneration: fixture.wrapper.keyGeneration
+        ) == fixture.keyWrap.vaultKey.base64URLData)
+    }
+
+    @Test("macOS background cycle provisions wrappers and refreshes ciphertext")
+    func teamVaultBackgroundSync() async throws {
+        let fixture = try Self.fixture()
+        let endpoint = try SelectiveRemoteCloudEndpoint.normalized("https://cloud.example.invalid")
+        let teamID = try fixture.wrapper.teamID.uuid
+        let vaultID = try fixture.wrapper.vaultID.uuid
+        let deviceID = try fixture.wrapper.deviceID.uuid
+        let membershipID = try fixture.wrapper.membershipID.uuid
+        let recipientID = try #require(UUID(uuidString: "55555555-5555-4555-8555-555555555555"))
+        let recipientMembershipID = try #require(
+            UUID(uuidString: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+        )
+        let identity = try SelectiveRemoteTeamDeviceIdentity(
+            deviceID: deviceID,
+            privateKeyRepresentation: try fixture.keyWrap.recipientPrivateScalar.base64URLData
+        )
+        let recipient = try SelectiveRemoteTeamDeviceIdentity(
+            deviceID: recipientID,
+            privateKeyRepresentation: Data(repeating: 0x03, count: 32)
+        )
+        let team = SelectiveRemoteCloudTeam(
+            id: teamID,
+            name: "Platform",
+            membershipID: membershipID,
+            role: .viewer,
+            membershipEpoch: fixture.wrapper.membershipEpoch,
+            createdAt: "2026-09-09T00:00:00.000Z",
+            updatedAt: "2026-09-09T00:00:00.000Z"
+        )
+        let vault = SelectiveRemoteCloudSharedVault(
+            id: vaultID,
+            teamID: teamID,
+            name: "Operations",
+            revision: fixture.payload.baseRevision + 1,
+            keyGeneration: fixture.wrapper.keyGeneration,
+            rotationRequired: false,
+            createdAt: "2026-09-09T00:00:00.000Z",
+            updatedAt: "2026-09-09T00:00:00.000Z"
+        )
+        let remote = TeamVaultRemoteStub(
+            envelope: Self.remoteEnvelope(
+                fixture,
+                wrapper: try Self.fixtureWrapper(fixture, identity: identity)
+            ),
+            writeResult: .init(
+                conflict: false,
+                revision: 6,
+                keyGeneration: fixture.wrapper.keyGeneration,
+                rotationCompleted: false
+            ),
+            teams: [team],
+            vaults: [vault],
+            keyDevices: [
+                .init(
+                    membershipID: membershipID,
+                    membershipEpoch: fixture.wrapper.membershipEpoch,
+                    deviceID: deviceID,
+                    publicKeyAlgorithm: "p256-ecdh-v1",
+                    publicKey: identity.publicKey,
+                    hasWrapper: true
+                ),
+                .init(
+                    membershipID: recipientMembershipID,
+                    membershipEpoch: 1,
+                    deviceID: recipientID,
+                    publicKeyAlgorithm: "p256-ecdh-v1",
+                    publicKey: recipient.publicKey,
+                    hasWrapper: false
+                )
+            ]
+        )
+        let keyStore = SelectiveRemoteTeamDeviceMemoryKeyStore()
+        _ = try keyStore.savePrivateKeyIfAbsent(
+            try fixture.keyWrap.recipientPrivateScalar.base64URLData,
+            for: endpoint,
+            deviceID: deviceID
+        )
+        let snapshots = SelectiveRemoteTeamVaultMemorySnapshotStore()
+        let autoSync = SelectiveRemoteTeamVaultAutoSync(
+            remote: remote,
+            identityManager: SelectiveRemoteTeamDeviceIdentityManager(store: keyStore),
+            snapshotStore: { snapshots }
+        )
+
+        let report = try await autoSync.synchronizeOnce(
+            endpoint: endpoint,
+            deviceID: deviceID
+        )
+        #expect(report.scannedVaults == 1)
+        #expect(report.synchronizedVaults == 1)
+        #expect(report.wrappersGranted == 1)
+        #expect(report.pendingWrappers == 0)
+        #expect(report.failures == 0)
+        #expect(try snapshots.load(endpoint: endpoint, teamID: teamID, vaultID: vaultID) != nil)
     }
 
     @Test("Team Vault coordinator stages and acknowledges one causal upload")
@@ -1268,9 +1465,15 @@ private actor TeamVaultReadBarrier {
     }
 }
 
-private actor TeamVaultRemoteStub: SelectiveRemoteTeamVaultRemote {
+private actor TeamVaultRemoteStub: SelectiveRemoteTeamVaultAutoSyncRemote {
     struct RecordedWrite: Equatable, Sendable {
         let upload: SelectiveRemoteCloudTeamVaultUpload
+        let idempotencyKey: String
+    }
+
+    struct RecordedGrant: Equatable, Sendable {
+        let wrapper: SelectiveRemoteTeamVaultKeyWrapper
+        let keyGeneration: Int
         let idempotencyKey: String
     }
 
@@ -1279,13 +1482,72 @@ private actor TeamVaultRemoteStub: SelectiveRemoteTeamVaultRemote {
     private var writeFailure: TeamVaultRemoteStubFailure?
     private var readBarrier: TeamVaultReadBarrier?
     private var writes: [RecordedWrite] = []
+    private var grants: [RecordedGrant] = []
+    private var teamValues: [SelectiveRemoteCloudTeam]
+    private var vaultValues: [SelectiveRemoteCloudSharedVault]
+    private var keyDeviceValues: [SelectiveRemoteCloudTeamKeyDevice]
 
     init(
         envelope: SelectiveRemoteCloudSharedVaultEnvelope,
-        writeResult: SelectiveRemoteCloudTeamVaultWriteResult
+        writeResult: SelectiveRemoteCloudTeamVaultWriteResult,
+        teams: [SelectiveRemoteCloudTeam] = [],
+        vaults: [SelectiveRemoteCloudSharedVault] = [],
+        keyDevices: [SelectiveRemoteCloudTeamKeyDevice] = []
     ) {
         self.envelope = envelope
         self.writeResult = writeResult
+        teamValues = teams
+        vaultValues = vaults
+        keyDeviceValues = keyDevices
+    }
+
+    func hasStoredSession(endpoint _: URL) async -> Bool {
+        true
+    }
+
+    func teams(endpoint _: URL) async throws -> [SelectiveRemoteCloudTeam] {
+        teamValues
+    }
+
+    func sharedVaults(
+        endpoint _: URL,
+        teamID: UUID
+    ) async throws -> [SelectiveRemoteCloudSharedVault] {
+        #expect(vaultValues.allSatisfy { $0.teamID == teamID })
+        return vaultValues
+    }
+
+    func teamKeyDevices(
+        endpoint _: URL,
+        teamID: UUID,
+        vaultID: UUID
+    ) async throws -> [SelectiveRemoteCloudTeamKeyDevice] {
+        #expect(envelope.teamID == teamID)
+        #expect(envelope.id == vaultID)
+        return keyDeviceValues
+    }
+
+    func grantSharedVaultWrapper(
+        endpoint _: URL,
+        teamID: UUID,
+        vaultID: UUID,
+        keyGeneration: Int,
+        wrapper: SelectiveRemoteTeamVaultKeyWrapper,
+        idempotencyKey: String
+    ) async throws -> SelectiveRemoteCloudTeamVaultWrapperGrant {
+        #expect(envelope.teamID == teamID)
+        #expect(envelope.id == vaultID)
+        #expect(envelope.keyGeneration == keyGeneration)
+        guard let index = keyDeviceValues.firstIndex(where: { $0.deviceID == wrapper.deviceID }) else {
+            throw SelectiveRemoteCloudError.invalidRequest
+        }
+        grants.append(.init(
+            wrapper: wrapper,
+            keyGeneration: keyGeneration,
+            idempotencyKey: idempotencyKey
+        ))
+        keyDeviceValues[index].hasWrapper = true
+        return .init(granted: true, keyGeneration: keyGeneration, deviceID: wrapper.deviceID)
     }
 
     func sharedVault(
@@ -1336,6 +1598,10 @@ private actor TeamVaultRemoteStub: SelectiveRemoteTeamVaultRemote {
 
     func recordedWrites() -> [RecordedWrite] {
         writes
+    }
+
+    func recordedGrants() -> [RecordedGrant] {
+        grants
     }
 }
 

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -76,6 +76,25 @@ test("macOS Team Vault coordinator preserves causal dirty and conflict state", a
   assert.match(coordinator, /wrappers: wrappers/);
 });
 
+test("macOS automatically provisions and synchronizes Team Vaults while unlocked", async () => {
+  const [client, coordinator, autoSync, app] = await Promise.all([
+    readFile(new URL("CloudAPIClient.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudTeamVaultSyncCoordinator.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudTeamVaultAutoSync.swift", sourceRoot), "utf8"),
+    readFile(new URL("SelectiveRemoteApp.swift", sourceRoot), "utf8"),
+  ]);
+  assert.match(client, /func grantSharedVaultWrapper\(/);
+  assert.match(client, /\/wrappers/);
+  assert.match(coordinator, /func provisionMissingWrappers\(/);
+  assert.match(coordinator, /actor\.membershipID == remoteVersion\.wrapper\.membershipID/);
+  assert.match(autoSync, /pollInterval: Duration = \.seconds\(15\)/);
+  assert.match(autoSync, /case \.localChanges:/);
+  assert.match(autoSync, /case \.conflict:/);
+  assert.doesNotMatch(autoSync, /func initialize\(/);
+  assert.match(app, /appLock\.isLocked/);
+  assert.match(app, /teamVaultAutoSync\.stop\(\)/);
+});
+
 test("Host context menu opens a real encrypted Team Vault share flow", async () => {
   const [content, sharing, coordinator] = await Promise.all([
     readFile(new URL("ContentView.swift", sourceRoot), "utf8"),

--- a/docs/cloud-v0.32-team-threat-model.md
+++ b/docs/cloud-v0.32-team-threat-model.md
@@ -190,6 +190,18 @@ logout. The interval grants no new role capability: Viewer writes still fail at
 the client and server, while any role may provision only after current-wrapper
 proof.
 
+While the macOS app is unlocked, its app-lifetime 15-second cycle enumerates
+only Teams and Vaults authorized by the current bearer session. For each
+non-empty, non-rotating Vault it first proves possession of the exact
+current-device wrapper, locally wraps the current Vault key for missing
+membership-epoch-scoped devices, and submits each wrapper through the same
+server proof gate. It then uses the existing causal coordinator to download a
+dominant ciphertext revision or conditionally upload an already-dirty local
+snapshot. Empty Vaults are never initialized in the background, conflicts are
+reported without choosing a winner, rotation freezes the Vault, and App Lock
+cancels the cycle. The file snapshot remains ciphertext and a device wrapper;
+plaintext and raw Vault keys are never persisted there.
+
 ## Removal and rotation
 
 Membership removal is a fail-closed state transition:
@@ -272,6 +284,7 @@ or wrappers.
 
 Team/shared Vault release status remains `planned_required`: the server-side
 protocol, browser Team UI/cryptography/causal sync/device approval/rotation and
-the bounded macOS crypto/transport/offline coordinator are implemented, but
-macOS UI, explicit conflict-resolution writes and the complete cross-client
+the bounded macOS crypto/transport/offline coordinator plus automatic wrapper
+delivery and background ciphertext synchronization are implemented, but macOS
+Team Hosts UI, explicit conflict-resolution writes and the complete cross-client
 acceptance suite must pass before Cloud 0.32 is complete.


### PR DESCRIPTION
## Summary

- add typed macOS transport for proof-gated, idempotent current-generation Team Vault wrapper grants;
- let a current key-holding macOS device provision every missing membership-epoch-scoped device wrapper without requiring an Owner/Admin client;
- run an app-lifetime 15-second Team Vault cycle while Selective Remote is unlocked;
- automatically refresh dominant ciphertext revisions and conditionally upload existing dirty snapshots;
- keep empty Vault initialization, conflict resolution, and rotation explicit and fail closed;
- cancel background work when App Lock activates and dynamically follow the configured signed-in Cloud account;
- add native transport, cryptographic provisioning, background-cycle, and source-contract coverage.

## Security boundaries

The Mac must decrypt its own exact current-generation wrapper before it can wrap the Vault key for another admitted device. The Cloud API revalidates the actor capability, target membership epoch, generation, context hash, and role permissions. The cycle never persists plaintext or a raw Vault key, never initializes an empty Vault, never chooses a conflict winner, and never writes during required rotation.

## Verification

Exact head `8f43d712b0b231cc40bcf47434117715d278233c`:

- [CI #560](https://github.com/PastFly/Selective-Remote/actions/runs/34409742716) — passed, including Swift/macOS tests, the new wrapper/background-cycle tests, full Cloud/browser tests, PostgreSQL 16, and release build;
- [Test DMG #236](https://github.com/PastFly/Selective-Remote/actions/runs/34409742715) — passed, including ARM64 ad-hoc signed DMG build and artifact upload.

## Stack

This PR is intentionally stacked on #77 exact head `9baa4766dd579f8984a58627509c727b894b1a56`. It does not change `main`.