### PR TITLE
Complete Team Host navigation and SSH tools

### DIFF
--- a/Sources/SelectiveRemote/CloudTeamHostEditor.swift
+++ b/Sources/SelectiveRemote/CloudTeamHostEditor.swift
@@ -20,6 +20,7 @@ struct SelectiveRemoteTeamHostEditorView: View {
     @State private var title: String
     @State private var address: String
     @State private var username: String
+    @State private var port: Int
     @State private var connectionType: ConnectionType
     @State private var folder: String
     @State private var tagsText: String
@@ -35,6 +36,7 @@ struct SelectiveRemoteTeamHostEditorView: View {
         _title = State(initialValue: profile?.friendlyName ?? "")
         _address = State(initialValue: profile.map(Self.address) ?? "")
         _username = State(initialValue: profile?.username ?? "")
+        _port = State(initialValue: profile?.sshPort ?? 22)
         _connectionType = State(initialValue: profile?.connectionType ?? .ssh)
         _folder = State(initialValue: profile?.group ?? "")
         _tagsText = State(initialValue: profile?.tags.joined(separator: ", ") ?? "")
@@ -54,6 +56,7 @@ struct SelectiveRemoteTeamHostEditorView: View {
             && !address.contains(where: { $0.isNewline })
             && username.count <= 256
             && !username.contains(where: { $0.isNewline })
+            && ((connectionType != .ssh && connectionType != .telnet) || (1 ... 65_535).contains(port))
             && validFolder
             && tagsText.utf8.count <= 8_192
             && parsedTags.count <= 64
@@ -129,6 +132,13 @@ struct SelectiveRemoteTeamHostEditorView: View {
                         text: $username
                     )
                 }
+                if connectionType == .ssh || connectionType == .telnet {
+                    TextField(
+                        UpdateLocalization.text(ru: "Порт", en: "Port"),
+                        value: $port,
+                        format: .number
+                    )
+                }
                 TextField(
                     UpdateLocalization.text(ru: "Папка", en: "Folder"),
                     text: $folder
@@ -187,6 +197,9 @@ struct SelectiveRemoteTeamHostEditorView: View {
         profile.group = folder
         profile.tags = parsedTags
         profile.profileDescription = profileDescription
+        if connectionType == .ssh || connectionType == .telnet {
+            profile.sshPort = port
+        }
         if connectionType == .serial {
             profile.serialDevicePath = address
         } else {

--- a/Sources/SelectiveRemote/CloudTeamHosts.swift
+++ b/Sources/SelectiveRemote/CloudTeamHosts.swift
@@ -859,6 +859,13 @@ struct SelectiveRemoteTeamHostsView: View {
 
                 GroupBox(UpdateLocalization.text(ru: "Подключение", en: "Connection")) {
                     VStack(alignment: .leading, spacing: 12) {
+                        if host.profile.connectionType == .ssh
+                            || host.profile.connectionType == .telnet {
+                            LabeledContent(
+                                UpdateLocalization.text(ru: "Порт", en: "Port"),
+                                value: "\(host.profile.sshPort)"
+                            )
+                        }
                         if host.profile.connectionType == .rdp
                             || host.profile.connectionType == .ssh {
                             TextField(

--- a/Sources/SelectiveRemote/CloudTeamHosts.swift
+++ b/Sources/SelectiveRemote/CloudTeamHosts.swift
@@ -459,6 +459,7 @@ struct SelectiveRemoteTeamHostsView: View {
     @ObservedObject private var personalSettingsStore =
         SelectiveRemoteTeamHostPersonalSettingsStore.shared
     let onOpenTerminal: (SelectiveRemoteTeamHost, String, String?) -> Void
+    let onOpenSFTP: (SelectiveRemoteTeamHost, String, String?) -> Void
 
     @State private var selectedHostID: UUID?
     @State private var username = ""
@@ -471,6 +472,8 @@ struct SelectiveRemoteTeamHostsView: View {
     @State private var mutationMessage: SelectiveRemoteTeamHostMutationMessage?
     @State private var searchText = ""
     @State private var selectedFolder = ""
+    @State private var expandedTeamIDs: Set<UUID> = []
+    @State private var expandedFolderKeys: Set<String> = []
     @AppStorage("SelectiveRemote.cloud.endpoint.v1") private var endpoint = SelectiveRemoteCloudEndpoint.production
     @AppStorage("SelectiveRemote.cloud.device-id.v1") private var storedDeviceID = ""
 
@@ -488,6 +491,24 @@ struct SelectiveRemoteTeamHostsView: View {
 
     private var folderNames: [String] {
         Array(Set(store.hosts.map { $0.profile.group }))
+            .sorted { folderTitle($0).localizedCaseInsensitiveCompare(folderTitle($1)) == .orderedAscending }
+    }
+
+    private var teamIDs: [UUID] {
+        Array(Set(visibleHosts.map(\.teamID))).sorted { left, right in
+            let leftName = store.hosts.first(where: { $0.teamID == left })?.teamName ?? ""
+            let rightName = store.hosts.first(where: { $0.teamID == right })?.teamName ?? ""
+            return leftName.localizedCaseInsensitiveCompare(rightName) == .orderedAscending
+        }
+    }
+
+    private func teamName(_ teamID: UUID) -> String {
+        store.hosts.first(where: { $0.teamID == teamID })?.teamName
+            ?? UpdateLocalization.text(ru: "Команда", en: "Team")
+    }
+
+    private func folders(in teamID: UUID) -> [String] {
+        Array(Set(visibleHosts.filter { $0.teamID == teamID }.map { $0.profile.group }))
             .sorted { folderTitle($0).localizedCaseInsensitiveCompare(folderTitle($1)) == .orderedAscending }
     }
 
@@ -524,15 +545,30 @@ struct SelectiveRemoteTeamHostsView: View {
                     )
                 } else {
                     List(selection: $selectedHostID) {
-                        ForEach(folderNames, id: \.self) { folder in
-                            let hosts = visibleHosts.filter { $0.profile.group == folder }
-                            if !hosts.isEmpty {
-                                Section(folderTitle(folder)) {
-                                    ForEach(hosts) { host in
-                                        hostRow(host)
-                                            .tag(host.id)
+                        ForEach(teamIDs, id: \.self) { teamID in
+                            DisclosureGroup(
+                                isExpanded: expansionBinding(for: teamID)
+                            ) {
+                                ForEach(folders(in: teamID), id: \.self) { folder in
+                                    DisclosureGroup(
+                                        isExpanded: folderExpansionBinding(
+                                            teamID: teamID,
+                                            folder: folder
+                                        )
+                                    ) {
+                                        ForEach(visibleHosts.filter {
+                                            $0.teamID == teamID && $0.profile.group == folder
+                                        }) { host in
+                                            hostRow(host)
+                                                .tag(host.id)
+                                        }
+                                    } label: {
+                                        Label(folderTitle(folder), systemImage: "folder")
                                     }
                                 }
+                            } label: {
+                                Label(teamName(teamID), systemImage: "person.3.fill")
+                                    .font(.headline)
                             }
                         }
                     }
@@ -626,8 +662,14 @@ struct SelectiveRemoteTeamHostsView: View {
             }
             .frame(minWidth: 480, maxWidth: .infinity, maxHeight: .infinity)
         }
-        .onAppear { normalizeSelection() }
-        .onChange(of: store.hosts.map(\.id)) { _, _ in normalizeSelection() }
+        .onAppear {
+            normalizeSelection()
+            expandNewHierarchy()
+        }
+        .onChange(of: store.hosts.map(\.id)) { _, _ in
+            normalizeSelection()
+            expandNewHierarchy()
+        }
         .onChange(of: selectedHostID) { _, _ in resetConnectionFields() }
         .sheet(item: $editorRequest) { request in
             SelectiveRemoteTeamHostEditorView(request: request) { profile in
@@ -877,6 +919,20 @@ struct SelectiveRemoteTeamHostsView: View {
                                         && password.isEmpty
                                 )
                             }
+                            if host.profile.connectionType == .ssh {
+                                Button(
+                                    UpdateLocalization.text(ru: "Открыть SFTP", en: "Open SFTP"),
+                                    systemImage: "folder.badge.gearshape"
+                                ) {
+                                    onOpenSFTP(
+                                        host,
+                                        username,
+                                        password.isEmpty ? nil : password
+                                    )
+                                    password = ""
+                                    gatewayPassword = ""
+                                }
+                            }
                             Spacer()
                         }
 
@@ -960,6 +1016,36 @@ struct SelectiveRemoteTeamHostsView: View {
         let value = UUID()
         storedDeviceID = value.canonicalCloudString
         return value
+    }
+
+    private func expansionBinding(for teamID: UUID) -> Binding<Bool> {
+        Binding(
+            get: { expandedTeamIDs.contains(teamID) },
+            set: { expanded in
+                if expanded { expandedTeamIDs.insert(teamID) }
+                else { expandedTeamIDs.remove(teamID) }
+            }
+        )
+    }
+
+    private func folderExpansionBinding(teamID: UUID, folder: String) -> Binding<Bool> {
+        let key = "\(teamID.uuidString.lowercased())/\(folder)"
+        return Binding(
+            get: { expandedFolderKeys.contains(key) },
+            set: { expanded in
+                if expanded { expandedFolderKeys.insert(key) }
+                else { expandedFolderKeys.remove(key) }
+            }
+        )
+    }
+
+    private func expandNewHierarchy() {
+        for host in store.hosts {
+            expandedTeamIDs.insert(host.teamID)
+            expandedFolderKeys.insert(
+                "\(host.teamID.uuidString.lowercased())/\(host.profile.group)"
+            )
+        }
     }
 
     private func connect(_ host: SelectiveRemoteTeamHost) {

--- a/Sources/SelectiveRemote/ContentView.swift
+++ b/Sources/SelectiveRemote/ContentView.swift
@@ -860,7 +860,8 @@ struct ContentView: View {
                 SelectiveRemoteTeamHostsView(
                     store: teamHosts,
                     model: model,
-                    onOpenTerminal: openTeamTerminal
+                    onOpenTerminal: openTeamTerminal,
+                    onOpenSFTP: openTeamSFTP
                 )
             case .snippets:
                 TerminalSnippetsLibraryView(
@@ -2563,6 +2564,27 @@ struct ContentView: View {
             temporaryPassword: temporaryPassword
         )
         setMainArea(.ssh)
+    }
+
+    private func openTeamSFTP(
+        _ host: SelectiveRemoteTeamHost,
+        username: String,
+        temporaryPassword: String?
+    ) {
+        guard host.profile.connectionType == .ssh else { return }
+        let connection = TerminalTabConnection.custom(
+            host: host.profile.host,
+            username: username,
+            port: host.profile.sshPort,
+            authenticationMode: temporaryPassword == nil ? .automatic : .password,
+            identityID: nil,
+            jumpHostProfileID: nil
+        )
+        model.sftpWorkspace.requestOpen(
+            connection: connection,
+            temporaryPassword: temporaryPassword
+        )
+        setMainArea(.sftp)
     }
 
     private func openForwardingTerminal(_ connection: TerminalTabConnection) {

--- a/Sources/SelectiveRemote/SFTPWorkspace.swift
+++ b/Sources/SelectiveRemote/SFTPWorkspace.swift
@@ -12,6 +12,7 @@ enum SFTPWorkspacePaneKind: String, Equatable, Sendable {
 struct SFTPWorkspaceOpenRequest: Identifiable, Equatable {
     let id = UUID()
     let connection: TerminalTabConnection
+    let temporaryPassword: String?
     let path: String?
 }
 
@@ -226,9 +227,14 @@ final class SFTPWorkspaceModel: ObservableObject {
         }
     }
 
-    func requestOpen(connection: TerminalTabConnection, path: String? = nil) {
+    func requestOpen(
+        connection: TerminalTabConnection,
+        temporaryPassword: String? = nil,
+        path: String? = nil
+    ) {
         pendingOpenRequest = SFTPWorkspaceOpenRequest(
             connection: connection,
+            temporaryPassword: temporaryPassword,
             path: path
         )
     }
@@ -370,6 +376,7 @@ struct SFTPWorkspaceView: View {
                 connect(
                     pane: pane,
                     connection: request.connection,
+                    temporaryPassword: request.temporaryPassword,
                     path: request.path
                 )
             }

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -334,7 +334,7 @@ test("macOS Team Hosts expose shared folders, tags, and local filtering controls
   assert.match(hosts, /safe\.profileDescription = input\.profileDescription/u);
   assert.match(hosts, /\.searchable\(/u);
   assert.match(hosts, /selectedFolder/u);
-  assert.match(hosts, /Section\(folderTitle\(folder\)\)/u);
+  assert.match(hosts, /Label\(folderTitle\(folder\), systemImage: "folder"\)/u);
   assert.match(editor, /Теги через запятую/u);
   assert.match(editor, /Папка/u);
   assert.match(editor, /profile\.group = folder/u);

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -356,3 +356,23 @@ test("macOS Team Hosts keep per-user connection settings local and secret-free",
   assert.match(hosts, /personalSettingsStore\.appliedProfile\(/u);
   assert.match(hosts, /personalSettingsHost/u);
 });
+
+
+test("macOS Team Hosts nest teams and folders and expose SSH tools", async () => {
+  const [hosts, editor, content, sftp] = await Promise.all([
+    readFile(new URL("CloudTeamHosts.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudTeamHostEditor.swift", sourceRoot), "utf8"),
+    readFile(new URL("ContentView.swift", sourceRoot), "utf8"),
+    readFile(new URL("SFTPWorkspace.swift", sourceRoot), "utf8"),
+  ]);
+  assert.match(hosts, /DisclosureGroup\(/u);
+  assert.match(hosts, /Label\(teamName\(teamID\), systemImage: "person\.3\.fill"\)/u);
+  assert.match(hosts, /Label\(folderTitle\(folder\), systemImage: "folder"\)/u);
+  assert.match(editor, /ru: "Порт", en: "Port"/u);
+  assert.match(editor, /profile\.sshPort = port/u);
+  assert.match(hosts, /onOpenSFTP/u);
+  assert.match(content, /private func openTeamSFTP/u);
+  assert.match(content, /temporaryPassword: temporaryPassword/u);
+  assert.match(sftp, /let temporaryPassword: String\?/u);
+  assert.match(sftp, /temporaryPassword: request\.temporaryPassword/u);
+});


### PR DESCRIPTION
## Summary
- nest Team Hosts as Team → Folder → Host so users in multiple teams never see mixed folders
- expose the shared SSH/Telnet port in the Team Host editor
- open SSH Team Hosts directly in the SFTP workspace
- pass an entered password ephemerally to SFTP and remove its temporary Keychain item after connection

## Stack
Depends on #83.

## Follow-ups
- per-user RDP display selection
- single application/device unlock across Cloud and Team Vaults
- encrypted Team Credentials
- web Personal Vault auto-sync and Team UX