### PR TITLE
Add role-aware macOS Team Host mutations

### DIFF
--- a/Sources/SelectiveRemote/CloudTeamHostEditor.swift
+++ b/Sources/SelectiveRemote/CloudTeamHostEditor.swift
@@ -64,6 +64,10 @@ struct SelectiveRemoteTeamHostEditorView: View {
             }
 
             Form {
+                LabeledContent(
+                    UpdateLocalization.text(ru: "Роль", en: "Role"),
+                    value: Self.roleTitle(request.context.role)
+                )
                 Picker(
                     UpdateLocalization.text(ru: "Протокол", en: "Protocol"),
                     selection: $connectionType
@@ -146,5 +150,14 @@ struct SelectiveRemoteTeamHostEditorView: View {
 
     private static func address(_ profile: ConnectionProfile) -> String {
         profile.connectionType == .serial ? profile.serialDevicePath : profile.host
+    }
+
+    private static func roleTitle(_ role: SelectiveRemoteCloudTeamRole) -> String {
+        switch role {
+        case .owner: "Owner"
+        case .admin: "Admin"
+        case .editor: "Editor"
+        case .viewer: "Viewer"
+        }
     }
 }

--- a/Sources/SelectiveRemote/CloudTeamHostEditor.swift
+++ b/Sources/SelectiveRemote/CloudTeamHostEditor.swift
@@ -1,0 +1,150 @@
+import SwiftUI
+
+struct SelectiveRemoteTeamHostEditorRequest: Identifiable {
+    let id = UUID()
+    let context: SelectiveRemoteTeamHostVaultContext
+    let host: SelectiveRemoteTeamHost?
+}
+
+struct SelectiveRemoteTeamHostMutationMessage: Identifiable {
+    let id = UUID()
+    let text: String
+    let isError: Bool
+}
+
+struct SelectiveRemoteTeamHostEditorView: View {
+    let request: SelectiveRemoteTeamHostEditorRequest
+    let onSave: (ConnectionProfile) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var title: String
+    @State private var address: String
+    @State private var username: String
+    @State private var connectionType: ConnectionType
+
+    init(
+        request: SelectiveRemoteTeamHostEditorRequest,
+        onSave: @escaping (ConnectionProfile) -> Void
+    ) {
+        self.request = request
+        self.onSave = onSave
+        let profile = request.host?.profile
+        _title = State(initialValue: profile?.friendlyName ?? "")
+        _address = State(initialValue: profile.map(Self.address) ?? "")
+        _username = State(initialValue: profile?.username ?? "")
+        _connectionType = State(initialValue: profile?.connectionType ?? .ssh)
+    }
+
+    private var isValid: Bool {
+        let cleanTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let cleanAddress = address.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !cleanTitle.isEmpty
+            && cleanTitle == title
+            && title.count <= 120
+            && !title.contains(where: { $0.isNewline })
+            && !cleanAddress.isEmpty
+            && cleanAddress == address
+            && address.utf8.count <= 2_048
+            && !address.contains(where: { $0.isNewline })
+            && username.count <= 256
+            && !username.contains(where: { $0.isNewline })
+            && (connectionType != .serial || address.hasPrefix("/dev/cu."))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(request.host == nil
+                    ? UpdateLocalization.text(ru: "Новый Team Host", en: "New Team Host")
+                    : UpdateLocalization.text(ru: "Изменить Team Host", en: "Edit Team Host")
+                )
+                .font(.title2.bold())
+                Text("\(request.context.teamName) / \(request.context.vaultName)")
+                    .foregroundStyle(.secondary)
+            }
+
+            Form {
+                Picker(
+                    UpdateLocalization.text(ru: "Протокол", en: "Protocol"),
+                    selection: $connectionType
+                ) {
+                    Text("RDP").tag(ConnectionType.rdp)
+                    Text("SSH").tag(ConnectionType.ssh)
+                    Text("Telnet").tag(ConnectionType.telnet)
+                    Text("Serial").tag(ConnectionType.serial)
+                }
+                .disabled(request.host != nil)
+                .help(request.host == nil
+                    ? ""
+                    : UpdateLocalization.text(
+                        ru: "Протокол существующего Team Host нельзя менять в этой форме",
+                        en: "This form does not change an existing Team Host protocol"
+                    )
+                )
+
+                TextField(
+                    UpdateLocalization.text(ru: "Название", en: "Name"),
+                    text: $title
+                )
+                TextField(
+                    connectionType == .serial
+                        ? UpdateLocalization.text(ru: "Устройство", en: "Device")
+                        : UpdateLocalization.text(ru: "Host или IP", en: "Host or IP"),
+                    text: $address
+                )
+                if connectionType == .rdp || connectionType == .ssh {
+                    TextField(
+                        UpdateLocalization.text(ru: "Пользователь", en: "Username"),
+                        text: $username
+                    )
+                }
+            }
+            .formStyle(.grouped)
+
+            Label(
+                UpdateLocalization.text(
+                    ru: "Пароли и ссылки на Personal Vault не сохраняются в Team Host.",
+                    en: "Passwords and Personal Vault references are not saved in a Team Host."
+                ),
+                systemImage: "lock.shield"
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+            HStack {
+                Spacer()
+                Button(UpdateLocalization.text(ru: "Отмена", en: "Cancel")) {
+                    dismiss()
+                }
+                Button(request.host == nil
+                    ? UpdateLocalization.text(ru: "Добавить", en: "Add")
+                    : UpdateLocalization.text(ru: "Сохранить", en: "Save")
+                ) {
+                    onSave(profile())
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!isValid)
+            }
+        }
+        .padding(24)
+        .frame(width: 520)
+    }
+
+    private func profile() -> ConnectionProfile {
+        var profile = request.host?.profile ?? ConnectionProfile(connectionType: connectionType)
+        profile.id = request.host?.recordID ?? UUID()
+        profile.friendlyName = title
+        profile.username = username
+        if connectionType == .serial {
+            profile.serialDevicePath = address
+        } else {
+            profile.host = address
+        }
+        return profile
+    }
+
+    private static func address(_ profile: ConnectionProfile) -> String {
+        profile.connectionType == .serial ? profile.serialDevicePath : profile.host
+    }
+}

--- a/Sources/SelectiveRemote/CloudTeamHostMutation.swift
+++ b/Sources/SelectiveRemote/CloudTeamHostMutation.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+enum SelectiveRemoteTeamHostMutationError: Error, Equatable {
+    case readOnlyRole
+    case duplicateHost
+    case hostNotFound
+    case recordIsNotHost
+}
+
+enum SelectiveRemoteTeamHostDocumentMutation {
+    static func create(
+        profile: ConnectionProfile,
+        role: SelectiveRemoteCloudTeamRole,
+        deviceID: UUID,
+        modifiedAt: String
+    ) throws -> SelectiveRemoteVaultDocument {
+        try mutate(
+            document: .init(),
+            profile: profile,
+            recordID: profile.id,
+            role: role,
+            deviceID: deviceID,
+            modifiedAt: modifiedAt,
+            requiresExistingHost: false
+        )
+    }
+
+    static func create(
+        in document: SelectiveRemoteVaultDocument,
+        profile: ConnectionProfile,
+        role: SelectiveRemoteCloudTeamRole,
+        deviceID: UUID,
+        modifiedAt: String
+    ) throws -> SelectiveRemoteVaultDocument {
+        guard document.records.allSatisfy({ $0.id != profile.id }),
+              document.tombstones.allSatisfy({ $0.id != profile.id })
+        else { throw SelectiveRemoteTeamHostMutationError.duplicateHost }
+        return try mutate(
+            document: document,
+            profile: profile,
+            recordID: profile.id,
+            role: role,
+            deviceID: deviceID,
+            modifiedAt: modifiedAt,
+            requiresExistingHost: false
+        )
+    }
+
+    static func update(
+        in document: SelectiveRemoteVaultDocument,
+        recordID: UUID,
+        profile: ConnectionProfile,
+        role: SelectiveRemoteCloudTeamRole,
+        deviceID: UUID,
+        modifiedAt: String
+    ) throws -> SelectiveRemoteVaultDocument {
+        try mutate(
+            document: document,
+            profile: profile,
+            recordID: recordID,
+            role: role,
+            deviceID: deviceID,
+            modifiedAt: modifiedAt,
+            requiresExistingHost: true
+        )
+    }
+
+    static func delete(
+        from document: SelectiveRemoteVaultDocument,
+        recordID: UUID,
+        role: SelectiveRemoteCloudTeamRole,
+        deviceID: UUID,
+        deletedAt: String
+    ) throws -> SelectiveRemoteVaultDocument {
+        try requireWritable(role)
+        guard let existing = document.records.first(where: { $0.id == recordID }) else {
+            if document.tombstones.contains(where: { $0.id == recordID }) {
+                throw SelectiveRemoteTeamHostMutationError.hostNotFound
+            }
+            throw SelectiveRemoteTeamHostMutationError.hostNotFound
+        }
+        guard existing.type == .host else {
+            throw SelectiveRemoteTeamHostMutationError.recordIsNotHost
+        }
+        let tombstone = try SelectiveRemoteVaultTombstone(
+            id: recordID,
+            version: existing.version.incrementing(deviceID),
+            deletedAt: deletedAt
+        )
+        return try .init(
+            records: document.records.filter { $0.id != recordID },
+            tombstones: document.tombstones.filter { $0.id != recordID } + [tombstone]
+        )
+    }
+
+    private static func mutate(
+        document: SelectiveRemoteVaultDocument,
+        profile: ConnectionProfile,
+        recordID: UUID,
+        role: SelectiveRemoteCloudTeamRole,
+        deviceID: UUID,
+        modifiedAt: String,
+        requiresExistingHost: Bool
+    ) throws -> SelectiveRemoteVaultDocument {
+        try requireWritable(role)
+        let existing = document.records.first(where: { $0.id == recordID })
+        if requiresExistingHost {
+            guard let existing else { throw SelectiveRemoteTeamHostMutationError.hostNotFound }
+            guard existing.type == .host else {
+                throw SelectiveRemoteTeamHostMutationError.recordIsNotHost
+            }
+        }
+
+        var exportedProfile = profile
+        exportedProfile.id = recordID
+        let exported = try SelectiveRemotePersonalVaultExporter.makeExport(
+            profiles: [exportedProfile],
+            credentials: [],
+            snippets: [],
+            forwarding: [],
+            deviceID: deviceID
+        ).document.records[0]
+        let priorVersion = existing?.version
+            ?? document.tombstones.first(where: { $0.id == recordID })?.version
+        let record = try SelectiveRemoteVaultRecord(
+            id: recordID,
+            type: .host,
+            version: try priorVersion?.incrementing(deviceID)
+                ?? SelectiveRemoteVaultVersion([deviceID: 1]),
+            modifiedAt: modifiedAt,
+            data: exported.data
+        )
+        return try .init(
+            records: document.records.filter { $0.id != recordID } + [record],
+            tombstones: document.tombstones.filter { $0.id != recordID }
+        )
+    }
+
+    private static func requireWritable(_ role: SelectiveRemoteCloudTeamRole) throws {
+        guard role == .owner || role == .admin || role == .editor else {
+            throw SelectiveRemoteTeamHostMutationError.readOnlyRole
+        }
+    }
+}

--- a/Sources/SelectiveRemote/CloudTeamHostMutation.swift
+++ b/Sources/SelectiveRemote/CloudTeamHostMutation.swift
@@ -5,6 +5,7 @@ enum SelectiveRemoteTeamHostMutationError: LocalizedError, Equatable {
     case duplicateHost
     case hostNotFound
     case recordIsNotHost
+    case syncConflict
 
     var errorDescription: String? {
         switch self {
@@ -19,6 +20,11 @@ enum SelectiveRemoteTeamHostMutationError: LocalizedError, Equatable {
             UpdateLocalization.text(ru: "Team Host больше не существует.", en: "The Team Host no longer exists.")
         case .recordIsNotHost:
             UpdateLocalization.text(ru: "Выбранная запись не является Team Host.", en: "The selected record is not a Team Host.")
+        case .syncConflict:
+            UpdateLocalization.text(
+                ru: "Team Vault изменился параллельно. Локальная версия сохранена; синхронизируйте Vault и повторите.",
+                en: "The Team Vault changed concurrently. The local version was preserved; synchronize the Vault and try again."
+            )
         }
     }
 }
@@ -160,5 +166,164 @@ enum SelectiveRemoteTeamHostDocumentMutation {
         guard isWritable(role: role) else {
             throw SelectiveRemoteTeamHostMutationError.readOnlyRole
         }
+    }
+}
+
+
+struct SelectiveRemoteTeamHostVaultContext: Identifiable, Equatable {
+    let id: UUID
+    let teamID: UUID
+    let teamName: String
+    let role: SelectiveRemoteCloudTeamRole
+    let vaultID: UUID
+    let vaultName: String
+}
+
+enum SelectiveRemoteTeamHostMutationChange {
+    case create(ConnectionProfile)
+    case update(recordID: UUID, profile: ConnectionProfile)
+    case delete(recordID: UUID)
+}
+
+@MainActor
+final class SelectiveRemoteTeamHostMutationService {
+    private let remote: any SelectiveRemoteTeamVaultRemote
+    private let snapshots: any SelectiveRemoteTeamVaultSnapshotStore
+
+    init(
+        remote: any SelectiveRemoteTeamVaultRemote = SelectiveRemoteCloudAPIClient(),
+        snapshots: any SelectiveRemoteTeamVaultSnapshotStore
+    ) {
+        self.remote = remote
+        self.snapshots = snapshots
+    }
+
+    convenience init() throws {
+        try self.init(snapshots: SelectiveRemoteTeamVaultFileSnapshotStore())
+    }
+
+    func apply(
+        _ change: SelectiveRemoteTeamHostMutationChange,
+        to context: SelectiveRemoteTeamHostVaultContext,
+        endpoint: URL,
+        identity: SelectiveRemoteTeamDeviceIdentity,
+        now: Date = Date()
+    ) async throws -> SelectiveRemoteTeamVaultMaterializedSnapshot {
+        guard SelectiveRemoteTeamHostDocumentMutation.isWritable(role: context.role) else {
+            throw SelectiveRemoteTeamHostMutationError.readOnlyRole
+        }
+        let coordinator = try SelectiveRemoteTeamVaultSyncCoordinator(
+            endpoint: endpoint,
+            remote: remote,
+            snapshots: snapshots
+        )
+        let refreshed = try await coordinator.refresh(
+            teamID: context.teamID,
+            vaultID: context.vaultID,
+            identity: identity
+        )
+        let timestamp = Self.timestamp(now)
+        let outcome: SelectiveRemoteTeamVaultPushOutcome
+        switch refreshed {
+        case let .synchronized(snapshot), let .localChanges(snapshot):
+            let current = try SelectiveRemoteVaultDocument.decode(snapshot.payload)
+            let document = try Self.mutated(
+                current,
+                change: change,
+                role: context.role,
+                deviceID: identity.deviceID,
+                timestamp: timestamp
+            )
+            _ = try await coordinator.stage(
+                document.encoded(),
+                teamID: context.teamID,
+                vaultID: context.vaultID,
+                identity: identity
+            )
+            outcome = try await coordinator.push(
+                teamID: context.teamID,
+                vaultID: context.vaultID,
+                identity: identity
+            )
+        case .empty:
+            guard context.role == .owner || context.role == .admin,
+                  case let .create(profile) = change
+            else { throw SelectiveRemoteTeamHostMutationError.hostNotFound }
+            let document = try SelectiveRemoteTeamHostDocumentMutation.create(
+                profile: profile,
+                role: context.role,
+                deviceID: identity.deviceID,
+                modifiedAt: timestamp
+            )
+            let devices = try await remote.teamKeyDevices(
+                endpoint: endpoint,
+                teamID: context.teamID,
+                vaultID: context.vaultID
+            )
+            outcome = try await coordinator.initialize(
+                payload: document.encoded(),
+                teamID: context.teamID,
+                vaultID: context.vaultID,
+                identity: identity,
+                keyDevices: devices
+            )
+        case .conflict:
+            throw SelectiveRemoteTeamHostMutationError.syncConflict
+        }
+        guard case let .uploaded(uploaded) = outcome else {
+            throw SelectiveRemoteTeamHostMutationError.syncConflict
+        }
+        return .init(
+            teamID: context.teamID,
+            teamName: context.teamName,
+            role: context.role,
+            vaultID: context.vaultID,
+            vaultName: context.vaultName,
+            revision: uploaded.snapshot.serverRevision,
+            keyGeneration: uploaded.snapshot.keyGeneration,
+            payload: uploaded.payload
+        )
+    }
+
+    private static func mutated(
+        _ document: SelectiveRemoteVaultDocument,
+        change: SelectiveRemoteTeamHostMutationChange,
+        role: SelectiveRemoteCloudTeamRole,
+        deviceID: UUID,
+        timestamp: String
+    ) throws -> SelectiveRemoteVaultDocument {
+        switch change {
+        case let .create(profile):
+            try SelectiveRemoteTeamHostDocumentMutation.create(
+                in: document,
+                profile: profile,
+                role: role,
+                deviceID: deviceID,
+                modifiedAt: timestamp
+            )
+        case let .update(recordID, profile):
+            try SelectiveRemoteTeamHostDocumentMutation.update(
+                in: document,
+                recordID: recordID,
+                profile: profile,
+                role: role,
+                deviceID: deviceID,
+                modifiedAt: timestamp
+            )
+        case let .delete(recordID):
+            try SelectiveRemoteTeamHostDocumentMutation.delete(
+                from: document,
+                recordID: recordID,
+                role: role,
+                deviceID: deviceID,
+                deletedAt: timestamp
+            )
+        }
+    }
+
+    private static func timestamp(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
     }
 }

--- a/Sources/SelectiveRemote/CloudTeamHostMutation.swift
+++ b/Sources/SelectiveRemote/CloudTeamHostMutation.swift
@@ -1,13 +1,33 @@
 import Foundation
 
-enum SelectiveRemoteTeamHostMutationError: Error, Equatable {
+enum SelectiveRemoteTeamHostMutationError: LocalizedError, Equatable {
     case readOnlyRole
     case duplicateHost
     case hostNotFound
     case recordIsNotHost
+
+    var errorDescription: String? {
+        switch self {
+        case .readOnlyRole:
+            UpdateLocalization.text(
+                ru: "Роль Viewer может только просматривать Team Hosts.",
+                en: "The Viewer role can only view Team Hosts."
+            )
+        case .duplicateHost:
+            UpdateLocalization.text(ru: "Team Host с таким ID уже существует.", en: "A Team Host with this ID already exists.")
+        case .hostNotFound:
+            UpdateLocalization.text(ru: "Team Host больше не существует.", en: "The Team Host no longer exists.")
+        case .recordIsNotHost:
+            UpdateLocalization.text(ru: "Выбранная запись не является Team Host.", en: "The selected record is not a Team Host.")
+        }
+    }
 }
 
 enum SelectiveRemoteTeamHostDocumentMutation {
+    static func isWritable(role: SelectiveRemoteCloudTeamRole) -> Bool {
+        role == .owner || role == .admin || role == .editor
+    }
+
     static func create(
         profile: ConnectionProfile,
         role: SelectiveRemoteCloudTeamRole,
@@ -137,7 +157,7 @@ enum SelectiveRemoteTeamHostDocumentMutation {
     }
 
     private static func requireWritable(_ role: SelectiveRemoteCloudTeamRole) throws {
-        guard role == .owner || role == .admin || role == .editor else {
+        guard isWritable(role: role) else {
             throw SelectiveRemoteTeamHostMutationError.readOnlyRole
         }
     }

--- a/Sources/SelectiveRemote/CloudTeamHosts.swift
+++ b/Sources/SelectiveRemote/CloudTeamHosts.swift
@@ -350,9 +350,12 @@ final class SelectiveRemoteTeamHostStore: ObservableObject {
     static let shared = SelectiveRemoteTeamHostStore()
 
     @Published private(set) var hosts: [SelectiveRemoteTeamHost] = []
+    @Published private(set) var vaults: [SelectiveRemoteTeamHostVaultContext] = []
     @Published private(set) var lastUpdatedAt: Date?
     @Published private(set) var synchronizedVaultCount = 0
     @Published private(set) var invalidVaultCount = 0
+
+    private var snapshots: [String: SelectiveRemoteTeamVaultMaterializedSnapshot] = [:]
 
     init() {}
 
@@ -360,16 +363,54 @@ final class SelectiveRemoteTeamHostStore: ObservableObject {
         with snapshots: [SelectiveRemoteTeamVaultMaterializedSnapshot],
         now: Date = Date()
     ) {
-        var next: [SelectiveRemoteTeamHost] = []
+        self.snapshots = Dictionary(
+            snapshots.map { (scopeKey(teamID: $0.teamID, vaultID: $0.vaultID), $0) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+        rebuild(now: now)
+    }
+
+    func replaceVault(
+        with snapshot: SelectiveRemoteTeamVaultMaterializedSnapshot,
+        now: Date = Date()
+    ) {
+        snapshots[scopeKey(teamID: snapshot.teamID, vaultID: snapshot.vaultID)] = snapshot
+        rebuild(now: now)
+    }
+
+    func clear() {
+        snapshots = [:]
+        hosts = []
+        vaults = []
+        synchronizedVaultCount = 0
+        invalidVaultCount = 0
+        lastUpdatedAt = nil
+    }
+
+    private func rebuild(now: Date) {
+        var nextHosts: [SelectiveRemoteTeamHost] = []
+        var nextVaults: [SelectiveRemoteTeamHostVaultContext] = []
         var invalid = 0
-        for snapshot in snapshots {
+        for snapshot in snapshots.values {
             do {
-                next += try SelectiveRemoteTeamHostMaterializer.materialize(snapshot)
+                nextHosts += try SelectiveRemoteTeamHostMaterializer.materialize(snapshot)
+                nextVaults.append(.init(
+                    id: SelectiveRemoteTeamHostMaterializer.scopedID(
+                        teamID: snapshot.teamID,
+                        vaultID: snapshot.vaultID,
+                        recordID: snapshot.vaultID
+                    ),
+                    teamID: snapshot.teamID,
+                    teamName: snapshot.teamName,
+                    role: snapshot.role,
+                    vaultID: snapshot.vaultID,
+                    vaultName: snapshot.vaultName
+                ))
             } catch {
                 invalid += 1
             }
         }
-        hosts = next.sorted {
+        hosts = nextHosts.sorted {
             let left = [$0.teamName, $0.vaultName, $0.profile.friendlyName]
                 .map { $0.localizedLowercase }
             let right = [$1.teamName, $1.vaultName, $1.profile.friendlyName]
@@ -378,16 +419,19 @@ final class SelectiveRemoteTeamHostStore: ObservableObject {
                 ? $0.recordID.canonicalCloudString < $1.recordID.canonicalCloudString
                 : left.lexicographicallyPrecedes(right)
         }
+        vaults = nextVaults.sorted {
+            [$0.teamName.localizedLowercase, $0.vaultName.localizedLowercase]
+                .lexicographicallyPrecedes(
+                    [$1.teamName.localizedLowercase, $1.vaultName.localizedLowercase]
+                )
+        }
         synchronizedVaultCount = snapshots.count - invalid
         invalidVaultCount = invalid
         lastUpdatedAt = now
     }
 
-    func clear() {
-        hosts = []
-        synchronizedVaultCount = 0
-        invalidVaultCount = 0
-        lastUpdatedAt = nil
+    private func scopeKey(teamID: UUID, vaultID: UUID) -> String {
+        "\(teamID.canonicalCloudString)/\(vaultID.canonicalCloudString)"
     }
 }
 

--- a/Sources/SelectiveRemote/CloudTeamHosts.swift
+++ b/Sources/SelectiveRemote/CloudTeamHosts.swift
@@ -444,9 +444,23 @@ struct SelectiveRemoteTeamHostsView: View {
     @State private var username = ""
     @State private var password = ""
     @State private var gatewayPassword = ""
+    @State private var editorRequest: SelectiveRemoteTeamHostEditorRequest?
+    @State private var hostPendingDeletion: SelectiveRemoteTeamHost?
+    @State private var isMutating = false
+    @State private var mutationMessage: SelectiveRemoteTeamHostMutationMessage?
+    @AppStorage("SelectiveRemote.cloud.endpoint.v1") private var endpoint = SelectiveRemoteCloudEndpoint.production
+    @AppStorage("SelectiveRemote.cloud.device-id.v1") private var storedDeviceID = ""
+
+    private let identityManager = SelectiveRemoteTeamDeviceIdentityManager()
 
     private var selectedHost: SelectiveRemoteTeamHost? {
         store.hosts.first(where: { $0.id == selectedHostID })
+    }
+
+    private var writableVaults: [SelectiveRemoteTeamHostVaultContext] {
+        store.vaults.filter {
+            SelectiveRemoteTeamHostDocumentMutation.isWritable(role: $0.role)
+        }
     }
 
     var body: some View {
@@ -502,6 +516,29 @@ struct SelectiveRemoteTeamHostsView: View {
                         Text(lastUpdatedAt, style: .time)
                     }
                     Spacer()
+                    Menu {
+                        ForEach(writableVaults) { vault in
+                            Button("\(vault.teamName) / \(vault.vaultName)") {
+                                editorRequest = .init(context: vault, host: nil)
+                            }
+                        }
+                    } label: {
+                        Label(
+                            UpdateLocalization.text(ru: "Добавить Host", en: "Add Host"),
+                            systemImage: "plus"
+                        )
+                    }
+                    .disabled(writableVaults.isEmpty || isMutating)
+                    .help(writableVaults.isEmpty
+                        ? UpdateLocalization.text(
+                            ru: "Нет синхронизированного Team Vault с правом записи",
+                            en: "No synchronized writable Team Vault"
+                        )
+                        : UpdateLocalization.text(
+                            ru: "Добавить Host в Team Vault",
+                            en: "Add a Host to a Team Vault"
+                        )
+                    )
                     if store.invalidVaultCount > 0 {
                         Label(
                             "\(store.invalidVaultCount)",
@@ -535,6 +572,66 @@ struct SelectiveRemoteTeamHostsView: View {
         .onAppear { normalizeSelection() }
         .onChange(of: store.hosts.map(\.id)) { _, _ in normalizeSelection() }
         .onChange(of: selectedHostID) { _, _ in resetConnectionFields() }
+        .sheet(item: $editorRequest) { request in
+            SelectiveRemoteTeamHostEditorView(request: request) { profile in
+                mutate(
+                    request.host.map {
+                        .update(recordID: $0.recordID, profile: profile)
+                    } ?? .create(profile),
+                    context: request.context,
+                    selectedRecordID: profile.id
+                )
+            }
+        }
+        .confirmationDialog(
+            UpdateLocalization.text(ru: "Удалить Team Host?", en: "Delete Team Host?"),
+            isPresented: Binding(
+                get: { hostPendingDeletion != nil },
+                set: { if !$0 { hostPendingDeletion = nil } }
+            ),
+            presenting: hostPendingDeletion
+        ) { host in
+            Button(
+                UpdateLocalization.text(ru: "Удалить", en: "Delete"),
+                role: .destructive
+            ) {
+                if let context = context(for: host) {
+                    mutate(
+                        .delete(recordID: host.recordID),
+                        context: context,
+                        selectedRecordID: nil
+                    )
+                }
+                hostPendingDeletion = nil
+            }
+            Button(UpdateLocalization.text(ru: "Отмена", en: "Cancel"), role: .cancel) {}
+        } message: { host in
+            Text(host.profile.friendlyName)
+        }
+        .alert(item: $mutationMessage) { value in
+            Alert(
+                title: Text(value.isError
+                    ? UpdateLocalization.text(ru: "Team Host не изменён", en: "Team Host Not Changed")
+                    : UpdateLocalization.text(ru: "Team Host обновлён", en: "Team Host Updated")
+                ),
+                message: Text(value.text),
+                dismissButton: .default(Text("OK"))
+            )
+        }
+        .overlay {
+            if isMutating {
+                ZStack {
+                    Color.black.opacity(0.12)
+                    ProgressView(UpdateLocalization.text(
+                        ru: "Шифрование и синхронизация…",
+                        en: "Encrypting and synchronizing…"
+                    ))
+                    .padding(18)
+                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+                }
+                .ignoresSafeArea()
+            }
+        }
     }
 
     private func hostDetail(_ host: SelectiveRemoteTeamHost) -> some View {
@@ -554,6 +651,25 @@ struct SelectiveRemoteTeamHostsView: View {
                             .textSelection(.enabled)
                     }
                     Spacer()
+                    if SelectiveRemoteTeamHostDocumentMutation.isWritable(role: host.role) {
+                        Button(
+                            UpdateLocalization.text(ru: "Изменить", en: "Edit"),
+                            systemImage: "pencil"
+                        ) {
+                            if let context = context(for: host) {
+                                editorRequest = .init(context: context, host: host)
+                            }
+                        }
+                        .disabled(isMutating)
+                        Button(
+                            UpdateLocalization.text(ru: "Удалить", en: "Delete"),
+                            systemImage: "trash",
+                            role: .destructive
+                        ) {
+                            hostPendingDeletion = host
+                        }
+                        .disabled(isMutating)
+                    }
                     Text(roleTitle(host.role))
                         .font(.caption.bold())
                         .padding(.horizontal, 9)
@@ -658,6 +774,70 @@ struct SelectiveRemoteTeamHostsView: View {
             .frame(maxWidth: 900, alignment: .leading)
             .padding(24)
         }
+    }
+
+    private func context(
+        for host: SelectiveRemoteTeamHost
+    ) -> SelectiveRemoteTeamHostVaultContext? {
+        store.vaults.first {
+            $0.teamID == host.teamID && $0.vaultID == host.vaultID
+        }
+    }
+
+    private func mutate(
+        _ change: SelectiveRemoteTeamHostMutationChange,
+        context: SelectiveRemoteTeamHostVaultContext,
+        selectedRecordID: UUID?
+    ) {
+        guard !isMutating else { return }
+        isMutating = true
+        Task { @MainActor in
+            defer { isMutating = false }
+            do {
+                let url = try SelectiveRemoteCloudEndpoint.normalized(endpoint)
+                let deviceID = resolvedDeviceID()
+                let identity = try await identityManager.identity(
+                    endpoint: url,
+                    deviceID: deviceID
+                )
+                let service = try SelectiveRemoteTeamHostMutationService()
+                let snapshot = try await service.apply(
+                    change,
+                    to: context,
+                    endpoint: url,
+                    identity: identity
+                )
+                store.replaceVault(with: snapshot)
+                if let selectedRecordID {
+                    selectedHostID = SelectiveRemoteTeamHostMaterializer.scopedID(
+                        teamID: context.teamID,
+                        vaultID: context.vaultID,
+                        recordID: selectedRecordID
+                    )
+                } else {
+                    selectedHostID = nil
+                }
+                mutationMessage = .init(
+                    text: UpdateLocalization.text(
+                        ru: "Зашифрованная Team Vault ревизия синхронизирована.",
+                        en: "The encrypted Team Vault revision was synchronized."
+                    ),
+                    isError: false
+                )
+            } catch {
+                mutationMessage = .init(text: error.localizedDescription, isError: true)
+            }
+        }
+    }
+
+    private func resolvedDeviceID() -> UUID {
+        if let value = UUID(uuidString: storedDeviceID),
+           value.isSelectiveRemoteCloudUUID {
+            return value
+        }
+        let value = UUID()
+        storedDeviceID = value.canonicalCloudString
+        return value
     }
 
     private func connect(_ host: SelectiveRemoteTeamHost) {

--- a/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
@@ -144,6 +144,107 @@ struct CloudTeamHostsTests {
         #expect(store.invalidVaultCount == 1)
     }
 
+
+    @Test("Owner, Admin, and Editor can create, update, and delete a Team Host")
+    func writableRolesMutateHostCausally() throws {
+        let deviceID = try #require(
+            UUID(uuidString: "44444444-4444-4444-8444-444444444444")
+        )
+        let recordID = try #require(
+            UUID(uuidString: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+        )
+        for role in [
+            SelectiveRemoteCloudTeamRole.owner,
+            .admin,
+            .editor
+        ] {
+            var profile = ConnectionProfile(connectionType: .ssh)
+            profile.id = recordID
+            profile.friendlyName = "Build Host"
+            profile.host = "build.example.invalid"
+            profile.username = "builder"
+
+            let created = try SelectiveRemoteTeamHostDocumentMutation.create(
+                profile: profile,
+                role: role,
+                deviceID: deviceID,
+                modifiedAt: "2026-09-10T01:00:00.000Z"
+            )
+            let createdRecord = try #require(created.records.first)
+            #expect(createdRecord.type == .host)
+            #expect(createdRecord.version.counters[deviceID] == 1)
+
+            profile.friendlyName = "Production Host"
+            let updated = try SelectiveRemoteTeamHostDocumentMutation.update(
+                in: created,
+                recordID: recordID,
+                profile: profile,
+                role: role,
+                deviceID: deviceID,
+                modifiedAt: "2026-09-10T01:01:00.000Z"
+            )
+            #expect(updated.records.first?.version.counters[deviceID] == 2)
+
+            let deleted = try SelectiveRemoteTeamHostDocumentMutation.delete(
+                from: updated,
+                recordID: recordID,
+                role: role,
+                deviceID: deviceID,
+                deletedAt: "2026-09-10T01:02:00.000Z"
+            )
+            #expect(deleted.records.isEmpty)
+            #expect(deleted.tombstones.first?.id == recordID)
+            #expect(deleted.tombstones.first?.version.counters[deviceID] == 3)
+        }
+    }
+
+    @Test("Viewer mutations fail before changing the Team Vault document")
+    func viewerIsStrictlyReadOnly() throws {
+        let deviceID = try #require(
+            UUID(uuidString: "44444444-4444-4444-8444-444444444444")
+        )
+        var profile = ConnectionProfile(connectionType: .rdp)
+        profile.id = try #require(
+            UUID(uuidString: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+        )
+        profile.friendlyName = "Denied"
+        profile.host = "denied.example.invalid"
+
+        #expect(throws: SelectiveRemoteTeamHostMutationError.readOnlyRole) {
+            _ = try SelectiveRemoteTeamHostDocumentMutation.create(
+                profile: profile,
+                role: .viewer,
+                deviceID: deviceID,
+                modifiedAt: "2026-09-10T02:00:00.000Z"
+            )
+        }
+    }
+
+    @Test("Host mutations preserve unrelated Team Vault records")
+    func preservesUnrelatedRecords() throws {
+        let deviceID = try #require(
+            UUID(uuidString: "44444444-4444-4444-8444-444444444444")
+        )
+        let original = try SelectiveRemoteVaultDocument.decode(Self.fixtureData())
+        let preserved = try #require(original.records.first)
+        var profile = ConnectionProfile(connectionType: .ssh)
+        profile.id = try #require(
+            UUID(uuidString: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+        )
+        profile.friendlyName = "New Host"
+        profile.host = "new.example.invalid"
+
+        let mutated = try SelectiveRemoteTeamHostDocumentMutation.create(
+            in: original,
+            profile: profile,
+            role: .editor,
+            deviceID: deviceID,
+            modifiedAt: "2026-09-10T03:00:00.000Z"
+        )
+        #expect(mutated.records.first(where: { $0.id == preserved.id }) == preserved)
+        #expect(mutated.records.count == original.records.count + 1)
+    }
+
     private static func snapshot(
         payload: Data
     ) -> SelectiveRemoteTeamVaultMaterializedSnapshot {

--- a/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
@@ -245,8 +245,45 @@ struct CloudTeamHostsTests {
         #expect(mutated.records.count == original.records.count + 1)
     }
 
+
+    @MainActor
+    @Test("store exposes valid Vault contexts and replaces one Vault without touching another")
+    func storeReplacesOneVault() throws {
+        let first = Self.snapshot(payload: try Self.fixtureData(), role: .editor)
+        let second = SelectiveRemoteTeamVaultMaterializedSnapshot(
+            teamID: try #require(UUID(uuidString: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")),
+            teamName: "Security",
+            role: role,
+            vaultID: try #require(UUID(uuidString: "cccccccc-cccc-4ccc-8ccc-cccccccccccc")),
+            vaultName: "Audit",
+            revision: 1,
+            keyGeneration: 1,
+            payload: try SelectiveRemoteVaultDocument().encoded()
+        )
+        let store = SelectiveRemoteTeamHostStore()
+        store.replace(with: [first, second])
+        #expect(store.vaults.count == 2)
+        #expect(store.vaults.first(where: { $0.vaultID == first.vaultID })?.role == .editor)
+
+        let updated = SelectiveRemoteTeamVaultMaterializedSnapshot(
+            teamID: first.teamID,
+            teamName: first.teamName,
+            role: first.role,
+            vaultID: first.vaultID,
+            vaultName: first.vaultName,
+            revision: first.revision + 1,
+            keyGeneration: first.keyGeneration,
+            payload: try SelectiveRemoteVaultDocument().encoded()
+        )
+        store.replaceVault(with: updated)
+        #expect(store.vaults.count == 2)
+        #expect(store.hosts.isEmpty)
+        #expect(store.synchronizedVaultCount == 2)
+    }
+
     private static func snapshot(
-        payload: Data
+        payload: Data,
+        role: SelectiveRemoteCloudTeamRole = .viewer
     ) -> SelectiveRemoteTeamVaultMaterializedSnapshot {
         .init(
             teamID: UUID(uuidString: "11111111-1111-4111-8111-111111111111")!,

--- a/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
@@ -145,6 +145,15 @@ struct CloudTeamHostsTests {
     }
 
 
+
+    @Test("Team Host write capability matches the complete role matrix")
+    func writeCapabilityRoleMatrix() {
+        #expect(SelectiveRemoteTeamHostDocumentMutation.isWritable(role: .owner))
+        #expect(SelectiveRemoteTeamHostDocumentMutation.isWritable(role: .admin))
+        #expect(SelectiveRemoteTeamHostDocumentMutation.isWritable(role: .editor))
+        #expect(!SelectiveRemoteTeamHostDocumentMutation.isWritable(role: .viewer))
+    }
+
     @Test("Owner, Admin, and Editor can create, update, and delete a Team Host")
     func writableRolesMutateHostCausally() throws {
         let deviceID = try #require(

--- a/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
@@ -297,7 +297,7 @@ struct CloudTeamHostsTests {
         .init(
             teamID: UUID(uuidString: "11111111-1111-4111-8111-111111111111")!,
             teamName: "Platform",
-            role: .viewer,
+            role: role,
             vaultID: UUID(uuidString: "22222222-2222-4222-8222-222222222222")!,
             vaultName: "Operations",
             revision: 7,

--- a/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
@@ -262,7 +262,7 @@ struct CloudTeamHostsTests {
         let second = SelectiveRemoteTeamVaultMaterializedSnapshot(
             teamID: try #require(UUID(uuidString: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")),
             teamName: "Security",
-            role: role,
+            role: .viewer,
             vaultID: try #require(UUID(uuidString: "cccccccc-cccc-4ccc-8ccc-cccccccccccc")),
             vaultName: "Audit",
             revision: 1,

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -300,3 +300,25 @@ test("macOS projects Team Hosts separately and connects without Personal persist
   assert.match(terminal, /var isEphemeral: Bool/);
   assert.match(terminal, /tabs\.filter \{ !\$0\.isEphemeral \}\.map/);
 });
+
+
+test("macOS Team Host controls expose writes only through the encrypted role-aware service", async () => {
+  const [hosts, editor, mutation] = await Promise.all([
+    readFile(new URL("CloudTeamHosts.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudTeamHostEditor.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudTeamHostMutation.swift", sourceRoot), "utf8"),
+  ]);
+  assert.match(hosts, /writableVaults[\s\S]*isWritable\(role:/u);
+  assert.match(hosts, /if SelectiveRemoteTeamHostDocumentMutation\.isWritable\(role: host\.role\)/u);
+  assert.match(hosts, /\.create\(profile\)/u);
+  assert.match(hosts, /\.update\(recordID:/u);
+  assert.match(hosts, /\.delete\(recordID:/u);
+  assert.match(hosts, /store\.replaceVault\(with: snapshot\)/u);
+  assert.doesNotMatch(hosts, /model\.profiles|profiles\.append/u);
+  assert.match(editor, /Passwords and Personal Vault references are not saved/u);
+  assert.doesNotMatch(editor, /SecureField|password/u);
+  assert.match(mutation, /case \.readOnlyRole/u);
+  assert.match(mutation, /coordinator\.refresh/u);
+  assert.match(mutation, /coordinator\.stage/u);
+  assert.match(mutation, /coordinator\.push/u);
+});


### PR DESCRIPTION
## Summary

Stacked on #80.

- add role-aware macOS create, edit, and delete controls for Team Hosts
- expose writable Vault selection only for Owner, Admin, and Editor
- keep Viewer UI strictly read-only while preserving connection actions
- edit safe Host fields without showing or storing passwords
- refresh, stage, encrypt, and causally push Team Vault revisions
- advance version vectors/tombstones and preserve unrelated Vault records
- rematerialize only the uploaded Vault and keep Team records out of Personal persistence
- show progress, success/failure feedback, and destructive delete confirmation

## Validation

- CI #570: success
- Test DMG #246: success
- 393 Swift tests, terminal web tests, Cloud tests, PostgreSQL 16 tests, and release build passed
- ARM64 artifact: `SelectiveRemote-test-81-arm64` (33,336,971 bytes)
- Artifact SHA-256: `f30576dd654f14100b3efe56c3d5b0c6c16c7aadd36112269a1367143a383390`

## Stack

This PR is intentionally based on #80 (`feature/team-automation-recovery-ui`).