### PR TITLE
Materialize macOS Team Hosts separately

### DIFF
--- a/Sources/SelectiveRemote/AppModel.swift
+++ b/Sources/SelectiveRemote/AppModel.swift
@@ -3425,6 +3425,46 @@ final class AppModel: NSObject, ObservableObject {
         }
     }
 
+    func connectTeamHost(
+        _ teamProfile: ConnectionProfile,
+        password: String,
+        gatewayPassword: String
+    ) {
+        guard teamProfile.connectionType == .rdp,
+              teamProfile.id.isSelectiveRemoteCloudUUID
+        else {
+            errorMessage = UpdateLocalization.text(
+                ru: "Team Host содержит некорректный RDP-профиль",
+                en: "The Team Host contains an invalid RDP profile"
+            )
+            return
+        }
+        guard !profiles.contains(where: { $0.id == teamProfile.id }) else {
+            errorMessage = UpdateLocalization.text(
+                ru: "Team Host пересекается с идентификатором Personal-профиля",
+                en: "The Team Host collides with a Personal profile identifier"
+            )
+            return
+        }
+
+        var profile = teamProfile
+        profile.selectedDisplayIDs = Set(displays.map(\.id))
+        profile.primaryDisplayID = displays.first(where: \.isSystemMain)?.id ?? displays.first?.id
+        profile.displayLayoutMode = .automatic
+        profile.virtualDisplayOrigins = [:]
+        profile.autoReconnect = false
+        profile.reconnectAfterWake = false
+        connectRDPProfile(
+            profile,
+            typedPassword: password,
+            typedGatewayPassword: gatewayPassword,
+            automatic: false,
+            smartReconnectAttempt: nil,
+            allowsStoredCredentials: false,
+            persistsProfileState: false
+        )
+    }
+
     func sshConnectionSettings(
         connection: TerminalTabConnection,
         tabID: UUID
@@ -5047,10 +5087,31 @@ final class AppModel: NSObject, ObservableObject {
         automatic: Bool,
         smartReconnectAttempt: Int? = nil
     ) {
+        guard let profile = profiles.first(where: { $0.id == profileID }) else { return }
+        connectRDPProfile(
+            profile,
+            typedPassword: typedPassword,
+            typedGatewayPassword: typedGatewayPassword,
+            automatic: automatic,
+            smartReconnectAttempt: smartReconnectAttempt,
+            allowsStoredCredentials: true,
+            persistsProfileState: true
+        )
+    }
+
+    private func connectRDPProfile(
+        _ profile: ConnectionProfile,
+        typedPassword: String,
+        typedGatewayPassword: String,
+        automatic: Bool,
+        smartReconnectAttempt: Int?,
+        allowsStoredCredentials: Bool,
+        persistsProfileState: Bool
+    ) {
+        let profileID = profile.id
         if smartReconnectAttempt == nil {
             cancelRDPSmartReconnect(profileID)
         }
-        guard let profile = profiles.first(where: { $0.id == profileID }) else { return }
         guard profile.connectionType == .rdp else { return }
         guard !isSessionRunning(profileID: profileID) else {
             if !automatic { errorMessage = SelectiveRemoteAppError.profileAlreadyRunning.localizedDescription }
@@ -5063,7 +5124,9 @@ final class AppModel: NSObject, ObservableObject {
             from: profile,
             displays: displays
         ) else {
-            reconnectCandidateProfileIDs.insert(profileID)
+            if persistsProfileState {
+                reconnectCandidateProfileIDs.insert(profileID)
+            }
             if !automatic {
                 if missingCount > 0 {
                     errorMessage = SelectiveRemoteAppError.selectedDisplaysUnavailable(missingCount).localizedDescription
@@ -5102,7 +5165,8 @@ final class AppModel: NSObject, ObservableObject {
 
         // A normal/manual start with the complete automatic display set defines
         // the baseline order for subsequent monitor hot-plug reconnects.
-        if smartReconnectAttempt == nil,
+        if persistsProfileState,
+           smartReconnectAttempt == nil,
            profile.displayLayoutMode == .automatic,
            runtimeProfile.selectedDisplayIDs == profile.selectedDisplayIDs {
             rdpStableAutomaticTopologyOrigins[profileID] =
@@ -5110,21 +5174,31 @@ final class AppModel: NSObject, ObservableObject {
         }
 
         do {
-            let connectionPassword = try resolvedPassword(
-                typed: typedPassword,
-                profileID: profileID,
-                kind: .rdp
-            )
+            let connectionPassword: String
+            if allowsStoredCredentials {
+                connectionPassword = try resolvedPassword(
+                    typed: typedPassword,
+                    profileID: profileID,
+                    kind: .rdp
+                )
+            } else {
+                guard !typedPassword.isEmpty else {
+                    throw SelectiveRemoteAppError.rdpPasswordRequired
+                }
+                connectionPassword = typedPassword
+            }
             let resolvedGatewayPassword: String
             if profile.gatewayHost.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 resolvedGatewayPassword = ""
-            } else {
+            } else if allowsStoredCredentials {
                 resolvedGatewayPassword = try resolvedPassword(
                     typed: typedGatewayPassword,
                     profileID: profileID,
                     kind: .gateway,
                     required: false
                 )
+            } else {
+                resolvedGatewayPassword = typedGatewayPassword
             }
 
             let connection = try freeRDP.launch(
@@ -5140,19 +5214,22 @@ final class AppModel: NSObject, ObservableObject {
             )
             rdpActivityIDs[profileID] = connectionActivity.begin(
                 kind: .rdp,
-                profileID: profileID,
+                profileID: persistsProfileState ? profileID : nil,
                 profileName: profile.friendlyName,
                 target: profile.host,
                 route: profile.gatewayHost.isEmpty ? nil : profile.gatewayHost
             )
             managedSessions[profileID] = runtime
             sessions[profileID] = runtime.summary
-            reconnectCandidateProfileIDs.remove(profileID)
-            if selectedProfileID == profileID {
+            if persistsProfileState {
+                reconnectCandidateProfileIDs.remove(profileID)
+            }
+            if persistsProfileState, selectedProfileID == profileID {
                 password = ""
                 gatewayPassword = ""
             }
-            if let index = profiles.firstIndex(where: { $0.id == profileID }) {
+            if persistsProfileState,
+               let index = profiles.firstIndex(where: { $0.id == profileID }) {
                 profiles[index].lastConnectedAt = Date()
             }
             if let smartReconnectAttempt {
@@ -5183,13 +5260,15 @@ final class AppModel: NSObject, ObservableObject {
             }
             connectionActivity.recordFailure(
                 kind: .rdp,
-                profileID: profileID,
+                profileID: persistsProfileState ? profileID : nil,
                 profileName: profile.friendlyName,
                 target: profile.host,
                 route: profile.gatewayHost.isEmpty ? nil : profile.gatewayHost,
                 errorMessage: error.localizedDescription
             )
-            reconnectCandidateProfileIDs.insert(profileID)
+            if persistsProfileState {
+                reconnectCandidateProfileIDs.insert(profileID)
+            }
         }
     }
 
@@ -5604,15 +5683,27 @@ final class AppModel: NSObject, ObservableObject {
         lastSessionLogURLs[profileID] = runtime.connection.logURL
         managedSessions.removeValue(forKey: profileID)
         sessions.removeValue(forKey: profileID)
+        if !profiles.contains(where: { $0.id == profileID }) {
+            reconnectCandidateProfileIDs.remove(profileID)
+            rdpStableAutomaticTopologyOrigins.removeValue(forKey: profileID)
+        }
         if managedSessions.isEmpty {
             sessionTimer?.invalidate()
             sessionTimer = nil
         }
 
         if interruption.shouldAttemptSmartReconnect {
+            guard let profile = profiles.first(where: { $0.id == profileID }) else {
+                cancelRDPSmartReconnect(profileID)
+                statusMessage = UpdateLocalization.text(
+                    ru: "Team Host отключён после изменения конфигурации мониторов",
+                    en: "The Team Host disconnected after the monitor configuration changed"
+                )
+                errorMessage = nil
+                return
+            }
             reconnectCandidateProfileIDs.insert(profileID)
-            if let profile = profiles.first(where: { $0.id == profileID }),
-               profile.autoReconnect,
+            if profile.autoReconnect,
                passwordStoredProfileIDs.contains(profileID.uuidString) {
                 scheduleRDPSmartReconnect(
                     profileID: profileID,

--- a/Sources/SelectiveRemote/CloudTeamHosts.swift
+++ b/Sources/SelectiveRemote/CloudTeamHosts.swift
@@ -79,7 +79,7 @@ enum SelectiveRemoteTeamHostMaterializer {
                 guard let username = string(data["username"]),
                       let connectionType = string(data["connectionType"]),
                       let encodedProfile = string(data["profile"]),
-                      username.utf8.count <= 256,
+                      username.count <= 256,
                       !username.contains(where: { $0.isNewline }),
                       encodedProfile.utf8.count <= maximumProfileBytes * 2,
                       let profileData = Data(selectiveRemoteBase64URL: encodedProfile),
@@ -208,7 +208,7 @@ enum SelectiveRemoteTeamHostMaterializer {
         runtimeID: UUID
     ) throws -> ConnectionProfile {
         guard input.id.isSelectiveRemoteCloudUUID,
-              input.username.utf8.count <= 256,
+              input.username.count <= 256,
               !input.username.contains(where: { $0.isNewline }),
               input.gatewayHost.utf8.count <= 2_048,
               input.gatewayUsername.utf8.count <= 256,
@@ -324,7 +324,7 @@ enum SelectiveRemoteTeamHostMaterializer {
         let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return !normalized.isEmpty
             && normalized == value
-            && value.utf8.count <= 120
+            && value.count <= 120
             && !value.contains(where: { $0.isNewline })
     }
 

--- a/Sources/SelectiveRemote/CloudTeamHosts.swift
+++ b/Sources/SelectiveRemote/CloudTeamHosts.swift
@@ -1,0 +1,667 @@
+import CryptoKit
+import Foundation
+import SwiftUI
+
+struct SelectiveRemoteTeamVaultMaterializedSnapshot: Equatable, Sendable {
+    let teamID: UUID
+    let teamName: String
+    let role: SelectiveRemoteCloudTeamRole
+    let vaultID: UUID
+    let vaultName: String
+    let revision: Int
+    let keyGeneration: Int
+    let payload: Data
+}
+
+struct SelectiveRemoteTeamHost: Identifiable, Equatable {
+    let id: UUID
+    let recordID: UUID
+    let teamID: UUID
+    let teamName: String
+    let role: SelectiveRemoteCloudTeamRole
+    let vaultID: UUID
+    let vaultName: String
+    let revision: Int
+    let keyGeneration: Int
+    let modifiedAt: String
+    let address: String
+    let profile: ConnectionProfile
+}
+
+enum SelectiveRemoteTeamHostMaterializationError: Error, Equatable {
+    case invalidSnapshot
+    case invalidHostRecord
+}
+
+enum SelectiveRemoteTeamHostMaterializer {
+    private static let browserKeys: Set<String> = ["title", "address"]
+    private static let macOSKeys: Set<String> = [
+        "title", "address", "username", "connectionType", "profile"
+    ]
+    private static let maximumProfileBytes = 384 * 1024
+
+    static func materialize(
+        _ snapshot: SelectiveRemoteTeamVaultMaterializedSnapshot
+    ) throws -> [SelectiveRemoteTeamHost] {
+        guard snapshot.teamID.isSelectiveRemoteCloudUUID,
+              snapshot.vaultID.isSelectiveRemoteCloudUUID,
+              snapshot.revision > 0,
+              snapshot.keyGeneration > 0,
+              validName(snapshot.teamName),
+              validName(snapshot.vaultName)
+        else { throw SelectiveRemoteTeamHostMaterializationError.invalidSnapshot }
+
+        let document: SelectiveRemoteVaultDocument
+        do {
+            document = try SelectiveRemoteVaultDocument.decode(snapshot.payload)
+        } catch {
+            throw SelectiveRemoteTeamHostMaterializationError.invalidSnapshot
+        }
+
+        return try document.records.compactMap { record in
+            guard record.type == .host else { return nil }
+            guard case let .object(data) = record.data,
+                  let title = string(data["title"]),
+                  let address = string(data["address"]),
+                  validTitle(title),
+                  validAddress(address)
+            else { throw SelectiveRemoteTeamHostMaterializationError.invalidHostRecord }
+
+            let input: ConnectionProfile
+            let keys = Set(data.keys)
+            if keys == browserKeys {
+                input = try browserProfile(
+                    recordID: record.id,
+                    title: title,
+                    address: address
+                )
+            } else if keys == macOSKeys {
+                guard let username = string(data["username"]),
+                      let connectionType = string(data["connectionType"]),
+                      let encodedProfile = string(data["profile"]),
+                      username.utf8.count <= 256,
+                      !username.contains(where: { $0.isNewline }),
+                      encodedProfile.utf8.count <= maximumProfileBytes * 2,
+                      let profileData = Data(selectiveRemoteBase64URL: encodedProfile),
+                      profileData.count <= maximumProfileBytes
+                else { throw SelectiveRemoteTeamHostMaterializationError.invalidHostRecord }
+
+                let decoder = JSONDecoder()
+                decoder.dateDecodingStrategy = .iso8601
+                guard let decoded = try? decoder.decode(ConnectionProfile.self, from: profileData),
+                      decoded.id == record.id,
+                      decoded.connectionType.rawValue == connectionType,
+                      decoded.username == username,
+                      exportedAddress(decoded) == address,
+                      exportedTitle(decoded, address: address) == title
+                else { throw SelectiveRemoteTeamHostMaterializationError.invalidHostRecord }
+                input = decoded
+            } else {
+                throw SelectiveRemoteTeamHostMaterializationError.invalidHostRecord
+            }
+
+            return SelectiveRemoteTeamHost(
+                id: scopedID(
+                    teamID: snapshot.teamID,
+                    vaultID: snapshot.vaultID,
+                    recordID: record.id
+                ),
+                recordID: record.id,
+                teamID: snapshot.teamID,
+                teamName: snapshot.teamName,
+                role: snapshot.role,
+                vaultID: snapshot.vaultID,
+                vaultName: snapshot.vaultName,
+                revision: snapshot.revision,
+                keyGeneration: snapshot.keyGeneration,
+                modifiedAt: record.modifiedAt,
+                address: address,
+                profile: try sanitized(
+                    input,
+                    title: title,
+                    runtimeID: scopedID(
+                        teamID: snapshot.teamID,
+                        vaultID: snapshot.vaultID,
+                        recordID: record.id
+                    )
+                )
+            )
+        }
+    }
+
+    static func scopedID(teamID: UUID, vaultID: UUID, recordID: UUID) -> UUID {
+        let scope = [
+            "selective-remote/team-host/v1",
+            teamID.canonicalCloudString,
+            vaultID.canonicalCloudString,
+            recordID.canonicalCloudString
+        ].joined(separator: "\u{0}")
+        var bytes = Array(SHA256.hash(data: Data(scope.utf8)).prefix(16))
+        bytes[6] = (bytes[6] & 0x0f) | 0x50
+        bytes[8] = (bytes[8] & 0x3f) | 0x80
+        return UUID(uuid: (
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[12], bytes[13], bytes[14], bytes[15]
+        ))
+    }
+
+    private static func browserProfile(
+        recordID: UUID,
+        title: String,
+        address: String
+    ) throws -> ConnectionProfile {
+        var profile = ConnectionProfile(connectionType: .rdp)
+        profile.id = recordID
+        profile.friendlyName = title
+
+        guard address.contains("://") else {
+            profile.host = address
+            return profile
+        }
+        guard let components = URLComponents(string: address),
+              let scheme = components.scheme?.lowercased(),
+              components.password == nil,
+              components.query == nil,
+              components.fragment == nil
+        else { throw SelectiveRemoteTeamHostMaterializationError.invalidHostRecord }
+
+        switch scheme {
+        case "rdp", "ssh", "telnet":
+            guard let host = components.host,
+                  !host.isEmpty,
+                  components.path.isEmpty || components.path == "/"
+            else { throw SelectiveRemoteTeamHostMaterializationError.invalidHostRecord }
+            let username = components.user ?? ""
+            if scheme == "rdp" {
+                profile.connectionType = .rdp
+                profile.host = addressHost(host, port: components.port)
+                profile.username = username
+            } else if scheme == "ssh" {
+                profile.connectionType = .ssh
+                profile.host = host
+                profile.username = username
+                profile.sshPort = components.port ?? 22
+            } else {
+                profile.connectionType = .telnet
+                profile.host = host
+                profile.sshPort = components.port ?? 23
+            }
+        case "serial":
+            guard components.host == nil,
+                  components.user == nil,
+                  components.port == nil,
+                  components.path.hasPrefix("/dev/cu.")
+            else { throw SelectiveRemoteTeamHostMaterializationError.invalidHostRecord }
+            profile.connectionType = .serial
+            profile.serialDevicePath = components.path
+        default:
+            throw SelectiveRemoteTeamHostMaterializationError.invalidHostRecord
+        }
+        return profile
+    }
+
+    private static func sanitized(
+        _ input: ConnectionProfile,
+        title: String,
+        runtimeID: UUID
+    ) throws -> ConnectionProfile {
+        guard input.id.isSelectiveRemoteCloudUUID,
+              input.username.utf8.count <= 256,
+              !input.username.contains(where: { $0.isNewline }),
+              input.gatewayHost.utf8.count <= 2_048,
+              input.gatewayUsername.utf8.count <= 256,
+              !input.gatewayHost.contains(where: { $0.isNewline }),
+              !input.gatewayUsername.contains(where: { $0.isNewline })
+        else { throw SelectiveRemoteTeamHostMaterializationError.invalidHostRecord }
+
+        switch input.connectionType {
+        case .rdp:
+            guard validEndpoint(input.host) else {
+                throw SelectiveRemoteTeamHostMaterializationError.invalidHostRecord
+            }
+        case .ssh, .telnet:
+            guard validEndpoint(input.host), (1 ... 65_535).contains(input.sshPort) else {
+                throw SelectiveRemoteTeamHostMaterializationError.invalidHostRecord
+            }
+        case .serial:
+            guard input.serialDevicePath.hasPrefix("/dev/cu."),
+                  input.serialDevicePath.utf8.count <= 2_048,
+                  !input.serialDevicePath.contains(where: { $0.isNewline }),
+                  TerminalTransportService.supportedBaudRates.contains(input.serialBaudRate),
+                  (5 ... 8).contains(input.serialDataBits),
+                  (1 ... 2).contains(input.serialStopBits)
+            else { throw SelectiveRemoteTeamHostMaterializationError.invalidHostRecord }
+        }
+
+        var safe = ConnectionProfile(connectionType: input.connectionType)
+        safe.id = runtimeID
+        safe.friendlyName = title
+        safe.host = input.host
+        safe.username = input.username
+        safe.sshPort = input.sshPort
+        safe.sshTerminalProtocol = .ssh
+        safe.sshAuthenticationMode = .automatic
+        safe.sshHostKeyPolicy = input.sshHostKeyPolicy
+        safe.sshCompression = input.sshCompression
+        safe.sshKeepAliveSeconds = min(max(input.sshKeepAliveSeconds, 0), 3_600)
+        safe.serialDevicePath = input.serialDevicePath
+        safe.serialBaudRate = input.serialBaudRate
+        safe.serialDataBits = input.serialDataBits
+        safe.serialParity = input.serialParity
+        safe.serialStopBits = input.serialStopBits
+        safe.serialFlowControl = input.serialFlowControl
+        safe.gatewayHost = input.gatewayHost
+        safe.gatewayUsername = input.gatewayUsername
+        safe.windowsScale = input.windowsScale
+        safe.rdpQuality = input.rdpQuality
+        safe.certificatePolicy = input.certificatePolicy == .ignore
+            ? .trustOnFirstUse
+            : input.certificatePolicy
+        safe.clipboardMode = .disabled
+        safe.audioMode = .muted
+        safe.redirectMicrophone = false
+        safe.redirectCamera = false
+        safe.redirectPrinters = false
+        safe.redirectedFolders = []
+        safe.sshIdentityID = nil
+        safe.sshProxyMode = .none
+        safe.sshProxyHost = ""
+        safe.sshProxyUsername = ""
+        safe.sshJumpHostProfileID = nil
+        safe.sshAgentForwarding = false
+        safe.sshStartupSnippetID = nil
+        safe.sshStartupSnippetMode = .disabled
+        safe.sshStartupSnippetAfterReconnect = false
+        safe.terminalVariables = []
+        safe.portForwards = []
+        safe.selectedDisplayIDs = []
+        safe.primaryDisplayID = nil
+        safe.displayLayoutMode = .automatic
+        safe.virtualDisplayOrigins = [:]
+        safe.customKeyMappings = []
+        safe.isFavorite = false
+        safe.autoReconnect = false
+        safe.reconnectAfterWake = false
+        safe.adminSession = false
+        safe.startFullScreen = false
+        safe.rdpWindowMode = .fixedWindow
+        safe.windowWidth = min(max(input.windowWidth, 640), 16_384)
+        safe.windowHeight = min(max(input.windowHeight, 480), 16_384)
+        safe.detectedOperatingSystem = ""
+        safe.detectedOperatingSystemID = ""
+        safe.detectedOperatingSystemLike = ""
+        safe.operatingSystemDetectedAt = nil
+        safe.group = ""
+        safe.tags = []
+        safe.profileDescription = ""
+        safe.createdAt = Date(timeIntervalSince1970: 0)
+        safe.lastConnectedAt = nil
+        return safe
+    }
+
+    private static func exportedAddress(_ profile: ConnectionProfile) -> String {
+        profile.connectionType == .serial ? profile.serialDevicePath : profile.host
+    }
+
+    private static func exportedTitle(_ profile: ConnectionProfile, address: String) -> String {
+        let normalized = profile.friendlyName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return String((normalized.isEmpty ? address : normalized).prefix(120))
+    }
+
+    private static func addressHost(_ host: String, port: Int?) -> String {
+        let value = host.contains(":") ? "[\(host)]" : host
+        return port.map { "\(value):\($0)" } ?? value
+    }
+
+    private static func string(_ value: SelectiveRemoteJSONValue?) -> String? {
+        guard case let .string(result) = value else { return nil }
+        return result
+    }
+
+    private static func validName(_ value: String) -> Bool {
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !normalized.isEmpty
+            && normalized == value
+            && value.utf8.count <= 120
+            && !value.contains(where: { $0.isNewline })
+    }
+
+    private static func validTitle(_ value: String) -> Bool {
+        validName(value)
+    }
+
+    private static func validAddress(_ value: String) -> Bool {
+        validEndpoint(value)
+    }
+
+    private static func validEndpoint(_ value: String) -> Bool {
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !normalized.isEmpty
+            && normalized == value
+            && value.utf8.count <= 2_048
+            && !value.contains(where: { $0.isNewline })
+    }
+}
+
+@MainActor
+final class SelectiveRemoteTeamHostStore: ObservableObject {
+    static let shared = SelectiveRemoteTeamHostStore()
+
+    @Published private(set) var hosts: [SelectiveRemoteTeamHost] = []
+    @Published private(set) var lastUpdatedAt: Date?
+    @Published private(set) var synchronizedVaultCount = 0
+    @Published private(set) var invalidVaultCount = 0
+
+    init() {}
+
+    func replace(
+        with snapshots: [SelectiveRemoteTeamVaultMaterializedSnapshot],
+        now: Date = Date()
+    ) {
+        var next: [SelectiveRemoteTeamHost] = []
+        var invalid = 0
+        for snapshot in snapshots {
+            do {
+                next += try SelectiveRemoteTeamHostMaterializer.materialize(snapshot)
+            } catch {
+                invalid += 1
+            }
+        }
+        hosts = next.sorted {
+            let left = [$0.teamName, $0.vaultName, $0.profile.friendlyName]
+                .map { $0.localizedLowercase }
+            let right = [$1.teamName, $1.vaultName, $1.profile.friendlyName]
+                .map { $0.localizedLowercase }
+            return left == right
+                ? $0.recordID.canonicalCloudString < $1.recordID.canonicalCloudString
+                : left.lexicographicallyPrecedes(right)
+        }
+        synchronizedVaultCount = snapshots.count - invalid
+        invalidVaultCount = invalid
+        lastUpdatedAt = now
+    }
+
+    func clear() {
+        hosts = []
+        synchronizedVaultCount = 0
+        invalidVaultCount = 0
+        lastUpdatedAt = nil
+    }
+}
+
+struct SelectiveRemoteTeamHostsView: View {
+    @ObservedObject var store: SelectiveRemoteTeamHostStore
+    @ObservedObject var model: AppModel
+    let onOpenTerminal: (SelectiveRemoteTeamHost, String, String?) -> Void
+
+    @State private var selectedHostID: UUID?
+    @State private var username = ""
+    @State private var password = ""
+    @State private var gatewayPassword = ""
+
+    private var selectedHost: SelectiveRemoteTeamHost? {
+        store.hosts.first(where: { $0.id == selectedHostID })
+    }
+
+    var body: some View {
+        HSplitView {
+            VStack(spacing: 0) {
+                if store.hosts.isEmpty {
+                    ContentUnavailableView(
+                        UpdateLocalization.text(
+                            ru: "Team Hosts пока не синхронизированы",
+                            en: "Team Hosts have not synchronized yet"
+                        ),
+                        systemImage: "person.2.slash",
+                        description: Text(UpdateLocalization.text(
+                            ru: "Разблокируйте приложение и дождитесь безопасного Team Vault sync.",
+                            en: "Unlock the app and wait for a safe Team Vault sync."
+                        ))
+                    )
+                } else {
+                    List(store.hosts, selection: $selectedHostID) { host in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Label(
+                                host.profile.friendlyName,
+                                systemImage: host.profile.connectionType.systemImage
+                            )
+                            .font(.headline)
+                            HStack(spacing: 5) {
+                                Text(host.teamName)
+                                Text("·")
+                                Text(host.vaultName)
+                                Text("·")
+                                Text(host.profile.connectionType.title)
+                            }
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            Text(host.address)
+                                .font(.caption.monospaced())
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                        .padding(.vertical, 4)
+                        .tag(host.id)
+                    }
+                    .listStyle(.sidebar)
+                }
+
+                Divider()
+                HStack(spacing: 8) {
+                    Label(
+                        "\(store.hosts.count)",
+                        systemImage: "externaldrive.connected.to.line.below"
+                    )
+                    if let lastUpdatedAt = store.lastUpdatedAt {
+                        Text(lastUpdatedAt, style: .time)
+                    }
+                    Spacer()
+                    if store.invalidVaultCount > 0 {
+                        Label(
+                            "\(store.invalidVaultCount)",
+                            systemImage: "exclamationmark.triangle.fill"
+                        )
+                        .foregroundStyle(.orange)
+                        .help(UpdateLocalization.text(
+                            ru: "Некорректные Team Vaults скрыты целиком",
+                            en: "Invalid Team Vaults are hidden in full"
+                        ))
+                    }
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(10)
+            }
+            .frame(minWidth: 290, idealWidth: 350, maxWidth: 440)
+
+            Group {
+                if let host = selectedHost {
+                    hostDetail(host)
+                } else {
+                    ContentUnavailableView(
+                        UpdateLocalization.text(ru: "Выберите Team Host", en: "Select a Team Host"),
+                        systemImage: "person.2"
+                    )
+                }
+            }
+            .frame(minWidth: 480, maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .onAppear { normalizeSelection() }
+        .onChange(of: store.hosts.map(\.id)) { _, _ in normalizeSelection() }
+        .onChange(of: selectedHostID) { _, _ in resetConnectionFields() }
+    }
+
+    private func hostDetail(_ host: SelectiveRemoteTeamHost) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                HStack(alignment: .top, spacing: 14) {
+                    Image(systemName: host.profile.connectionType.systemImage)
+                        .font(.system(size: 28, weight: .semibold))
+                        .foregroundStyle(Color.accentColor)
+                        .frame(width: 54, height: 54)
+                        .background(Color.accentColor.opacity(0.12), in: RoundedRectangle(cornerRadius: 14))
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(host.profile.friendlyName)
+                            .font(.title2.bold())
+                        Text(host.address)
+                            .font(.body.monospaced())
+                            .textSelection(.enabled)
+                    }
+                    Spacer()
+                    Text(roleTitle(host.role))
+                        .font(.caption.bold())
+                        .padding(.horizontal, 9)
+                        .padding(.vertical, 5)
+                        .background(.secondary.opacity(0.12), in: Capsule())
+                }
+
+                GroupBox(UpdateLocalization.text(ru: "Общий ресурс", en: "Shared Resource")) {
+                    VStack(alignment: .leading, spacing: 9) {
+                        LabeledContent("Team", value: host.teamName)
+                        LabeledContent("Vault", value: host.vaultName)
+                        LabeledContent(
+                            UpdateLocalization.text(ru: "Ревизия", en: "Revision"),
+                            value: "\(host.revision)"
+                        )
+                        LabeledContent(
+                            UpdateLocalization.text(ru: "Поколение ключа", en: "Key Generation"),
+                            value: "\(host.keyGeneration)"
+                        )
+                    }
+                    .padding(6)
+                }
+
+                GroupBox(UpdateLocalization.text(ru: "Подключение", en: "Connection")) {
+                    VStack(alignment: .leading, spacing: 12) {
+                        if host.profile.connectionType == .rdp
+                            || host.profile.connectionType == .ssh {
+                            TextField(
+                                UpdateLocalization.text(ru: "Пользователь", en: "Username"),
+                                text: $username
+                            )
+                            .textFieldStyle(.roundedBorder)
+                        }
+                        if host.profile.connectionType == .rdp
+                            || host.profile.connectionType == .ssh {
+                            SecureField(
+                                host.profile.connectionType == .rdp
+                                    ? UpdateLocalization.text(
+                                        ru: "Пароль RDP (не сохраняется)",
+                                        en: "RDP Password (not saved)"
+                                    )
+                                    : UpdateLocalization.text(
+                                        ru: "Пароль SSH, если нужен (не сохраняется)",
+                                        en: "SSH Password, if needed (not saved)"
+                                    ),
+                                text: $password
+                            )
+                            .textFieldStyle(.roundedBorder)
+                        }
+                        if host.profile.connectionType == .rdp,
+                           !host.profile.gatewayHost.isEmpty {
+                            SecureField(
+                                UpdateLocalization.text(
+                                    ru: "Пароль Gateway (не сохраняется)",
+                                    en: "Gateway Password (not saved)"
+                                ),
+                                text: $gatewayPassword
+                            )
+                            .textFieldStyle(.roundedBorder)
+                        }
+
+                        HStack {
+                            if host.profile.connectionType == .rdp,
+                               model.isSessionRunning(profileID: host.id) {
+                                Button(
+                                    UpdateLocalization.text(ru: "Отключить", en: "Disconnect"),
+                                    role: .destructive
+                                ) {
+                                    model.disconnect(profileID: host.id)
+                                }
+                            } else {
+                                Button(
+                                    connectionButtonTitle(host.profile.connectionType),
+                                    systemImage: host.profile.connectionType == .rdp
+                                        ? "play.fill"
+                                        : "terminal"
+                                ) {
+                                    connect(host)
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .disabled(
+                                    host.profile.connectionType == .rdp
+                                        && password.isEmpty
+                                )
+                            }
+                            Spacer()
+                        }
+
+                        Label(
+                            UpdateLocalization.text(
+                                ru: "Проекция только для чтения: профиль не добавляется в Personal Vault, введённые пароли не сохраняются.",
+                                en: "Read-only projection: the profile is not added to Personal Vault and entered passwords are not saved."
+                            ),
+                            systemImage: "lock.shield"
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
+                    .padding(6)
+                }
+            }
+            .frame(maxWidth: 900, alignment: .leading)
+            .padding(24)
+        }
+    }
+
+    private func connect(_ host: SelectiveRemoteTeamHost) {
+        var profile = host.profile
+        profile.username = username
+        if profile.connectionType == .rdp {
+            model.connectTeamHost(
+                profile,
+                password: password,
+                gatewayPassword: gatewayPassword
+            )
+        } else {
+            onOpenTerminal(host, username, password.isEmpty ? nil : password)
+        }
+        password = ""
+        gatewayPassword = ""
+    }
+
+    private func normalizeSelection() {
+        if let selectedHostID,
+           store.hosts.contains(where: { $0.id == selectedHostID }) {
+            return
+        }
+        self.selectedHostID = store.hosts.first?.id
+        resetConnectionFields()
+    }
+
+    private func resetConnectionFields() {
+        username = selectedHost?.profile.username ?? ""
+        password = ""
+        gatewayPassword = ""
+    }
+
+    private func roleTitle(_ role: SelectiveRemoteCloudTeamRole) -> String {
+        switch role {
+        case .owner: "Owner"
+        case .admin: "Admin"
+        case .editor: "Editor"
+        case .viewer: "Viewer"
+        }
+    }
+
+    private func connectionButtonTitle(_ type: ConnectionType) -> String {
+        switch type {
+        case .rdp: UpdateLocalization.text(ru: "Подключить RDP", en: "Connect RDP")
+        case .ssh: UpdateLocalization.text(ru: "Открыть SSH", en: "Open SSH")
+        case .telnet: UpdateLocalization.text(ru: "Открыть Telnet", en: "Open Telnet")
+        case .serial: UpdateLocalization.text(ru: "Открыть Serial", en: "Open Serial")
+        }
+    }
+}

--- a/Sources/SelectiveRemote/CloudTeamVaultAutoSync.swift
+++ b/Sources/SelectiveRemote/CloudTeamVaultAutoSync.swift
@@ -23,10 +23,14 @@ struct SelectiveRemoteTeamVaultAutoSyncReport: Equatable, Sendable {
 typealias SelectiveRemoteTeamVaultSnapshotStoreFactory =
     @Sendable () throws -> any SelectiveRemoteTeamVaultSnapshotStore
 
+typealias SelectiveRemoteTeamVaultMaterializedSnapshotConsumer =
+    @Sendable ([SelectiveRemoteTeamVaultMaterializedSnapshot]) async -> Void
+
 actor SelectiveRemoteTeamVaultAutoSync {
     private let remote: any SelectiveRemoteTeamVaultAutoSyncRemote
     private let identityManager: SelectiveRemoteTeamDeviceIdentityManager
     private let snapshotStore: SelectiveRemoteTeamVaultSnapshotStoreFactory
+    private let snapshotConsumer: SelectiveRemoteTeamVaultMaterializedSnapshotConsumer
     private let pollInterval: Duration
     private var cycle: Task<Void, Never>?
 
@@ -36,11 +40,15 @@ actor SelectiveRemoteTeamVaultAutoSync {
         snapshotStore: @escaping SelectiveRemoteTeamVaultSnapshotStoreFactory = {
             try SelectiveRemoteTeamVaultFileSnapshotStore()
         },
+        snapshotConsumer: @escaping SelectiveRemoteTeamVaultMaterializedSnapshotConsumer = {
+            await SelectiveRemoteTeamHostStore.shared.replace(with: $0)
+        },
         pollInterval: Duration = .seconds(15)
     ) {
         self.remote = remote
         self.identityManager = identityManager
         self.snapshotStore = snapshotStore
+        self.snapshotConsumer = snapshotConsumer
         self.pollInterval = pollInterval
     }
 
@@ -51,9 +59,10 @@ actor SelectiveRemoteTeamVaultAutoSync {
         }
     }
 
-    func stop() {
+    func stop() async {
         cycle?.cancel()
         cycle = nil
+        await snapshotConsumer([])
     }
 
     func synchronizeOnce(
@@ -65,10 +74,14 @@ actor SelectiveRemoteTeamVaultAutoSync {
             throw SelectiveRemoteCloudError.invalidRequest
         }
         var report = SelectiveRemoteTeamVaultAutoSyncReport()
-        guard await remote.hasStoredSession(endpoint: endpoint) else { return report }
+        guard await remote.hasStoredSession(endpoint: endpoint) else {
+            await snapshotConsumer([])
+            return report
+        }
 
         let identity = try await identityManager.identity(endpoint: endpoint, deviceID: deviceID)
         let teams = try await remote.teams(endpoint: endpoint)
+        var materialized: [SelectiveRemoteTeamVaultMaterializedSnapshot] = []
         for team in teams {
             try Task.checkCancellation()
             let vaults: [SelectiveRemoteCloudSharedVault]
@@ -108,8 +121,13 @@ actor SelectiveRemoteTeamVaultAutoSync {
                     switch refreshed {
                     case .empty:
                         report.emptyVaults += 1
-                    case .synchronized:
+                    case let .synchronized(value):
                         report.synchronizedVaults += 1
+                        materialized.append(Self.materializedSnapshot(
+                            team: team,
+                            vault: vault,
+                            value: value
+                        ))
                     case .localChanges:
                         let pushed = try await coordinator.push(
                             teamID: team.id,
@@ -117,8 +135,13 @@ actor SelectiveRemoteTeamVaultAutoSync {
                             identity: identity
                         )
                         switch pushed {
-                        case .uploaded:
+                        case let .uploaded(value):
                             report.uploadedVaults += 1
+                            materialized.append(Self.materializedSnapshot(
+                                team: team,
+                                vault: vault,
+                                value: value
+                            ))
                         case .conflict:
                             report.conflicts += 1
                         }
@@ -136,7 +159,26 @@ actor SelectiveRemoteTeamVaultAutoSync {
                 }
             }
         }
+        try Task.checkCancellation()
+        await snapshotConsumer(materialized)
         return report
+    }
+
+    private static func materializedSnapshot(
+        team: SelectiveRemoteCloudTeam,
+        vault: SelectiveRemoteCloudSharedVault,
+        value: SelectiveRemoteTeamVaultDecryptedSnapshot
+    ) -> SelectiveRemoteTeamVaultMaterializedSnapshot {
+        .init(
+            teamID: team.id,
+            teamName: team.name,
+            role: team.role,
+            vaultID: vault.id,
+            vaultName: vault.name,
+            revision: value.snapshot.serverRevision,
+            keyGeneration: value.snapshot.keyGeneration,
+            payload: value.payload
+        )
     }
 
     private func runLoop() async {
@@ -147,6 +189,8 @@ actor SelectiveRemoteTeamVaultAutoSync {
                         endpoint: account.endpoint,
                         deviceID: account.deviceID
                     )
+                } else {
+                    await snapshotConsumer([])
                 }
                 try await Task.sleep(for: pollInterval)
             } catch is CancellationError {

--- a/Sources/SelectiveRemote/CloudTeamVaultAutoSync.swift
+++ b/Sources/SelectiveRemote/CloudTeamVaultAutoSync.swift
@@ -41,7 +41,7 @@ actor SelectiveRemoteTeamVaultAutoSync {
             try SelectiveRemoteTeamVaultFileSnapshotStore()
         },
         snapshotConsumer: @escaping SelectiveRemoteTeamVaultMaterializedSnapshotConsumer = {
-            await SelectiveRemoteTeamHostStore.shared.replace(with: $0)
+            SelectiveRemoteTeamHostStore.shared.replace(with: $0)
         },
         pollInterval: Duration = .seconds(15)
     ) {

--- a/Sources/SelectiveRemote/ContentView.swift
+++ b/Sources/SelectiveRemote/ContentView.swift
@@ -35,6 +35,7 @@ private enum ProfileTab: String, CaseIterable, Identifiable {
 private enum MainArea: String, CaseIterable, Identifiable {
     case connectionCenter = "Connection Center"
     case connections = "Подключения"
+    case teamHosts = "Team Hosts"
     case ssh = "SSH"
     case terminal = "Терминал"
     case sftp = "SFTP"
@@ -54,6 +55,7 @@ private enum MainArea: String, CaseIterable, Identifiable {
             en: "Connection Center"
         )
         case .connections: UpdateLocalization.text(ru: "Подключения", en: "Connections")
+        case .teamHosts: "Team Hosts"
         case .ssh: "SSH"
         case .terminal: UpdateLocalization.text(ru: "Терминал", en: "Terminal")
         case .sftp: UpdateLocalization.text(ru: "Файлы SFTP", en: "SFTP")
@@ -73,6 +75,7 @@ private enum MainArea: String, CaseIterable, Identifiable {
         switch self {
         case .connectionCenter: "point.3.connected.trianglepath.dotted"
         case .connections: "rectangle.stack"
+        case .teamHosts: "person.2.fill"
         case .snippets: "curlybraces"
         case .sessionLogs: "doc.text.magnifyingglass"
         case .activity: "clock.arrow.circlepath"
@@ -104,6 +107,7 @@ struct ContentView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @StateObject private var terminalAppearance = TerminalAppearanceStore()
     @StateObject private var snippets = TerminalCommandHistoryStore.shared
+    @StateObject private var teamHosts = SelectiveRemoteTeamHostStore.shared
     @State private var selectedTab = ProfileTab.general
     @State private var profileTabs: [UUID: ProfileTab] = [:]
     @State private var mainArea = MainArea.connectionCenter
@@ -472,6 +476,11 @@ struct ContentView: View {
                                 .frame(width: 22)
                             Text(area.title)
                             Spacer()
+                            if area == .teamHosts, !teamHosts.hosts.isEmpty {
+                                Text("\(teamHosts.hosts.count)")
+                                    .font(.caption.bold())
+                                    .foregroundStyle(Color.accentColor)
+                            }
                             if area == .ssh,
                                model.globalTerminalWorkspace().runningSessionCount > 0 {
                                 Text("\(model.globalTerminalWorkspace().runningSessionCount)")
@@ -847,6 +856,12 @@ struct ContentView: View {
                 connectionCenterDetail
             case .connections:
                 profileDetail
+            case .teamHosts:
+                SelectiveRemoteTeamHostsView(
+                    store: teamHosts,
+                    model: model,
+                    onOpenTerminal: openTeamTerminal
+                )
             case .snippets:
                 TerminalSnippetsLibraryView(
                     store: snippets,
@@ -2489,6 +2504,59 @@ struct ContentView: View {
             return
         }
         model.connectSSHTerminal(
+            connection: connection,
+            tabID: tab.id,
+            session: tab.session,
+            temporaryPassword: temporaryPassword
+        )
+        setMainArea(.ssh)
+    }
+
+    private func openTeamTerminal(
+        _ host: SelectiveRemoteTeamHost,
+        username: String,
+        temporaryPassword: String?
+    ) {
+        let profile = host.profile
+        let connection: TerminalTabConnection
+        switch profile.connectionType {
+        case .rdp:
+            return
+        case .ssh:
+            connection = .custom(
+                host: profile.host,
+                username: username,
+                port: profile.sshPort,
+                authenticationMode: temporaryPassword == nil ? .automatic : .password,
+                identityID: nil,
+                jumpHostProfileID: nil
+            )
+        case .telnet:
+            connection = .telnet(host: profile.host, port: profile.sshPort)
+        case .serial:
+            connection = .serial(
+                devicePath: profile.serialDevicePath,
+                baudRate: profile.serialBaudRate,
+                dataBits: profile.serialDataBits,
+                parity: profile.serialParity,
+                stopBits: profile.serialStopBits,
+                flowControl: profile.serialFlowControl
+            )
+        }
+
+        let workspace = model.globalTerminalWorkspace()
+        guard let tab = workspace.addTab(
+            connection: connection,
+            title: "\(host.teamName) · \(profile.friendlyName)",
+            ephemeral: true
+        ) else {
+            model.errorMessage = UpdateLocalization.text(
+                ru: "Достигнут лимит вкладок Terminal Workspace",
+                en: "The Terminal Workspace tab limit has been reached"
+            )
+            return
+        }
+        model.connectTerminal(
             connection: connection,
             tabID: tab.id,
             session: tab.session,

--- a/Sources/SelectiveRemote/TerminalWorkspace.swift
+++ b/Sources/SelectiveRemote/TerminalWorkspace.swift
@@ -348,6 +348,7 @@ struct TerminalWorkspaceTab: Identifiable {
     var connection: TerminalTabConnection
     var isPinned: Bool
     var colorIndex: Int
+    var isEphemeral: Bool
     let appearance: TerminalAppearanceStore
 
     @MainActor
@@ -359,6 +360,7 @@ struct TerminalWorkspaceTab: Identifiable {
         connection: TerminalTabConnection,
         isPinned: Bool,
         colorIndex: Int,
+        isEphemeral: Bool = false,
         appearanceDefaults: UserDefaults = .standard
     ) {
         self.id = id
@@ -368,6 +370,7 @@ struct TerminalWorkspaceTab: Identifiable {
         self.connection = connection
         self.isPinned = isPinned
         self.colorIndex = colorIndex
+        self.isEphemeral = isEphemeral
         appearance = TerminalAppearanceStore(
             defaults: appearanceDefaults,
             storageNamespace: "pane.\(id.uuidString)",
@@ -572,7 +575,8 @@ final class TerminalWorkspaceModel: ObservableObject {
     func addTab(
         connection: TerminalTabConnection? = nil,
         title: String? = nil,
-        select: Bool = true
+        select: Bool = true,
+        ephemeral: Bool = false
     ) -> TerminalWorkspaceTab? {
         if isEmptyState {
             let resolvedConnection = connection ?? .savedProfile(profileID)
@@ -581,6 +585,7 @@ final class TerminalWorkspaceModel: ObservableObject {
                 title ?? "Терминал 1",
                 fallback: "Терминал 1"
             )
+            tabs[0].isEphemeral = ephemeral
             selectedTabID = tabs[0].id
             persist()
             objectWillChange.send()
@@ -598,6 +603,7 @@ final class TerminalWorkspaceModel: ObservableObject {
             connection: connection ?? .savedProfile(profileID),
             isPinned: false,
             colorIndex: tabs.count % 6,
+            isEphemeral: ephemeral,
             appearanceDefaults: defaults
         )
         tabs.append(tab)
@@ -614,7 +620,8 @@ final class TerminalWorkspaceModel: ObservableObject {
         let baseTitle = source.title.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let created = addTab(
             connection: source.connection,
-            title: baseTitle.isEmpty ? "Копия терминала" : "\(baseTitle) · копия"
+            title: baseTitle.isEmpty ? "Копия терминала" : "\(baseTitle) · копия",
+            ephemeral: source.isEphemeral
         ) else { return nil }
         if let index = tabs.firstIndex(where: { $0.id == created.id }) {
             tabs[index].colorIndex = source.colorIndex
@@ -648,6 +655,7 @@ final class TerminalWorkspaceModel: ObservableObject {
             tabs[0].title = "Новый терминал"
             tabs[0].connection = .custom(host: "", username: "")
             tabs[0].isPrimary = true
+            tabs[0].isEphemeral = false
             layout = .single
             secondaryTabID = nil
             persist()
@@ -749,7 +757,7 @@ final class TerminalWorkspaceModel: ObservableObject {
 
     func workspaceSnapshot() -> TerminalWorkspaceSnapshot {
         TerminalWorkspaceSnapshot(
-            tabs: tabs.map { tab in
+            tabs: tabs.filter { !$0.isEphemeral }.map { tab in
                 TerminalWorkspaceSnapshot.Tab(
                     id: tab.id,
                     title: tab.title,
@@ -886,7 +894,7 @@ final class TerminalWorkspaceModel: ObservableObject {
     private func persist() {
         guard !isRestoring else { return }
         let value = StoredTerminalWorkspace(
-            tabs: tabs.map {
+            tabs: tabs.filter { !$0.isEphemeral }.map {
                 StoredTerminalWorkspace.Tab(
                     id: $0.id,
                     title: $0.title,

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -732,10 +732,12 @@ struct CloudMacOSFoundationTests {
             deviceID: deviceID
         )
         let snapshots = SelectiveRemoteTeamVaultMemorySnapshotStore()
+        let materialized = TeamVaultMaterializedSnapshotSink()
         let autoSync = SelectiveRemoteTeamVaultAutoSync(
             remote: remote,
             identityManager: SelectiveRemoteTeamDeviceIdentityManager(store: keyStore),
-            snapshotStore: { snapshots }
+            snapshotStore: { snapshots },
+            snapshotConsumer: { await materialized.replace(with: $0) }
         )
 
         let report = try await autoSync.synchronizeOnce(
@@ -748,6 +750,13 @@ struct CloudMacOSFoundationTests {
         #expect(report.pendingWrappers == 0)
         #expect(report.failures == 0)
         #expect(try snapshots.load(endpoint: endpoint, teamID: teamID, vaultID: vaultID) != nil)
+        let published = await materialized.snapshots()
+        #expect(published.count == 1)
+        #expect(published.first?.teamID == teamID)
+        #expect(published.first?.vaultID == vaultID)
+        #expect(published.first?.role == .viewer)
+        let expectedPayload = try fixture.payload.plaintext.base64URLData
+        #expect(published.first?.payload == expectedPayload)
     }
 
     @Test("Team Vault coordinator stages and acknowledges one causal upload")
@@ -1675,5 +1684,18 @@ private extension Data {
             .replacingOccurrences(of: "+", with: "-")
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+
+private actor TeamVaultMaterializedSnapshotSink {
+    private var values: [SelectiveRemoteTeamVaultMaterializedSnapshot] = []
+
+    func replace(with snapshots: [SelectiveRemoteTeamVaultMaterializedSnapshot]) {
+        values = snapshots
+    }
+
+    func snapshots() -> [SelectiveRemoteTeamVaultMaterializedSnapshot] {
+        values
     }
 }

--- a/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Testing
+@testable import SelectiveRemote
+
+@Suite("macOS Team Host materialization")
+struct CloudTeamHostsTests {
+    @MainActor
+    @Test("browser and macOS host records materialize into one separate read-only projection")
+    func crossClientFixture() throws {
+        let payload = try Self.fixtureData()
+        let document = try SelectiveRemoteVaultDocument.decode(payload)
+        #expect(document.records.count == 2)
+
+        let store = SelectiveRemoteTeamHostStore()
+        store.replace(with: [Self.snapshot(payload: payload)])
+
+        #expect(store.synchronizedVaultCount == 1)
+        #expect(store.invalidVaultCount == 0)
+        #expect(store.hosts.count == 2)
+
+        let browser = try #require(store.hosts.first {
+            $0.recordID.uuidString.lowercased() == "33333333-3333-4333-8333-333333333333"
+        })
+        #expect(browser.profile.connectionType == .ssh)
+        #expect(browser.profile.host == "bastion.example.invalid")
+        #expect(browser.profile.username == "deployer")
+        #expect(browser.profile.sshPort == 2_222)
+        #expect(browser.id != browser.recordID)
+
+        let mac = try #require(store.hosts.first {
+            $0.recordID.uuidString.lowercased() == "77777777-7777-4777-8777-777777777777"
+        })
+        #expect(mac.profile.connectionType == .rdp)
+        #expect(mac.profile.host == "rdp.example.invalid")
+        #expect(mac.profile.username == "operator")
+        #expect(mac.profile.clipboardMode == .disabled)
+        #expect(mac.profile.audioMode == .muted)
+        #expect(mac.profile.redirectedFolders.isEmpty)
+        #expect(mac.id != mac.recordID)
+    }
+
+    @MainActor
+    @Test("rich Team hosts discard Personal references and unsafe device settings")
+    func sanitizesMacOSProfile() throws {
+        let profileID = try #require(
+            UUID(uuidString: "88888888-8888-4888-8888-888888888888")
+        )
+        let deviceID = try #require(
+            UUID(uuidString: "44444444-4444-4444-8444-444444444444")
+        )
+        var profile = ConnectionProfile(connectionType: .ssh)
+        profile.id = profileID
+        profile.friendlyName = "Operations SSH"
+        profile.host = "ops.example.invalid"
+        profile.username = "operator"
+        profile.sshPort = 2_222
+        profile.sshIdentityID = UUID()
+        profile.sshJumpHostProfileID = UUID()
+        profile.sshProxyMode = .socks5
+        profile.sshProxyHost = "localhost"
+        profile.sshAgentForwarding = true
+        profile.redirectMicrophone = true
+        profile.redirectCamera = true
+        profile.redirectPrinters = true
+        profile.redirectedFolders = ["/Users/example/Secrets"]
+        profile.clipboardMode = .bidirectional
+        profile.audioMode = .local
+        profile.autoReconnect = true
+        profile.reconnectAfterWake = true
+        profile.adminSession = true
+        profile.certificatePolicy = .ignore
+
+        let personalProfiles = [profile]
+        let exported = try SelectiveRemotePersonalVaultExporter.makeExport(
+            profiles: personalProfiles,
+            credentials: [],
+            snippets: [],
+            forwarding: [],
+            deviceID: deviceID
+        )
+        let store = SelectiveRemoteTeamHostStore()
+        let snapshot = Self.snapshot(payload: try exported.document.encoded())
+        store.replace(with: [snapshot])
+
+        let host = try #require(store.hosts.first)
+        let firstRuntimeID = host.id
+        #expect(host.recordID == profileID)
+        #expect(host.id != profileID)
+        #expect(host.profile.sshIdentityID == nil)
+        #expect(host.profile.sshJumpHostProfileID == nil)
+        #expect(host.profile.sshProxyMode == .none)
+        #expect(host.profile.sshProxyHost.isEmpty)
+        #expect(host.profile.sshAgentForwarding == false)
+        #expect(host.profile.redirectMicrophone == false)
+        #expect(host.profile.redirectCamera == false)
+        #expect(host.profile.redirectPrinters == false)
+        #expect(host.profile.redirectedFolders.isEmpty)
+        #expect(host.profile.clipboardMode == .disabled)
+        #expect(host.profile.audioMode == .muted)
+        #expect(host.profile.autoReconnect == false)
+        #expect(host.profile.reconnectAfterWake == false)
+        #expect(host.profile.adminSession == false)
+        #expect(host.profile.certificatePolicy == .trustOnFirstUse)
+        #expect(host.profile.createdAt == Date(timeIntervalSince1970: 0))
+        #expect(personalProfiles.count == 1)
+        #expect(personalProfiles[0].sshIdentityID != nil)
+
+        store.replace(with: [snapshot])
+        #expect(store.hosts.first?.id == firstRuntimeID)
+    }
+
+    @MainActor
+    @Test("one malformed host hides its complete Team Vault scope")
+    func malformedVaultFailsClosed() throws {
+        let valid = try SelectiveRemoteVaultDocument.decode(Self.fixtureData())
+        let invalidID = try #require(
+            UUID(uuidString: "99999999-9999-4999-8999-999999999999")
+        )
+        let deviceID = try #require(
+            UUID(uuidString: "44444444-4444-4444-8444-444444444444")
+        )
+        let invalid = try SelectiveRemoteVaultRecord(
+            id: invalidID,
+            type: .host,
+            version: SelectiveRemoteVaultVersion([deviceID: 1]),
+            modifiedAt: "2026-09-10T00:02:00.000Z",
+            data: .object([
+                "title": .string("Injected"),
+                "address": .string("injected.example.invalid"),
+                "unexpected": .boolean(true)
+            ])
+        )
+        let document = try SelectiveRemoteVaultDocument(
+            records: valid.records + [invalid],
+            tombstones: valid.tombstones
+        )
+        let store = SelectiveRemoteTeamHostStore()
+        store.replace(with: [Self.snapshot(payload: try document.encoded())])
+
+        #expect(store.hosts.isEmpty)
+        #expect(store.synchronizedVaultCount == 0)
+        #expect(store.invalidVaultCount == 1)
+    }
+
+    private static func snapshot(
+        payload: Data
+    ) -> SelectiveRemoteTeamVaultMaterializedSnapshot {
+        .init(
+            teamID: UUID(uuidString: "11111111-1111-4111-8111-111111111111")!,
+            teamName: "Platform",
+            role: .viewer,
+            vaultID: UUID(uuidString: "22222222-2222-4222-8222-222222222222")!,
+            vaultName: "Operations",
+            revision: 7,
+            keyGeneration: 3,
+            payload: payload
+        )
+    }
+
+    private static func fixtureData() throws -> Data {
+        let url = try #require(Bundle.module.url(
+            forResource: "team-host-record-v1",
+            withExtension: "json",
+            subdirectory: "Fixtures"
+        ))
+        return try Data(contentsOf: url)
+    }
+}

--- a/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
@@ -48,9 +48,10 @@ struct CloudTeamHostsTests {
         let deviceID = try #require(
             UUID(uuidString: "44444444-4444-4444-8444-444444444444")
         )
+        let unicodeTitle = String(repeating: "Я", count: 120)
         var profile = ConnectionProfile(connectionType: .ssh)
         profile.id = profileID
-        profile.friendlyName = "Operations SSH"
+        profile.friendlyName = unicodeTitle
         profile.host = "ops.example.invalid"
         profile.username = "operator"
         profile.sshPort = 2_222
@@ -86,6 +87,7 @@ struct CloudTeamHostsTests {
         let firstRuntimeID = host.id
         #expect(host.recordID == profileID)
         #expect(host.id != profileID)
+        #expect(host.profile.friendlyName == unicodeTitle)
         #expect(host.profile.sshIdentityID == nil)
         #expect(host.profile.sshJumpHostProfileID == nil)
         #expect(host.profile.sshProxyMode == .none)

--- a/Tests/SelectiveRemoteTests/Fixtures/team-host-record-v1.json
+++ b/Tests/SelectiveRemoteTests/Fixtures/team-host-record-v1.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": 1,
+  "records": [
+    {
+      "id": "33333333-3333-4333-8333-333333333333",
+      "type": "host",
+      "version": {
+        "44444444-4444-4444-8444-444444444444": 1
+      },
+      "modifiedAt": "2026-09-10T00:00:00.000Z",
+      "data": {
+        "title": "Browser Bastion",
+        "address": "ssh://deployer@bastion.example.invalid:2222"
+      }
+    },
+    {
+      "id": "77777777-7777-4777-8777-777777777777",
+      "type": "host",
+      "version": {
+        "44444444-4444-4444-8444-444444444444": 2
+      },
+      "modifiedAt": "2026-09-10T00:01:00.000Z",
+      "data": {
+        "title": "Mac RDP",
+        "address": "rdp.example.invalid",
+        "username": "operator",
+        "connectionType": "rdp",
+        "profile": "eyJjb25uZWN0aW9uVHlwZSI6InJkcCIsImZyaWVuZGx5TmFtZSI6Ik1hYyBSRFAiLCJob3N0IjoicmRwLmV4YW1wbGUuaW52YWxpZCIsImlkIjoiNzc3Nzc3NzctNzc3Ny00Nzc3LTg3NzctNzc3Nzc3Nzc3Nzc3IiwidXNlcm5hbWUiOiJvcGVyYXRvciJ9"
+      }
+    }
+  ],
+  "tombstones": []
+}

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
+import { validateVaultDocument } from "../public/vault-model.js";
 
 const sourceRoot = new URL("../../Sources/SelectiveRemote/", import.meta.url);
 
@@ -236,4 +237,65 @@ test("macOS Personal Vault first upload is encrypted, explicit and non-destructi
   assert.match(settings, /Task\.detached/);
   assert.match(settings, /personalVaultRecoveryPhrase = ""/);
   assert.match(appSettings, /CloudSettingsView\(model: model\)/);
+});
+
+
+test("browser and macOS share the bounded Team Host record fixture", async () => {
+  const fixtureURL = new URL(
+    "../../Tests/SelectiveRemoteTests/Fixtures/team-host-record-v1.json",
+    import.meta.url,
+  );
+  const fixture = validateVaultDocument(JSON.parse(await readFile(fixtureURL, "utf8")));
+  assert.equal(fixture.records.length, 2);
+
+  const browser = fixture.records.find((record) => record.id === "33333333-3333-4333-8333-333333333333");
+  assert.deepEqual(Object.keys(browser.data).sort(), ["address", "title"]);
+  assert.equal(browser.data.address, "ssh://deployer@bastion.example.invalid:2222");
+
+  const mac = fixture.records.find((record) => record.id === "77777777-7777-4777-8777-777777777777");
+  assert.deepEqual(
+    Object.keys(mac.data).sort(),
+    ["address", "connectionType", "profile", "title", "username"],
+  );
+  const decodedProfile = JSON.parse(Buffer.from(mac.data.profile, "base64url").toString("utf8"));
+  assert.equal(decodedProfile.id, mac.id);
+  assert.equal(decodedProfile.connectionType, "rdp");
+  assert.equal(decodedProfile.host, mac.data.address);
+  assert.equal(decodedProfile.username, mac.data.username);
+});
+
+test("macOS projects Team Hosts separately and connects without Personal persistence", async () => {
+  const [hosts, autoSync, content, appModel, terminal] = await Promise.all([
+    readFile(new URL("CloudTeamHosts.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudTeamVaultAutoSync.swift", sourceRoot), "utf8"),
+    readFile(new URL("ContentView.swift", sourceRoot), "utf8"),
+    readFile(new URL("AppModel.swift", sourceRoot), "utf8"),
+    readFile(new URL("TerminalWorkspace.swift", sourceRoot), "utf8"),
+  ]);
+  assert.match(hosts, /final class SelectiveRemoteTeamHostStore: ObservableObject/);
+  assert.match(hosts, /browserKeys[\s\S]*"title", "address"/);
+  assert.match(hosts, /macOSKeys[\s\S]*"connectionType", "profile"/);
+  assert.match(hosts, /selective-remote\/team-host\/v1/);
+  assert.match(hosts, /sshIdentityID = nil/);
+  assert.match(hosts, /redirectedFolders = \[\]/);
+  assert.match(hosts, /clipboardMode = \.disabled/);
+  assert.doesNotMatch(hosts, /profiles\.append|model\.profiles/);
+
+  assert.match(autoSync, /case let \.synchronized\(value\)/);
+  assert.match(autoSync, /case let \.uploaded\(value\)/);
+  assert.match(autoSync, /await snapshotConsumer\(materialized\)/);
+  assert.match(autoSync, /func stop\(\) async[\s\S]*snapshotConsumer\(\[\]\)/);
+
+  assert.match(content, /case teamHosts = "Team Hosts"/);
+  assert.match(content, /SelectiveRemoteTeamHostsView/);
+  assert.match(content, /ephemeral: true/);
+  assert.match(appModel, /func connectTeamHost\(/);
+  assert.match(appModel, /allowsStoredCredentials: false/);
+  assert.match(appModel, /persistsProfileState: false/);
+  assert.doesNotMatch(
+    appModel.match(/func connectTeamHost\([\s\S]*?\n    \}\n\n    func sshConnectionSettings/u)?.[0] ?? "",
+    /profiles\.append/,
+  );
+  assert.match(terminal, /var isEphemeral: Bool/);
+  assert.match(terminal, /tabs\.filter \{ !\$0\.isEphemeral \}\.map/);
 });

--- a/docs/cloud-v0.32-team-threat-model.md
+++ b/docs/cloud-v0.32-team-threat-model.md
@@ -202,6 +202,35 @@ reported without choosing a winner, rotation freezes the Vault, and App Lock
 cancels the cycle. The file snapshot remains ciphertext and a device wrapper;
 plaintext and raw Vault keys are never persisted there.
 
+
+A successful macOS refresh now projects only validated Host records into a
+separate main-actor Team Host store and UI. It accepts the browser's exact
+`title/address` shape (with explicit `rdp://`, `ssh://`, `telnet://` or
+`serial://` transport hints, and RDP as the scheme-less compatibility
+default) and the exact richer macOS export shape. Rich records must agree with
+their embedded profile on record ID, title, address, username and connection
+type. Unknown keys, malformed profiles or unusable endpoints invalidate the
+whole Vault projection instead of partially rendering attacker-controlled
+state.
+
+A Team Host receives a deterministic Team/Vault/record-scoped runtime UUID, so
+it cannot resolve Personal Keychain credentials or collide with a Personal
+profile ID. Materialization rebuilds a safe connection profile: local SSH key,
+jump/proxy, snippet, forwarding, display and device references are discarded;
+clipboard, audio capture, folder, camera, microphone and printer redirection
+are disabled; ignored-certificate policy is upgraded to trust-on-first-use;
+automatic reconnect and administrative sessions are disabled. The read-only
+Team UI never appends to the Personal profile collection and exposes no Vault
+mutation to a Viewer. RDP uses only credentials entered for that launch and
+does not consult stored Personal credentials. SSH/Telnet/Serial launches use
+ephemeral Terminal Workspace tabs excluded from UserDefaults and workspace
+exports; temporary SSH passwords retain the existing launch-scoped cleanup.
+App Lock, logout or loss of a stored session clears the materialized Host
+projection. A transport outage keeps the last in-memory projection rather than
+claiming revocation; the existing removal/rotation guarantee still concerns
+new server data and cannot erase plaintext or active sessions already held by
+an authorized device.
+
 ## Removal and rotation
 
 Membership removal is a fail-closed state transition:
@@ -283,8 +312,9 @@ or wrappers.
   present.
 
 Team/shared Vault release status remains `planned_required`: the server-side
-protocol, browser Team UI/cryptography/causal sync/device approval/rotation and
-the bounded macOS crypto/transport/offline coordinator plus automatic wrapper
-delivery and background ciphertext synchronization are implemented, but macOS
-Team Hosts UI, explicit conflict-resolution writes and the complete cross-client
-acceptance suite must pass before Cloud 0.32 is complete.
+protocol, browser Team UI/cryptography/causal sync/device approval/rotation,
+the macOS crypto/transport/conflict coordinator, automatic wrapper delivery,
+background ciphertext synchronization, separate Team Host projection and the
+browser-to-macOS record fixture are implemented. Live two-member staging
+acceptance and the remaining recovery/lifecycle gates must pass before Cloud
+0.32 is complete.


### PR DESCRIPTION
## Summary

- materialize successfully decrypted Team Vault host records into a separate macOS Team Hosts store and main-area UI
- accept both the browser `title/address` host shape and the richer macOS profile export with strict cross-field validation
- derive Team/Vault/record-scoped runtime IDs and rebuild safe connection profiles without Personal IDs, Keychain references, redirection, auto-reconnect, admin mode, or ignored certificates
- connect RDP without stored Personal credentials and open SSH/Telnet/Serial in terminal tabs excluded from workspace persistence
- feed only conflict-free, non-rotating synchronized payloads from the existing 15-second Team Vault cycle; App Lock/session loss clears the projection
- add a shared browser/macOS record fixture, Swift materialization regressions (including 120-character Unicode names), source-contract coverage, and threat-model updates

## Security boundaries

- Team hosts are never appended to `AppModel.profiles` or Personal Vault
- malformed host data invalidates the entire Vault projection
- Viewer receives a read-only host projection; this PR adds no Team Vault mutation surface
- no password, recovery phrase, raw Vault key, or decrypted payload is persisted by the Team Host store
- RDP launch does not consult Personal Keychain; temporary SSH authentication retains launch-scoped cleanup
- conflicts, missing wrappers, rotation, empty Vaults, and failed Vault refreshes remain fail closed

## Stack

- base: PR #78 exact head `8f43d712b0b231cc40bcf47434117715d278233c`
- exact head: `5f7630badc6c2ad6c291005f218c7fac3e301e14`
- exact tree: `dd1b6975c0b4b3222c63e2f6a2d41cecf2717e83`
- public `main` remains `59eda120e0b3f29f48581e77a77c8be227801ad3`; staging remains unchanged

## Verification

- [CI #564](https://github.com/PastFly/Selective-Remote/actions/runs/34415402271): success
  - Swift: 388 tests passed
  - terminal web interactions: 12 passed, 0 failed
  - Cloud/browser: 268 passed, 0 failed (the separate PostgreSQL-only test is exercised below)
  - PostgreSQL 16 Team transaction job: 1 passed, 0 failed
  - Release build: success
  - the PR-introduced redundant-`await` warning is absent from the exact-head raw log
- [Test DMG #240](https://github.com/PastFly/Selective-Remote/actions/runs/34415402248): success
  - ARM64 build and 388 Swift tests: success
  - native monitor, PTY bridge, Homebrew/portable FreeRDP, RDPECAM and DMG-layout smoke tests: success
  - artifact: [`SelectiveRemote-test-79-arm64`](https://github.com/PastFly/Selective-Remote/actions/runs/34415402248/artifacts/10129107275)
  - artifact ID: `10129107275`
  - artifact size: `33,248,057` bytes
  - artifact digest: `sha256:6eda9f34341d2aadef6a08a772736a047bb4adf2c0286a78007d8b4316c5d979`

No merge or deployment was performed.
