### PR TITLE
Make Team automation controls recovery-only

### DIFF
--- a/Sources/SelectiveRemote/CloudTeamVaultSyncCoordinator.swift
+++ b/Sources/SelectiveRemote/CloudTeamVaultSyncCoordinator.swift
@@ -23,8 +23,8 @@ enum SelectiveRemoteTeamVaultSyncError: LocalizedError, Equatable {
             )
         case .missingDeviceWrapper:
             UpdateLocalization.text(
-                ru: "Для этого Mac ещё не выдан ключ выбранного Team Vault. Откройте Vault в уже доверенном браузере или на другом устройстве, выдайте недостающие wrappers и повторите операцию.",
-                en: "This Mac does not have a key for the selected Team Vault yet. Open the Vault in an already trusted browser or on another device, grant the missing wrappers, and try again."
+                ru: "Для этого Mac ещё не выдан ключ выбранного Team Vault. Оставьте уже доверенный браузер или другое устройство с текущим ключом онлайн: wrapper будет выдан автоматически, после чего повторите операцию.",
+                en: "This Mac does not have a key for the selected Team Vault yet. Keep an already trusted browser or another device with the current key online: the wrapper will be granted automatically, then try again."
             )
         case .noLocalSnapshot:
             UpdateLocalization.text(

--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -104,6 +104,19 @@ export function localVaultConflictSideSummary(entity) {
   return `${boundedTitle} · ${String(entity.value?.type ?? "record")} · ${String(entity.value?.modifiedAt ?? "")}`;
 }
 
+export function teamVaultRecoveryMode({
+  outcomeStatus = null,
+  wrapperProvisioningFailed = false,
+  errorCode = null,
+} = {}) {
+  const code = String(errorCode ?? "");
+  if (code === "team_vault_rotation_required" || outcomeStatus === "conflict") return "none";
+  if (code === "team_vault_key_unavailable") return "access";
+  if (code) return "synchronize";
+  if (wrapperProvisioningFailed) return "wrappers";
+  return "none";
+}
+
 function setText(element, value) {
   if (element) element.textContent = value;
 }
@@ -461,6 +474,17 @@ export function initializeTeamWorkspace({
     return ["owner", "admin", "editor"].includes(selectedTeam?.role);
   }
 
+  function setRecoveryControls(mode = "none") {
+    const retriesSynchronization = mode === "synchronize" || mode === "access";
+    syncButton.hidden = !retriesSynchronization;
+    syncButton.disabled = !retriesSynchronization || !controller;
+    syncButton.textContent = mode === "access"
+      ? "Проверить доступ снова"
+      : "Повторить безопасную синхронизацию";
+    grantWrappersButton.hidden = mode !== "wrappers";
+    grantWrappersButton.disabled = mode !== "wrappers" || !controller || selectedVault?.rotationRequired;
+  }
+
   function updateTeamMessage() {
     if (!selectedTeam) return;
     if (activeView === "teams") {
@@ -606,7 +630,7 @@ export function initializeTeamWorkspace({
             idempotencyKey: `web:device:approve:${globalThis.crypto.randomUUID()}`,
           });
           await loadDevices();
-          setText(message, "Ключ устройства одобрен. Owner/Admin может выдать недостающие wrappers из открытого Shared Vault.");
+          setText(message, "Ключ устройства одобрен. Любой активный участник с текущим Team Vault key автоматически выдаст недостающий wrapper.");
         } catch {
           setText(message, "Ключ не одобрен: требуется уже одобренное текущее устройство и совпадающий отпечаток.");
           approve.disabled = false;
@@ -885,6 +909,10 @@ export function initializeTeamWorkspace({
       clearConflicts();
       renderRecords();
     }
+    setRecoveryControls(teamVaultRecoveryMode({
+      outcomeStatus: result.status,
+      wrapperProvisioningFailed,
+    }));
     if (background && result.status === "up_to_date"
       && !wrapperProvisioningFailed && (wrapperProvisioning?.granted ?? 0) === 0) {
       return;
@@ -905,11 +933,6 @@ export function initializeTeamWorkspace({
       status += ` Автоматически выдано недостающих wrappers: ${wrapperProvisioning.granted}.`;
     }
     setText(workspaceStatus, status);
-    if (!selectedVault?.rotationRequired
-      && !["conflict", "remote_changed"].includes(result.status)) {
-      grantWrappersButton.hidden = false;
-      grantWrappersButton.disabled = false;
-    }
   }
 
   async function runBackgroundTeamVaultSync() {
@@ -928,11 +951,15 @@ export function initializeTeamWorkspace({
         vaultSelect.value = selectedVault.id;
         rotateButton.hidden = !canManage();
         rotateButton.disabled = rotateButton.hidden;
-        grantWrappersButton.hidden = true;
+        setRecoveryControls("none");
         stopBackgroundSync();
         setText(workspaceStatus, "Фоновая запись заморожена до безопасной ротации ключа.");
       } else if (code === "team_vault_key_unavailable") {
+        setRecoveryControls(teamVaultRecoveryMode({ errorCode: code }));
         setText(workspaceStatus, "Ожидаем, пока устройство с текущим Team Vault key автоматически выдаст wrapper этому браузеру.");
+      } else {
+        setRecoveryControls(teamVaultRecoveryMode({ errorCode: code || "team_vault_sync_failed" }));
+        setText(workspaceStatus, "Автоматическая синхронизация временно остановилась; локальная зашифрованная копия сохранена.");
       }
     }
   }
@@ -945,8 +972,7 @@ export function initializeTeamWorkspace({
     workspace.hidden = true;
     rotateButton.hidden = true;
     rotateButton.disabled = true;
-    grantWrappersButton.hidden = true;
-    grantWrappersButton.disabled = true;
+    setRecoveryControls("none");
     records.replaceChildren();
     clearConflicts();
   }
@@ -985,27 +1011,23 @@ export function initializeTeamWorkspace({
     workspace.hidden = activeView === "teams";
     rotateButton.hidden = !vault.rotationRequired || !canManage();
     rotateButton.disabled = !vault.rotationRequired || !canManage();
-    grantWrappersButton.hidden = vault.rotationRequired;
-    grantWrappersButton.disabled = true;
+    setRecoveryControls("none");
     workspaceTitle.textContent = `${selectedTeam.name} / ${vault.name}`;
     setText(workspaceStatus, "Загружаем зашифрованную Team-ревизию…");
-    syncButton.disabled = true;
     try {
       const outcome = await synchronizeAndProvision();
       applySynchronizationOutcome(outcome);
-      syncButton.disabled = false;
-      grantWrappersButton.disabled = grantWrappersButton.hidden;
     } catch (error) {
       const code = String(error?.message ?? "");
       setWorkspaceControls(true);
-      grantWrappersButton.disabled = true;
       rotateButton.hidden = code !== "team_vault_rotation_required" || !canManage();
       rotateButton.disabled = rotateButton.hidden;
+      setRecoveryControls(teamVaultRecoveryMode({ errorCode: code }));
       setText(workspaceStatus, code === "team_vault_rotation_required"
         ? "Запись заморожена: после отзыва участника или устройства требуется полная ротация ключа."
         : code === "team_vault_key_unavailable"
           ? "Для этого устройства пока нет wrapper ключа. Ожидаем автоматическую выдачу от любого активного участника с текущим ключом."
-          : "Shared Vault не открыт; локальные данные не изменены.");
+          : "Shared Vault не открыт; локальные данные не изменены. Доступно безопасное повторение.");
     } finally {
       startBackgroundSync();
     }
@@ -1265,9 +1287,8 @@ export function initializeTeamWorkspace({
     if (!confirmValue("Зашифровать полную текущую Team-ревизию новым ключом и выдать wrappers всем актуальным авторизованным устройствам?")) return;
     stopBackgroundSync();
     rotateButton.disabled = true;
-    syncButton.disabled = true;
     lockButton.disabled = true;
-    grantWrappersButton.disabled = true;
+    setRecoveryControls("none");
     setWorkspaceControls(true);
     try {
       const result = await rotateTeamVault({ client, controller, role: selectedTeam.role });
@@ -1282,8 +1303,7 @@ export function initializeTeamWorkspace({
         populateVaults();
         vaultSelect.value = selectedVault.id;
         rotateButton.hidden = true;
-        grantWrappersButton.hidden = false;
-        grantWrappersButton.disabled = grantWrappersButton.hidden;
+        setRecoveryControls("none");
         clearConflicts();
         renderRecords();
         setWorkspaceControls(false);
@@ -1293,15 +1313,14 @@ export function initializeTeamWorkspace({
       setText(workspaceStatus, "Ротация не подтверждена. Локальный snapshot не заменён; безопасно повторите операцию.");
     } finally {
       lockButton.disabled = false;
-      syncButton.disabled = !controller || !rotateButton.hidden;
       rotateButton.disabled = rotateButton.hidden || !canManage() || Boolean(activeConflicts);
-      grantWrappersButton.disabled = grantWrappersButton.hidden || Boolean(activeConflicts);
+      setRecoveryControls("none");
       startBackgroundSync();
     }
   });
   grantWrappersButton.addEventListener("click", async () => {
     if (!controller || !selectedVault || selectedVault.rotationRequired) return;
-    grantWrappersButton.disabled = true;
+    setRecoveryControls("none");
     try {
       const result = await exclusiveVaultOperation(() => provisionTeamVaultWrappers({
         client,
@@ -1312,9 +1331,8 @@ export function initializeTeamWorkspace({
         ? "Все актуальные авторизованные устройства уже имеют wrapper этой генерации."
         : `Автоматически выдано недостающих wrappers: ${result.granted}. Vault plaintext не покидал браузер.`);
     } catch {
+      setRecoveryControls("wrappers");
       setText(workspaceStatus, "Не все wrappers подтверждены. Автоматический цикл безопасно повторит выдачу.");
-    } finally {
-      grantWrappersButton.disabled = !controller || selectedVault?.rotationRequired;
     }
   });
   recordType.addEventListener("change", updateRecordLabels);
@@ -1345,15 +1363,18 @@ export function initializeTeamWorkspace({
   });
 
   syncButton.addEventListener("click", async () => {
-    syncButton.disabled = true;
+    setRecoveryControls("none");
     try {
       applySynchronizationOutcome(await synchronizeAndProvision());
     } catch (error) {
-      setText(workspaceStatus, String(error?.message ?? "") === "team_vault_rotation_required"
+      const code = String(error?.message ?? "");
+      setRecoveryControls(teamVaultRecoveryMode({ errorCode: code }));
+      setText(workspaceStatus, code === "team_vault_rotation_required"
         ? "Синхронизация заморожена до безопасной ротации ключа."
-        : "Синхронизация не выполнена; локальная зашифрованная копия сохранена.");
+        : code === "team_vault_key_unavailable"
+          ? "Wrapper ещё недоступен. Любой активный участник с текущим ключом выдаст его автоматически."
+          : "Синхронизация не выполнена; локальная зашифрованная копия сохранена.");
     } finally {
-      syncButton.disabled = !controller;
       startBackgroundSync();
     }
   });
@@ -1364,7 +1385,8 @@ export function initializeTeamWorkspace({
     records.replaceChildren();
     clearConflicts();
     setWorkspaceControls(true);
-    setText(workspaceStatus, "Ключ Shared Vault удалён из памяти. Нажмите синхронизацию для повторного локального unlock.");
+    setRecoveryControls("none");
+    setText(workspaceStatus, "Ключ Shared Vault удалён из памяти. Откройте выбранный Vault снова для локального unlock.");
   });
 
   conflictForm.addEventListener("change", () => {

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -452,8 +452,8 @@
             </div>
             <div class="vault-actions">
               <button type="button" class="danger" id="team-vault-rotate" hidden>Завершить ротацию</button>
-              <button type="button" class="secondary" id="team-vault-grant-wrappers" hidden>Повторить безопасную выдачу wrappers</button>
-              <button type="button" id="team-vault-sync" hidden>Повторить безопасную синхронизацию</button>
+              <button type="button" class="secondary" id="team-vault-grant-wrappers" aria-describedby="team-vault-workspace-status" hidden>Повторить безопасную выдачу wrappers</button>
+              <button type="button" id="team-vault-sync" aria-describedby="team-vault-workspace-status" hidden>Повторить безопасную синхронизацию</button>
               <button type="button" class="secondary" id="team-vault-lock">Заблокировать</button>
             </div>
           </div>

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -448,12 +448,12 @@
             <div>
               <h3 id="team-vault-workspace-title">Shared Vault</h3>
               <p id="team-vault-workspace-status" aria-live="polite">Vault заблокирован.</p>
-              <small>После открытия зашифрованные изменения и недостающие wrappers синхронизируются автоматически.</small>
+              <small>После открытия изменения и wrappers синхронизируются автоматически. Recovery-действия появляются только при безопасно устранимом блокере.</small>
             </div>
             <div class="vault-actions">
               <button type="button" class="danger" id="team-vault-rotate" hidden>Завершить ротацию</button>
-              <button type="button" class="secondary" id="team-vault-grant-wrappers" hidden>Повторить выдачу wrappers</button>
-              <button type="button" id="team-vault-sync">Синхронизировать сейчас</button>
+              <button type="button" class="secondary" id="team-vault-grant-wrappers" hidden>Повторить безопасную выдачу wrappers</button>
+              <button type="button" id="team-vault-sync" hidden>Повторить безопасную синхронизацию</button>
               <button type="button" class="secondary" id="team-vault-lock">Заблокировать</button>
             </div>
           </div>

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -110,7 +110,8 @@ test("Host context menu opens a real encrypted Team Vault share flow", async () 
   assert.match(sharing, /coordinator\.push/);
   assert.match(sharing, /without its saved password/);
   assert.match(coordinator, /enum SelectiveRemoteTeamVaultSyncError: LocalizedError, Equatable/);
-  assert.match(coordinator, /case \.missingDeviceWrapper:[\s\S]*?не выдан ключ выбранного Team Vault/);
+  assert.match(coordinator, /case \.missingDeviceWrapper:[\s\S]*?wrapper будет выдан автоматически/);
+  assert.doesNotMatch(coordinator, /выдайте недостающие wrappers/);
   assert.match(sharing, /catch SelectiveRemoteTeamVaultSyncError\.missingDeviceWrapper/);
   assert.match(sharing, /needsDeviceWrapper = true/);
   assert.match(sharing, /Открыть Team Vaults в браузере/);

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -6,6 +6,7 @@ import {
   localVaultConflictSideSummary,
   localVaultRecordData,
   localVaultRecordSummary,
+  teamVaultRecoveryMode,
 } from "../public/app.js";
 
 test("appearance defaults to graphite and synchronizes every visible selector", () => {
@@ -62,6 +63,17 @@ test("Vault form mapping rejects incomplete and oversized records", () => {
     () => localVaultRecordData("host", { title: "x".repeat(121), target: "host.invalid", secret: "" }),
     /invalid_local_record/,
   );
+});
+
+test("Team Vault routine automation exposes controls only for recoverable blockers", () => {
+  assert.equal(teamVaultRecoveryMode(), "none");
+  assert.equal(teamVaultRecoveryMode({ outcomeStatus: "up_to_date" }), "none");
+  assert.equal(teamVaultRecoveryMode({ outcomeStatus: "remote_changed" }), "none");
+  assert.equal(teamVaultRecoveryMode({ outcomeStatus: "conflict" }), "none");
+  assert.equal(teamVaultRecoveryMode({ wrapperProvisioningFailed: true }), "wrappers");
+  assert.equal(teamVaultRecoveryMode({ errorCode: "team_vault_key_unavailable" }), "access");
+  assert.equal(teamVaultRecoveryMode({ errorCode: "network_unavailable" }), "synchronize");
+  assert.equal(teamVaultRecoveryMode({ errorCode: "team_vault_rotation_required" }), "none");
 });
 
 test("credential summaries never expose their secret", () => {
@@ -143,9 +155,11 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(html, /autocomplete="current-password"/u);
   assert.match(html, /id="team-devices"/u);
   assert.match(html, /id="team-vault-rotate"[^>]*hidden/u);
-  assert.match(html, /недостающие wrappers синхронизируются автоматически/u);
-  assert.match(html, /id="team-vault-grant-wrappers"[^>]*>Повторить выдачу wrappers/u);
-  assert.match(html, /id="team-vault-sync"[^>]*>Синхронизировать сейчас/u);
+  assert.match(html, /изменения и wrappers синхронизируются автоматически/u);
+  assert.match(html, /Recovery-действия появляются только при безопасно устранимом блокере/u);
+  assert.match(html, /id="team-vault-grant-wrappers"[^>]*hidden[^>]*>Повторить безопасную выдачу wrappers/u);
+  assert.match(html, /id="team-vault-sync"[^>]*hidden[^>]*>Повторить безопасную синхронизацию/u);
+  assert.doesNotMatch(html, /Синхронизировать сейчас/u);
   assert.match(html, /id="team-vault-record-form"/u);
   assert.match(html, /id="team-vault-conflicts-form"/u);
   assert.match(html, /id="workspace-overview"/u);
@@ -198,6 +212,9 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(application, /backgroundSyncIntervalMilliseconds = 15_000/u);
   assert.match(application, /documentValue\.visibilityState === "hidden"/u);
   assert.match(application, /runBackgroundTeamVaultSync/u);
+  assert.match(application, /teamVaultRecoveryMode/u);
+  assert.match(application, /setRecoveryControls/u);
+  assert.doesNotMatch(application, /Owner\/Admin может выдать недостающие wrappers/u);
   assert.match(teamSynchronization, /export async function provisionTeamVaultWrappers/u);
   assert.match(application, /rotateTeamVault/u);
   assert.match(application, /teamDevicePublicKeyFingerprint/u);

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -159,6 +159,7 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(html, /Recovery-действия появляются только при безопасно устранимом блокере/u);
   assert.match(html, /id="team-vault-grant-wrappers"[^>]*hidden[^>]*>Повторить безопасную выдачу wrappers/u);
   assert.match(html, /id="team-vault-sync"[^>]*hidden[^>]*>Повторить безопасную синхронизацию/u);
+  assert.equal((html.match(/aria-describedby="team-vault-workspace-status"/gu) ?? []).length, 2);
   assert.doesNotMatch(html, /Синхронизировать сейчас/u);
   assert.match(html, /id="team-vault-record-form"/u);
   assert.match(html, /id="team-vault-conflicts-form"/u);

--- a/docs/cloud-v0.32-team-threat-model.md
+++ b/docs/cloud-v0.32-team-threat-model.md
@@ -188,7 +188,11 @@ rotation, and retries idempotent missing-wrapper publication. It skips work
 while the page is hidden and stops after explicit key lock, Team change or
 logout. The interval grants no new role capability: Viewer writes still fail at
 the client and server, while any role may provision only after current-wrapper
-proof.
+proof. Routine synchronization and wrapper buttons remain hidden while this
+automation is healthy. The browser exposes only a scoped retry after a transient
+sync failure, missing current-device wrapper or failed automatic wrapper
+publication; conflicts and required rotation keep their explicit fail-closed
+recovery surfaces instead of a generic retry.
 
 While the macOS app is unlocked, its app-lifetime 15-second cycle enumerates
 only Teams and Vaults authorized by the current bearer session. For each


### PR DESCRIPTION
## Summary

- keep routine Team Vault synchronization and wrapper provisioning fully automatic while the opened Vault is healthy
- keep both retry controls hidden by default and reveal only the scoped recovery action for a transient sync failure, missing current-device wrapper, or failed automatic wrapper publication
- preserve explicit conflict resolution and Owner/Admin rotation as separate fail-closed recovery paths
- replace stale browser/macOS copy that instructed users to perform routine manual wrapper grants
- connect recovery controls to the live status with `aria-describedby`, document the boundary, and regression-test the recovery-state mapping

## Security boundary

- no server-side key creation or plaintext handling
- no change to Team roles, wrapper proof, rotation, causal revisions, Personal Vault isolation, staging, or deployment
- generic retry stays hidden for conflicts and required rotation

## Exact state

- stacked base: PR #79 branch `feature/macos-team-hosts`
- exact base head: `5f7630badc6c2ad6c291005f218c7fac3e301e14`
- exact head: `34f71aebf9845dbab685e51afe15666b0e22db3e`
- exact tree: `6c308df1930e8e11210fecff1feb3ee018132bf5`
- 2 commits, 6 changed files, +85/-40

## Verification

- [CI #565](https://github.com/PastFly/Selective-Remote/actions/runs/34446321226): success on the exact head
  - Swift: 388 passed
  - terminal web: 12 passed, 0 failed
  - Cloud/browser: 269 passed, 0 failed, 1 PostgreSQL-only case skipped in the general job
  - separate PostgreSQL 16 Team transaction: 1 passed, 0 failed
  - release build: success
- [Test DMG #241](https://github.com/PastFly/Selective-Remote/actions/runs/34446321080): success on the exact head
  - ARM64 DMG build, Homebrew/portable FreeRDP, RDPECAM and layout checks succeeded
  - artifact [SelectiveRemote-test-80-arm64](https://github.com/PastFly/Selective-Remote/actions/runs/34446321080/artifacts/10140018375), ID `10140018375`, 33,248,731 bytes
  - digest `sha256:645ddd85017af4023e74bbbc8e026987c44be13641d6b03f6f56807704e279c0`

The PR was temporarily retargeted to `main` only to enqueue the repository's base-filtered workflows, then restored to its intended stacked base. Public `main` never changed.

No merge, staging deployment, release, or public-`main` mutation is included.