### PR TITLE
Add per-user Team Host connection settings

### DIFF
--- a/Sources/SelectiveRemote/CloudTeamHostPersonalSettings.swift
+++ b/Sources/SelectiveRemote/CloudTeamHostPersonalSettings.swift
@@ -96,33 +96,41 @@ final class SelectiveRemoteTeamHostPersonalSettingsStore: ObservableObject {
         }
     }
 
-    func settings(for host: SelectiveRemoteTeamHost) -> SelectiveRemoteTeamHostPersonalSettings {
-        values[key(for: host)] ?? .init(profile: host.profile)
+    func settings(
+        for host: SelectiveRemoteTeamHost,
+        endpoint: String
+    ) -> SelectiveRemoteTeamHostPersonalSettings {
+        values[key(for: host, endpoint: endpoint)] ?? .init(profile: host.profile)
     }
 
-    func hasSettings(for host: SelectiveRemoteTeamHost) -> Bool {
-        values[key(for: host)] != nil
+    func hasSettings(for host: SelectiveRemoteTeamHost, endpoint: String) -> Bool {
+        values[key(for: host, endpoint: endpoint)] != nil
     }
 
     func save(
         _ settings: SelectiveRemoteTeamHostPersonalSettings,
-        for host: SelectiveRemoteTeamHost
+        for host: SelectiveRemoteTeamHost,
+        endpoint: String
     ) {
-        values[key(for: host)] = settings.normalized
+        values[key(for: host, endpoint: endpoint)] = settings.normalized
         persist()
     }
 
-    func reset(for host: SelectiveRemoteTeamHost) {
-        values.removeValue(forKey: key(for: host))
+    func reset(for host: SelectiveRemoteTeamHost, endpoint: String) {
+        values.removeValue(forKey: key(for: host, endpoint: endpoint))
         persist()
     }
 
-    func appliedProfile(for host: SelectiveRemoteTeamHost) -> ConnectionProfile {
-        settings(for: host).applying(to: host.profile)
+    func appliedProfile(
+        for host: SelectiveRemoteTeamHost,
+        endpoint: String
+    ) -> ConnectionProfile {
+        settings(for: host, endpoint: endpoint).applying(to: host.profile)
     }
 
-    private func key(for host: SelectiveRemoteTeamHost) -> String {
+    private func key(for host: SelectiveRemoteTeamHost, endpoint: String) -> String {
         [
+            endpoint.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
             host.teamID.uuidString.lowercased(),
             host.vaultID.uuidString.lowercased(),
             host.recordID.uuidString.lowercased()
@@ -138,17 +146,20 @@ final class SelectiveRemoteTeamHostPersonalSettingsStore: ObservableObject {
 @MainActor
 struct SelectiveRemoteTeamHostPersonalSettingsView: View {
     let host: SelectiveRemoteTeamHost
+    let endpoint: String
     @ObservedObject var store: SelectiveRemoteTeamHostPersonalSettingsStore
     @Environment(\.dismiss) private var dismiss
     @State private var draft: SelectiveRemoteTeamHostPersonalSettings
 
     init(
         host: SelectiveRemoteTeamHost,
+        endpoint: String,
         store: SelectiveRemoteTeamHostPersonalSettingsStore
     ) {
         self.host = host
+        self.endpoint = endpoint
         self.store = store
-        _draft = State(initialValue: store.settings(for: host))
+        _draft = State(initialValue: store.settings(for: host, endpoint: endpoint))
     }
 
     var body: some View {
@@ -275,16 +286,16 @@ struct SelectiveRemoteTeamHostPersonalSettingsView: View {
                     UpdateLocalization.text(ru: "Сбросить мои настройки", en: "Reset My Settings"),
                     role: .destructive
                 ) {
-                    store.reset(for: host)
+                    store.reset(for: host, endpoint: endpoint)
                     dismiss()
                 }
-                .disabled(!store.hasSettings(for: host))
+                .disabled(!store.hasSettings(for: host, endpoint: endpoint))
                 Spacer()
                 Button(UpdateLocalization.text(ru: "Отмена", en: "Cancel")) {
                     dismiss()
                 }
                 Button(UpdateLocalization.text(ru: "Сохранить", en: "Save")) {
-                    store.save(draft, for: host)
+                    store.save(draft, for: host, endpoint: endpoint)
                     dismiss()
                 }
                 .buttonStyle(.borderedProminent)

--- a/Sources/SelectiveRemote/CloudTeamHostPersonalSettings.swift
+++ b/Sources/SelectiveRemote/CloudTeamHostPersonalSettings.swift
@@ -1,0 +1,299 @@
+import Foundation
+import SwiftUI
+
+struct SelectiveRemoteTeamHostPersonalSettings: Codable, Equatable {
+    var preferredUsername: String
+    var windowsScale: WindowsScale
+    var rdpQuality: RDPQualityPreset
+    var audioMode: AudioMode
+    var clipboardMode: ClipboardMode
+    var mapCommandToControl: Bool
+    var mapOptionToWindows: Bool
+    var mapRightCommandToWindows: Bool
+    var fnSwitchesWindowsLanguage: Bool
+    var autoReconnect: Bool
+    var reconnectAfterWake: Bool
+    var adminSession: Bool
+    var rdpWindowMode: RDPWindowMode
+    var windowWidth: Int
+    var windowHeight: Int
+
+    init(profile: ConnectionProfile) {
+        preferredUsername = profile.username
+        windowsScale = profile.windowsScale
+        rdpQuality = profile.rdpQuality
+        audioMode = profile.audioMode
+        clipboardMode = profile.clipboardMode
+        mapCommandToControl = profile.mapCommandToControl
+        mapOptionToWindows = profile.mapOptionToWindows
+        mapRightCommandToWindows = profile.mapRightCommandToWindows
+        fnSwitchesWindowsLanguage = profile.fnSwitchesWindowsLanguage
+        autoReconnect = profile.autoReconnect
+        reconnectAfterWake = profile.reconnectAfterWake
+        adminSession = profile.adminSession
+        rdpWindowMode = profile.rdpWindowMode
+        windowWidth = profile.windowWidth
+        windowHeight = profile.windowHeight
+    }
+
+    func applying(to sharedProfile: ConnectionProfile) -> ConnectionProfile {
+        var profile = sharedProfile
+        profile.username = preferredUsername
+        profile.windowsScale = windowsScale
+        profile.rdpQuality = rdpQuality
+        profile.audioMode = audioMode
+        profile.clipboardMode = clipboardMode
+        profile.mapCommandToControl = mapCommandToControl
+        profile.mapOptionToWindows = mapOptionToWindows
+        profile.mapRightCommandToWindows = mapRightCommandToWindows
+        profile.fnSwitchesWindowsLanguage = fnSwitchesWindowsLanguage
+        profile.autoReconnect = autoReconnect
+        profile.reconnectAfterWake = reconnectAfterWake
+        profile.adminSession = adminSession
+        profile.rdpWindowMode = rdpWindowMode
+        profile.startFullScreen = rdpWindowMode == .fullScreen
+        profile.windowWidth = min(max(windowWidth, 640), 16_384)
+        profile.windowHeight = min(max(windowHeight, 480), 16_384)
+        return profile
+    }
+
+    var normalized: Self {
+        var value = self
+        value.preferredUsername = String(
+            preferredUsername
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .prefix(256)
+        )
+        value.windowWidth = min(max(windowWidth, 640), 16_384)
+        value.windowHeight = min(max(windowHeight, 480), 16_384)
+        return value
+    }
+}
+
+@MainActor
+final class SelectiveRemoteTeamHostPersonalSettingsStore: ObservableObject {
+    static let shared = SelectiveRemoteTeamHostPersonalSettingsStore()
+
+    @Published private(set) var values: [String: SelectiveRemoteTeamHostPersonalSettings]
+
+    private let defaults: UserDefaults
+    private let storageKey: String
+
+    init(
+        defaults: UserDefaults = .standard,
+        storageKey: String = "SelectiveRemote.team-host.personal-settings.v1"
+    ) {
+        self.defaults = defaults
+        self.storageKey = storageKey
+        if let data = defaults.data(forKey: storageKey),
+           let decoded = try? JSONDecoder().decode(
+               [String: SelectiveRemoteTeamHostPersonalSettings].self,
+               from: data
+           ) {
+            values = decoded
+        } else {
+            values = [:]
+        }
+    }
+
+    func settings(for host: SelectiveRemoteTeamHost) -> SelectiveRemoteTeamHostPersonalSettings {
+        values[key(for: host)] ?? .init(profile: host.profile)
+    }
+
+    func hasSettings(for host: SelectiveRemoteTeamHost) -> Bool {
+        values[key(for: host)] != nil
+    }
+
+    func save(
+        _ settings: SelectiveRemoteTeamHostPersonalSettings,
+        for host: SelectiveRemoteTeamHost
+    ) {
+        values[key(for: host)] = settings.normalized
+        persist()
+    }
+
+    func reset(for host: SelectiveRemoteTeamHost) {
+        values.removeValue(forKey: key(for: host))
+        persist()
+    }
+
+    func appliedProfile(for host: SelectiveRemoteTeamHost) -> ConnectionProfile {
+        settings(for: host).applying(to: host.profile)
+    }
+
+    private func key(for host: SelectiveRemoteTeamHost) -> String {
+        [
+            host.teamID.uuidString.lowercased(),
+            host.vaultID.uuidString.lowercased(),
+            host.recordID.uuidString.lowercased()
+        ].joined(separator: "/")
+    }
+
+    private func persist() {
+        guard let data = try? JSONEncoder().encode(values) else { return }
+        defaults.set(data, forKey: storageKey)
+    }
+}
+
+struct SelectiveRemoteTeamHostPersonalSettingsView: View {
+    let host: SelectiveRemoteTeamHost
+    @ObservedObject var store: SelectiveRemoteTeamHostPersonalSettingsStore
+    @Environment(\.dismiss) private var dismiss
+    @State private var draft: SelectiveRemoteTeamHostPersonalSettings
+
+    init(
+        host: SelectiveRemoteTeamHost,
+        store: SelectiveRemoteTeamHostPersonalSettingsStore
+    ) {
+        self.host = host
+        self.store = store
+        _draft = State(initialValue: store.settings(for: host))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(UpdateLocalization.text(
+                    ru: "Мои настройки Host",
+                    en: "My Host Settings"
+                ))
+                .font(.title2.bold())
+                Text(host.profile.friendlyName)
+                    .foregroundStyle(.secondary)
+            }
+
+            Form {
+                Section(UpdateLocalization.text(ru: "Учётная запись", en: "Account")) {
+                    TextField(
+                        UpdateLocalization.text(ru: "Мой пользователь", en: "My Username"),
+                        text: $draft.preferredUsername
+                    )
+                }
+
+                if host.profile.connectionType == .rdp {
+                    Section("RDP") {
+                        Picker(
+                            UpdateLocalization.text(ru: "Режим окна", en: "Window Mode"),
+                            selection: $draft.rdpWindowMode
+                        ) {
+                            ForEach(RDPWindowMode.allCases) { mode in
+                                Text(mode.title).tag(mode)
+                            }
+                        }
+                        if draft.rdpWindowMode == .fixedWindow {
+                            HStack {
+                                TextField(
+                                    UpdateLocalization.text(ru: "Ширина", en: "Width"),
+                                    value: $draft.windowWidth,
+                                    format: .number
+                                )
+                                TextField(
+                                    UpdateLocalization.text(ru: "Высота", en: "Height"),
+                                    value: $draft.windowHeight,
+                                    format: .number
+                                )
+                            }
+                        }
+                        Picker(
+                            UpdateLocalization.text(ru: "Масштаб Windows", en: "Windows Scale"),
+                            selection: $draft.windowsScale
+                        ) {
+                            ForEach(WindowsScale.allCases) { scale in
+                                Text(scale.title).tag(scale)
+                            }
+                        }
+                        Picker(
+                            UpdateLocalization.text(ru: "Качество", en: "Quality"),
+                            selection: $draft.rdpQuality
+                        ) {
+                            ForEach(RDPQualityPreset.allCases) { quality in
+                                Text(quality.title).tag(quality)
+                            }
+                        }
+                        Picker(
+                            UpdateLocalization.text(ru: "Буфер обмена", en: "Clipboard"),
+                            selection: $draft.clipboardMode
+                        ) {
+                            ForEach(ClipboardMode.allCases) { mode in
+                                Text(mode.title).tag(mode)
+                            }
+                        }
+                        Picker(
+                            UpdateLocalization.text(ru: "Звук", en: "Audio"),
+                            selection: $draft.audioMode
+                        ) {
+                            ForEach(AudioMode.allCases) { mode in
+                                Text(mode.title).tag(mode)
+                            }
+                        }
+                        Toggle(
+                            UpdateLocalization.text(ru: "Command → Control", en: "Command → Control"),
+                            isOn: $draft.mapCommandToControl
+                        )
+                        Toggle(
+                            UpdateLocalization.text(ru: "Option → Windows", en: "Option → Windows"),
+                            isOn: $draft.mapOptionToWindows
+                        )
+                        Toggle(
+                            UpdateLocalization.text(ru: "Правый Command → Windows", en: "Right Command → Windows"),
+                            isOn: $draft.mapRightCommandToWindows
+                        )
+                        Toggle(
+                            UpdateLocalization.text(ru: "Fn меняет язык Windows", en: "Fn switches Windows language"),
+                            isOn: $draft.fnSwitchesWindowsLanguage
+                        )
+                        Toggle(
+                            UpdateLocalization.text(ru: "Автопереподключение", en: "Auto Reconnect"),
+                            isOn: $draft.autoReconnect
+                        )
+                        Toggle(
+                            UpdateLocalization.text(ru: "Переподключаться после сна", en: "Reconnect After Wake"),
+                            isOn: $draft.reconnectAfterWake
+                        )
+                        Toggle(
+                            UpdateLocalization.text(ru: "Административная сессия", en: "Administrative Session"),
+                            isOn: $draft.adminSession
+                        )
+                    }
+                }
+            }
+            .formStyle(.grouped)
+
+            Label(
+                UpdateLocalization.text(
+                    ru: "Эти параметры хранятся только на этом Mac и не меняют общий Host.",
+                    en: "These settings are stored only on this Mac and do not change the shared Host."
+                ),
+                systemImage: "person.crop.circle.badge.checkmark"
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+            HStack {
+                Button(
+                    UpdateLocalization.text(ru: "Сбросить мои настройки", en: "Reset My Settings"),
+                    role: .destructive
+                ) {
+                    store.reset(for: host)
+                    dismiss()
+                }
+                .disabled(!store.hasSettings(for: host))
+                Spacer()
+                Button(UpdateLocalization.text(ru: "Отмена", en: "Cancel")) {
+                    dismiss()
+                }
+                Button(UpdateLocalization.text(ru: "Сохранить", en: "Save")) {
+                    store.save(draft, for: host)
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(
+                    draft.preferredUsername.contains(where: { $0.isNewline })
+                        || draft.preferredUsername.count > 256
+                )
+            }
+        }
+        .padding(24)
+        .frame(width: 560, height: host.profile.connectionType == .rdp ? 720 : 300)
+    }
+}

--- a/Sources/SelectiveRemote/CloudTeamHostPersonalSettings.swift
+++ b/Sources/SelectiveRemote/CloudTeamHostPersonalSettings.swift
@@ -135,6 +135,7 @@ final class SelectiveRemoteTeamHostPersonalSettingsStore: ObservableObject {
     }
 }
 
+@MainActor
 struct SelectiveRemoteTeamHostPersonalSettingsView: View {
     let host: SelectiveRemoteTeamHost
     @ObservedObject var store: SelectiveRemoteTeamHostPersonalSettingsStore

--- a/Sources/SelectiveRemote/CloudTeamHosts.swift
+++ b/Sources/SelectiveRemote/CloudTeamHosts.swift
@@ -643,6 +643,7 @@ struct SelectiveRemoteTeamHostsView: View {
         .sheet(item: $personalSettingsHost, onDismiss: resetConnectionFields) { host in
             SelectiveRemoteTeamHostPersonalSettingsView(
                 host: host,
+                endpoint: endpoint,
                 store: personalSettingsStore
             )
         }
@@ -962,7 +963,10 @@ struct SelectiveRemoteTeamHostsView: View {
     }
 
     private func connect(_ host: SelectiveRemoteTeamHost) {
-        var profile = personalSettingsStore.appliedProfile(for: host)
+        var profile = personalSettingsStore.appliedProfile(
+            for: host,
+            endpoint: endpoint
+        )
         profile.username = username
         if profile.connectionType == .rdp {
             model.connectTeamHost(
@@ -988,7 +992,7 @@ struct SelectiveRemoteTeamHostsView: View {
 
     private func resetConnectionFields() {
         username = selectedHost.map {
-            personalSettingsStore.settings(for: $0).preferredUsername
+            personalSettingsStore.settings(for: $0, endpoint: endpoint).preferredUsername
         } ?? ""
         password = ""
         gatewayPassword = ""

--- a/Sources/SelectiveRemote/CloudTeamHosts.swift
+++ b/Sources/SelectiveRemote/CloudTeamHosts.swift
@@ -456,6 +456,8 @@ final class SelectiveRemoteTeamHostStore: ObservableObject {
 struct SelectiveRemoteTeamHostsView: View {
     @ObservedObject var store: SelectiveRemoteTeamHostStore
     @ObservedObject var model: AppModel
+    @ObservedObject private var personalSettingsStore =
+        SelectiveRemoteTeamHostPersonalSettingsStore.shared
     let onOpenTerminal: (SelectiveRemoteTeamHost, String, String?) -> Void
 
     @State private var selectedHostID: UUID?
@@ -463,6 +465,7 @@ struct SelectiveRemoteTeamHostsView: View {
     @State private var password = ""
     @State private var gatewayPassword = ""
     @State private var editorRequest: SelectiveRemoteTeamHostEditorRequest?
+    @State private var personalSettingsHost: SelectiveRemoteTeamHost?
     @State private var hostPendingDeletion: SelectiveRemoteTeamHost?
     @State private var isMutating = false
     @State private var mutationMessage: SelectiveRemoteTeamHostMutationMessage?
@@ -637,6 +640,12 @@ struct SelectiveRemoteTeamHostsView: View {
                 )
             }
         }
+        .sheet(item: $personalSettingsHost, onDismiss: resetConnectionFields) { host in
+            SelectiveRemoteTeamHostPersonalSettingsView(
+                host: host,
+                store: personalSettingsStore
+            )
+        }
         .confirmationDialog(
             UpdateLocalization.text(ru: "Удалить Team Host?", en: "Delete Team Host?"),
             isPresented: Binding(
@@ -741,6 +750,12 @@ struct SelectiveRemoteTeamHostsView: View {
                             .textSelection(.enabled)
                     }
                     Spacer()
+                    Button(
+                        UpdateLocalization.text(ru: "Мои настройки", en: "My Settings"),
+                        systemImage: "person.crop.circle.badge.gearshape"
+                    ) {
+                        personalSettingsHost = host
+                    }
                     if SelectiveRemoteTeamHostDocumentMutation.isWritable(role: host.role) {
                         Button(
                             UpdateLocalization.text(ru: "Изменить", en: "Edit"),
@@ -866,8 +881,8 @@ struct SelectiveRemoteTeamHostsView: View {
 
                         Label(
                             UpdateLocalization.text(
-                                ru: "Проекция только для чтения: профиль не добавляется в Personal Vault, введённые пароли не сохраняются.",
-                                en: "Read-only projection: the profile is not added to Personal Vault and entered passwords are not saved."
+                                ru: "Общий профиль не добавляется в Personal Vault. Мои настройки хранятся только на этом Mac; введённые пароли не сохраняются.",
+                                en: "The shared profile is not added to Personal Vault. My settings stay on this Mac; entered passwords are not saved."
                             ),
                             systemImage: "lock.shield"
                         )
@@ -947,7 +962,7 @@ struct SelectiveRemoteTeamHostsView: View {
     }
 
     private func connect(_ host: SelectiveRemoteTeamHost) {
-        var profile = host.profile
+        var profile = personalSettingsStore.appliedProfile(for: host)
         profile.username = username
         if profile.connectionType == .rdp {
             model.connectTeamHost(
@@ -972,7 +987,9 @@ struct SelectiveRemoteTeamHostsView: View {
     }
 
     private func resetConnectionFields() {
-        username = selectedHost?.profile.username ?? ""
+        username = selectedHost.map {
+            personalSettingsStore.settings(for: $0).preferredUsername
+        } ?? ""
         password = ""
         gatewayPassword = ""
     }

--- a/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
@@ -330,16 +330,16 @@ struct CloudTeamHostsTests {
             defaults: defaults,
             storageKey: "settings"
         )
-        var personal = store.settings(for: host)
+        var personal = store.settings(for: host, endpoint: "https://cloud.example.test")
         personal.preferredUsername = "alice"
         personal.clipboardMode = .bidirectional
         personal.audioMode = .local
         personal.rdpWindowMode = .fixedWindow
         personal.windowWidth = 1
         personal.windowHeight = 99_999
-        store.save(personal, for: host)
+        store.save(personal, for: host, endpoint: "https://cloud.example.test")
 
-        let applied = store.appliedProfile(for: host)
+        let applied = store.appliedProfile(for: host, endpoint: "https://cloud.example.test")
         #expect(applied.username == "alice")
         #expect(applied.clipboardMode == .bidirectional)
         #expect(applied.audioMode == .local)
@@ -353,9 +353,9 @@ struct CloudTeamHostsTests {
             defaults: defaults,
             storageKey: "settings"
         )
-        #expect(restored.settings(for: host).preferredUsername == "alice")
-        restored.reset(for: host)
-        #expect(!restored.hasSettings(for: host))
+        #expect(restored.settings(for: host, endpoint: "https://cloud.example.test").preferredUsername == "alice")
+        restored.reset(for: host, endpoint: "https://cloud.example.test")
+        #expect(!restored.hasSettings(for: host, endpoint: "https://cloud.example.test"))
         #expect(restored.settings(for: host).preferredUsername == "shared-user")
     }
 

--- a/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
@@ -296,6 +296,69 @@ struct CloudTeamHostsTests {
         #expect(store.synchronizedVaultCount == 2)
     }
 
+    @MainActor
+    @Test("personal settings remain local and apply without mutating the shared Host")
+    func personalSettingsOverlay() throws {
+        let suiteName = "SelectiveRemoteTests.TeamHostPersonalSettings.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        var shared = ConnectionProfile(connectionType: .rdp)
+        shared.id = try #require(UUID(uuidString: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"))
+        shared.friendlyName = "Shared Desktop"
+        shared.host = "desktop.example.invalid"
+        shared.username = "shared-user"
+        shared.clipboardMode = .disabled
+        shared.audioMode = .muted
+
+        let host = SelectiveRemoteTeamHost(
+            id: try #require(UUID(uuidString: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")),
+            recordID: shared.id,
+            teamID: try #require(UUID(uuidString: "11111111-1111-4111-8111-111111111111")),
+            teamName: "Platform",
+            role: .viewer,
+            vaultID: try #require(UUID(uuidString: "22222222-2222-4222-8222-222222222222")),
+            vaultName: "Operations",
+            revision: 7,
+            keyGeneration: 3,
+            modifiedAt: "2026-09-10T08:00:00.000Z",
+            address: shared.host,
+            profile: shared
+        )
+
+        let store = SelectiveRemoteTeamHostPersonalSettingsStore(
+            defaults: defaults,
+            storageKey: "settings"
+        )
+        var personal = store.settings(for: host)
+        personal.preferredUsername = "alice"
+        personal.clipboardMode = .bidirectional
+        personal.audioMode = .local
+        personal.rdpWindowMode = .fixedWindow
+        personal.windowWidth = 1
+        personal.windowHeight = 99_999
+        store.save(personal, for: host)
+
+        let applied = store.appliedProfile(for: host)
+        #expect(applied.username == "alice")
+        #expect(applied.clipboardMode == .bidirectional)
+        #expect(applied.audioMode == .local)
+        #expect(applied.windowWidth == 640)
+        #expect(applied.windowHeight == 16_384)
+        #expect(host.profile.username == "shared-user")
+        #expect(host.profile.clipboardMode == .disabled)
+        #expect(host.profile.audioMode == .muted)
+
+        let restored = SelectiveRemoteTeamHostPersonalSettingsStore(
+            defaults: defaults,
+            storageKey: "settings"
+        )
+        #expect(restored.settings(for: host).preferredUsername == "alice")
+        restored.reset(for: host)
+        #expect(!restored.hasSettings(for: host))
+        #expect(restored.settings(for: host).preferredUsername == "shared-user")
+    }
+
     private static func snapshot(
         payload: Data,
         role: SelectiveRemoteCloudTeamRole = .viewer

--- a/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
@@ -356,7 +356,7 @@ struct CloudTeamHostsTests {
         #expect(restored.settings(for: host, endpoint: "https://cloud.example.test").preferredUsername == "alice")
         restored.reset(for: host, endpoint: "https://cloud.example.test")
         #expect(!restored.hasSettings(for: host, endpoint: "https://cloud.example.test"))
-        #expect(restored.settings(for: host).preferredUsername == "shared-user")
+        #expect(restored.settings(for: host, endpoint: "https://cloud.example.test").preferredUsername == "shared-user")
     }
 
     private static func snapshot(

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -340,3 +340,18 @@ test("macOS Team Hosts expose shared folders, tags, and local filtering controls
   assert.match(editor, /profile\.group = folder/u);
   assert.match(editor, /profile\.tags = parsedTags/u);
 });
+
+
+test("macOS Team Hosts keep per-user connection settings local and secret-free", async () => {
+  const [hosts, personal] = await Promise.all([
+    readFile(new URL("CloudTeamHosts.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudTeamHostPersonalSettings.swift", sourceRoot), "utf8"),
+  ]);
+  assert.match(personal, /SelectiveRemote\.team-host\.personal-settings\.v1/u);
+  assert.match(personal, /UserDefaults/u);
+  assert.match(personal, /func appliedProfile\(for host:/u);
+  assert.match(personal, /do not change the shared Host/u);
+  assert.doesNotMatch(personal, /password|secret|Keychain/u);
+  assert.match(hosts, /personalSettingsStore\.appliedProfile\(for: host\)/u);
+  assert.match(hosts, /personalSettingsHost/u);
+});

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -349,9 +349,10 @@ test("macOS Team Hosts keep per-user connection settings local and secret-free",
   ]);
   assert.match(personal, /SelectiveRemote\.team-host\.personal-settings\.v1/u);
   assert.match(personal, /UserDefaults/u);
-  assert.match(personal, /func appliedProfile\(for host:/u);
+  assert.match(personal, /func appliedProfile\(/u);
+  assert.match(personal, /endpoint: String/u);
   assert.match(personal, /do not change the shared Host/u);
   assert.doesNotMatch(personal, /password|secret|Keychain/u);
-  assert.match(hosts, /personalSettingsStore\.appliedProfile\(for: host\)/u);
+  assert.match(hosts, /personalSettingsStore\.appliedProfile\(/u);
   assert.match(hosts, /personalSettingsHost/u);
 });


### PR DESCRIPTION
## Summary
- add a device-local, secret-free settings overlay scoped to Team/Vault/Host
- let each user keep a preferred username and personalize RDP window, quality, scale, clipboard, audio, keyboard, and reconnect behavior
- apply the overlay only at connection time without mutating the encrypted shared Host or adding it to Personal Vault
- provide reset-to-shared defaults and persistence tests

## Security boundary
- no passwords, secrets, or Keychain references are stored in this overlay
- shared Team Vault records remain unchanged
- Team Credentials will follow as a separate E2EE slice

## Stack
Depends on #82.