### PR TITLE
Organize Team Hosts with shared folders and tags

### DIFF
--- a/Sources/SelectiveRemote/CloudTeamHostEditor.swift
+++ b/Sources/SelectiveRemote/CloudTeamHostEditor.swift
@@ -21,6 +21,9 @@ struct SelectiveRemoteTeamHostEditorView: View {
     @State private var address: String
     @State private var username: String
     @State private var connectionType: ConnectionType
+    @State private var folder: String
+    @State private var tagsText: String
+    @State private var profileDescription: String
 
     init(
         request: SelectiveRemoteTeamHostEditorRequest,
@@ -33,6 +36,9 @@ struct SelectiveRemoteTeamHostEditorView: View {
         _address = State(initialValue: profile.map(Self.address) ?? "")
         _username = State(initialValue: profile?.username ?? "")
         _connectionType = State(initialValue: profile?.connectionType ?? .ssh)
+        _folder = State(initialValue: profile?.group ?? "")
+        _tagsText = State(initialValue: profile?.tags.joined(separator: ", ") ?? "")
+        _profileDescription = State(initialValue: profile?.profileDescription ?? "")
     }
 
     private var isValid: Bool {
@@ -48,7 +54,28 @@ struct SelectiveRemoteTeamHostEditorView: View {
             && !address.contains(where: { $0.isNewline })
             && username.count <= 256
             && !username.contains(where: { $0.isNewline })
+            && validFolder
+            && tagsText.utf8.count <= 8_192
+            && parsedTags.count <= 64
+            && Set(parsedTags).count == parsedTags.count
+            && parsedTags.allSatisfy { $0.count <= 64 && !$0.contains(where: { $0.isNewline }) }
+            && profileDescription.utf8.count <= 2_048
+            && !profileDescription.contains(where: { $0.isNewline })
             && (connectionType != .serial || address.hasPrefix("/dev/cu."))
+    }
+
+    private var parsedTags: [String] {
+        tagsText.split(separator: ",", omittingEmptySubsequences: true)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private var validFolder: Bool {
+        folder.isEmpty || (
+            folder == folder.trimmingCharacters(in: .whitespacesAndNewlines)
+                && folder.count <= 120
+                && !folder.contains(where: { $0.isNewline })
+        )
     }
 
     var body: some View {
@@ -102,6 +129,23 @@ struct SelectiveRemoteTeamHostEditorView: View {
                         text: $username
                     )
                 }
+                TextField(
+                    UpdateLocalization.text(ru: "Папка", en: "Folder"),
+                    text: $folder
+                )
+                TextField(
+                    UpdateLocalization.text(
+                        ru: "Теги через запятую",
+                        en: "Comma-separated tags"
+                    ),
+                    text: $tagsText
+                )
+                TextField(
+                    UpdateLocalization.text(ru: "Описание", en: "Description"),
+                    text: $profileDescription,
+                    axis: .vertical
+                )
+                .lineLimit(2 ... 5)
             }
             .formStyle(.grouped)
 
@@ -140,6 +184,9 @@ struct SelectiveRemoteTeamHostEditorView: View {
         profile.id = request.host?.recordID ?? UUID()
         profile.friendlyName = title
         profile.username = username
+        profile.group = folder
+        profile.tags = parsedTags
+        profile.profileDescription = profileDescription
         if connectionType == .serial {
             profile.serialDevicePath = address
         } else {

--- a/Sources/SelectiveRemote/CloudTeamHosts.swift
+++ b/Sources/SelectiveRemote/CloudTeamHosts.swift
@@ -213,7 +213,13 @@ enum SelectiveRemoteTeamHostMaterializer {
               input.gatewayHost.utf8.count <= 2_048,
               input.gatewayUsername.utf8.count <= 256,
               !input.gatewayHost.contains(where: { $0.isNewline }),
-              !input.gatewayUsername.contains(where: { $0.isNewline })
+              !input.gatewayUsername.contains(where: { $0.isNewline }),
+              validOptionalName(input.group),
+              input.tags.count <= 64,
+              Set(input.tags).count == input.tags.count,
+              input.tags.allSatisfy(validTag),
+              input.profileDescription.utf8.count <= 2_048,
+              !input.profileDescription.contains(where: { $0.isNewline })
         else { throw SelectiveRemoteTeamHostMaterializationError.invalidHostRecord }
 
         switch input.connectionType {
@@ -293,9 +299,9 @@ enum SelectiveRemoteTeamHostMaterializer {
         safe.detectedOperatingSystemID = ""
         safe.detectedOperatingSystemLike = ""
         safe.operatingSystemDetectedAt = nil
-        safe.group = ""
-        safe.tags = []
-        safe.profileDescription = ""
+        safe.group = input.group
+        safe.tags = input.tags
+        safe.profileDescription = input.profileDescription
         safe.createdAt = Date(timeIntervalSince1970: 0)
         safe.lastConnectedAt = nil
         return safe
@@ -330,6 +336,18 @@ enum SelectiveRemoteTeamHostMaterializer {
 
     private static func validTitle(_ value: String) -> Bool {
         validName(value)
+    }
+
+    private static func validOptionalName(_ value: String) -> Bool {
+        value.isEmpty || validName(value)
+    }
+
+    private static func validTag(_ value: String) -> Bool {
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !normalized.isEmpty
+            && normalized == value
+            && value.count <= 64
+            && !value.contains(where: { $0.isNewline })
     }
 
     private static func validAddress(_ value: String) -> Bool {
@@ -448,6 +466,8 @@ struct SelectiveRemoteTeamHostsView: View {
     @State private var hostPendingDeletion: SelectiveRemoteTeamHost?
     @State private var isMutating = false
     @State private var mutationMessage: SelectiveRemoteTeamHostMutationMessage?
+    @State private var searchText = ""
+    @State private var selectedFolder = ""
     @AppStorage("SelectiveRemote.cloud.endpoint.v1") private var endpoint = SelectiveRemoteCloudEndpoint.production
     @AppStorage("SelectiveRemote.cloud.device-id.v1") private var storedDeviceID = ""
 
@@ -460,6 +480,27 @@ struct SelectiveRemoteTeamHostsView: View {
     private var writableVaults: [SelectiveRemoteTeamHostVaultContext] {
         store.vaults.filter {
             SelectiveRemoteTeamHostDocumentMutation.isWritable(role: $0.role)
+        }
+    }
+
+    private var folderNames: [String] {
+        Array(Set(store.hosts.map { $0.profile.group }))
+            .sorted { folderTitle($0).localizedCaseInsensitiveCompare(folderTitle($1)) == .orderedAscending }
+    }
+
+    private var visibleHosts: [SelectiveRemoteTeamHost] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return store.hosts.filter { host in
+            (selectedFolder.isEmpty || host.profile.group == selectedFolder)
+                && (query.isEmpty || [
+                    host.profile.friendlyName,
+                    host.address,
+                    host.profile.username,
+                    host.teamName,
+                    host.vaultName,
+                    host.profile.group,
+                    host.profile.tags.joined(separator: " ")
+                ].contains { $0.localizedCaseInsensitiveContains(query) })
         }
     }
 
@@ -479,31 +520,27 @@ struct SelectiveRemoteTeamHostsView: View {
                         ))
                     )
                 } else {
-                    List(store.hosts, selection: $selectedHostID) { host in
-                        VStack(alignment: .leading, spacing: 4) {
-                            Label(
-                                host.profile.friendlyName,
-                                systemImage: host.profile.connectionType.systemImage
-                            )
-                            .font(.headline)
-                            HStack(spacing: 5) {
-                                Text(host.teamName)
-                                Text("·")
-                                Text(host.vaultName)
-                                Text("·")
-                                Text(host.profile.connectionType.title)
+                    List(selection: $selectedHostID) {
+                        ForEach(folderNames, id: \.self) { folder in
+                            let hosts = visibleHosts.filter { $0.profile.group == folder }
+                            if !hosts.isEmpty {
+                                Section(folderTitle(folder)) {
+                                    ForEach(hosts) { host in
+                                        hostRow(host)
+                                            .tag(host.id)
+                                    }
+                                }
                             }
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            Text(host.address)
-                                .font(.caption.monospaced())
-                                .foregroundStyle(.secondary)
-                                .lineLimit(1)
                         }
-                        .padding(.vertical, 4)
-                        .tag(host.id)
                     }
                     .listStyle(.sidebar)
+                    .searchable(
+                        text: $searchText,
+                        prompt: UpdateLocalization.text(
+                            ru: "Host, адрес, папка или тег",
+                            en: "Host, address, folder, or tag"
+                        )
+                    )
                 }
 
                 Divider()
@@ -516,6 +553,23 @@ struct SelectiveRemoteTeamHostsView: View {
                         Text(lastUpdatedAt, style: .time)
                     }
                     Spacer()
+                    Menu {
+                        Button(UpdateLocalization.text(ru: "Все папки", en: "All Folders")) {
+                            selectedFolder = ""
+                        }
+                        Divider()
+                        ForEach(folderNames.filter { !$0.isEmpty }, id: \.self) { folder in
+                            Button(folder) { selectedFolder = folder }
+                        }
+                    } label: {
+                        Label(
+                            selectedFolder.isEmpty
+                                ? UpdateLocalization.text(ru: "Все папки", en: "All Folders")
+                                : selectedFolder,
+                            systemImage: "line.3.horizontal.decrease.circle"
+                        )
+                    }
+
                     Menu {
                         ForEach(writableVaults) { vault in
                             Button("\(vault.teamName) / \(vault.vaultName)") {
@@ -634,6 +688,42 @@ struct SelectiveRemoteTeamHostsView: View {
         }
     }
 
+    private func hostRow(_ host: SelectiveRemoteTeamHost) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Label(
+                host.profile.friendlyName,
+                systemImage: host.profile.connectionType.systemImage
+            )
+            .font(.headline)
+            HStack(spacing: 5) {
+                Text(host.teamName)
+                Text("·")
+                Text(host.vaultName)
+                Text("·")
+                Text(host.profile.connectionType.title)
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            Text(host.address)
+                .font(.caption.monospaced())
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            if !host.profile.tags.isEmpty {
+                Text(host.profile.tags.map { "#\($0)" }.joined(separator: " "))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func folderTitle(_ folder: String) -> String {
+        folder.isEmpty
+            ? UpdateLocalization.text(ru: "Без папки", en: "No Folder")
+            : folder
+    }
+
     private func hostDetail(_ host: SelectiveRemoteTeamHost) -> some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
@@ -681,6 +771,22 @@ struct SelectiveRemoteTeamHostsView: View {
                     VStack(alignment: .leading, spacing: 9) {
                         LabeledContent("Team", value: host.teamName)
                         LabeledContent("Vault", value: host.vaultName)
+                        LabeledContent(
+                            UpdateLocalization.text(ru: "Папка", en: "Folder"),
+                            value: folderTitle(host.profile.group)
+                        )
+                        if !host.profile.tags.isEmpty {
+                            LabeledContent(
+                                UpdateLocalization.text(ru: "Теги", en: "Tags"),
+                                value: host.profile.tags.map { "#\($0)" }.joined(separator: " ")
+                            )
+                        }
+                        if !host.profile.profileDescription.isEmpty {
+                            LabeledContent(
+                                UpdateLocalization.text(ru: "Описание", en: "Description"),
+                                value: host.profile.profileDescription
+                            )
+                        }
                         LabeledContent(
                             UpdateLocalization.text(ru: "Ревизия", en: "Revision"),
                             value: "\(host.revision)"

--- a/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
@@ -54,6 +54,9 @@ struct CloudTeamHostsTests {
         profile.friendlyName = unicodeTitle
         profile.host = "ops.example.invalid"
         profile.username = "operator"
+        profile.group = "Production / Linux"
+        profile.tags = ["critical", "eu-west"]
+        profile.profileDescription = "Shared bastion"
         profile.sshPort = 2_222
         profile.sshIdentityID = UUID()
         profile.sshJumpHostProfileID = UUID()
@@ -88,6 +91,9 @@ struct CloudTeamHostsTests {
         #expect(host.recordID == profileID)
         #expect(host.id != profileID)
         #expect(host.profile.friendlyName == unicodeTitle)
+        #expect(host.profile.group == "Production / Linux")
+        #expect(host.profile.tags == ["critical", "eu-west"])
+        #expect(host.profile.profileDescription == "Shared bastion")
         #expect(host.profile.sshIdentityID == nil)
         #expect(host.profile.sshJumpHostProfileID == nil)
         #expect(host.profile.sshProxyMode == .none)

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -322,3 +322,21 @@ test("macOS Team Host controls expose writes only through the encrypted role-awa
   assert.match(mutation, /coordinator\.stage/u);
   assert.match(mutation, /coordinator\.push/u);
 });
+
+
+test("macOS Team Hosts expose shared folders, tags, and local filtering controls", async () => {
+  const [hosts, editor] = await Promise.all([
+    readFile(new URL("CloudTeamHosts.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudTeamHostEditor.swift", sourceRoot), "utf8"),
+  ]);
+  assert.match(hosts, /safe\.group = input\.group/u);
+  assert.match(hosts, /safe\.tags = input\.tags/u);
+  assert.match(hosts, /safe\.profileDescription = input\.profileDescription/u);
+  assert.match(hosts, /\.searchable\(/u);
+  assert.match(hosts, /selectedFolder/u);
+  assert.match(hosts, /Section\(folderTitle\(folder\)\)/u);
+  assert.match(editor, /Теги через запятую/u);
+  assert.match(editor, /Папка/u);
+  assert.match(editor, /profile\.group = folder/u);
+  assert.match(editor, /profile\.tags = parsedTags/u);
+});


### PR DESCRIPTION
## Summary

- preserve bounded shared folder, tags, and description metadata inside encrypted Team Host profiles
- group the macOS Team Hosts list into folder sections, including a backward-compatible No Folder section
- filter by folder and search across host, address, username, Team, Vault, folder, and tags
- edit shared organization metadata without changing Personal profiles or credentials
- display folder, tags, and description in the shared-resource details
- reject malformed or oversized organization metadata fail-closed at whole-Vault materialization

## Validation

- CI #580: success
- Test DMG #248: success
- Swift tests, terminal-web tests, Cloud tests, PostgreSQL 16 tests, and release build passed
- ARM64 artifact: `SelectiveRemote-test-82-arm64` (33,365,335 bytes)
- Artifact SHA-256: `295dbad56ef79a51ad6d9b5dd8ec1f18959ff2ce82f447877e07a065844350c8`

## Follow-up

Personal per-member connection overrides and encrypted Team Credentials will follow as separate stacked slices so organization metadata, device-local preferences, and secrets keep distinct trust boundaries.