### PR TITLE
Restore per-Mac display selection for Team Hosts

### DIFF
--- a/Sources/SelectiveRemote/CloudTeamHostPersonalSettings.swift
+++ b/Sources/SelectiveRemote/CloudTeamHostPersonalSettings.swift
@@ -225,6 +225,12 @@ struct SelectiveRemoteTeamHostPersonalSettingsView: View {
                                 onPrimary: setPrimaryDisplay
                             )
                             .frame(height: 220)
+                            Text(UpdateLocalization.text(
+                                ru: "Щёлкните монитор, чтобы включить или исключить его; звезда выбирает основной экран Windows.",
+                                en: "Click a display to include or exclude it; the star selects the primary Windows display."
+                            ))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                             Button(
                                 UpdateLocalization.text(ru: "Обновить мониторы", en: "Refresh Displays"),
                                 systemImage: "arrow.clockwise"

--- a/Sources/SelectiveRemote/CloudTeamHostPersonalSettings.swift
+++ b/Sources/SelectiveRemote/CloudTeamHostPersonalSettings.swift
@@ -17,6 +17,9 @@ struct SelectiveRemoteTeamHostPersonalSettings: Codable, Equatable {
     var rdpWindowMode: RDPWindowMode
     var windowWidth: Int
     var windowHeight: Int
+    var selectedDisplayIDs: Set<String>?
+    var primaryDisplayID: String?
+    var displayLayoutMode: DisplayLayoutMode?
 
     init(profile: ConnectionProfile) {
         preferredUsername = profile.username
@@ -34,6 +37,9 @@ struct SelectiveRemoteTeamHostPersonalSettings: Codable, Equatable {
         rdpWindowMode = profile.rdpWindowMode
         windowWidth = profile.windowWidth
         windowHeight = profile.windowHeight
+        selectedDisplayIDs = profile.selectedDisplayIDs.isEmpty ? nil : profile.selectedDisplayIDs
+        primaryDisplayID = profile.primaryDisplayID
+        displayLayoutMode = profile.displayLayoutMode
     }
 
     func applying(to sharedProfile: ConnectionProfile) -> ConnectionProfile {
@@ -54,6 +60,14 @@ struct SelectiveRemoteTeamHostPersonalSettings: Codable, Equatable {
         profile.startFullScreen = rdpWindowMode == .fullScreen
         profile.windowWidth = min(max(windowWidth, 640), 16_384)
         profile.windowHeight = min(max(windowHeight, 480), 16_384)
+        if let selectedDisplayIDs, !selectedDisplayIDs.isEmpty {
+            profile.selectedDisplayIDs = selectedDisplayIDs
+            profile.primaryDisplayID = primaryDisplayID.flatMap {
+                selectedDisplayIDs.contains($0) ? $0 : nil
+            } ?? selectedDisplayIDs.sorted().first
+            profile.displayLayoutMode = displayLayoutMode ?? .automatic
+            profile.virtualDisplayOrigins = [:]
+        }
         return profile
     }
 
@@ -150,6 +164,7 @@ struct SelectiveRemoteTeamHostPersonalSettingsView: View {
     @ObservedObject var store: SelectiveRemoteTeamHostPersonalSettingsStore
     @Environment(\.dismiss) private var dismiss
     @State private var draft: SelectiveRemoteTeamHostPersonalSettings
+    @State private var displays: [DisplayDescriptor]
 
     init(
         host: SelectiveRemoteTeamHost,
@@ -159,7 +174,18 @@ struct SelectiveRemoteTeamHostPersonalSettingsView: View {
         self.host = host
         self.endpoint = endpoint
         self.store = store
-        _draft = State(initialValue: store.settings(for: host, endpoint: endpoint))
+        let currentDisplays = DisplayManager().currentDisplays()
+        var settings = store.settings(for: host, endpoint: endpoint)
+        if host.profile.connectionType == .rdp,
+           settings.selectedDisplayIDs?.isEmpty != false {
+            let external = currentDisplays.filter { !$0.isBuiltIn }
+            let initial = external.isEmpty ? currentDisplays : external
+            settings.selectedDisplayIDs = Set(initial.map(\.id))
+            settings.primaryDisplayID = initial.first?.id
+            settings.displayLayoutMode = .automatic
+        }
+        _draft = State(initialValue: settings)
+        _displays = State(initialValue: currentDisplays)
     }
 
     var body: some View {
@@ -183,6 +209,31 @@ struct SelectiveRemoteTeamHostPersonalSettingsView: View {
                 }
 
                 if host.profile.connectionType == .rdp {
+                    Section(UpdateLocalization.text(ru: "Мониторы", en: "Displays")) {
+                        if displays.isEmpty {
+                            Text(UpdateLocalization.text(
+                                ru: "macOS не обнаружила доступные мониторы",
+                                en: "macOS did not report any available displays"
+                            ))
+                            .foregroundStyle(.secondary)
+                        } else {
+                            MonitorMapView(
+                                displays: displays,
+                                selectedIDs: draft.selectedDisplayIDs ?? [],
+                                primaryID: draft.primaryDisplayID,
+                                onToggle: toggleDisplay,
+                                onPrimary: setPrimaryDisplay
+                            )
+                            .frame(height: 220)
+                            Button(
+                                UpdateLocalization.text(ru: "Обновить мониторы", en: "Refresh Displays"),
+                                systemImage: "arrow.clockwise"
+                            ) {
+                                refreshDisplays()
+                            }
+                        }
+                    }
+
                     Section("RDP") {
                         Picker(
                             UpdateLocalization.text(ru: "Режим окна", en: "Window Mode"),
@@ -306,6 +357,44 @@ struct SelectiveRemoteTeamHostPersonalSettingsView: View {
             }
         }
         .padding(24)
-        .frame(width: 560, height: host.profile.connectionType == .rdp ? 720 : 300)
+        .frame(width: 620, height: host.profile.connectionType == .rdp ? 840 : 300)
+    }
+
+    private func toggleDisplay(_ display: DisplayDescriptor) {
+        var selected = draft.selectedDisplayIDs ?? []
+        if selected.contains(display.id) {
+            guard selected.count > 1 else { return }
+            selected.remove(display.id)
+            if draft.primaryDisplayID == display.id {
+                draft.primaryDisplayID = displays.first(where: { selected.contains($0.id) })?.id
+            }
+        } else {
+            selected.insert(display.id)
+            if draft.primaryDisplayID == nil { draft.primaryDisplayID = display.id }
+        }
+        draft.selectedDisplayIDs = selected
+        draft.displayLayoutMode = .automatic
+    }
+
+    private func setPrimaryDisplay(_ display: DisplayDescriptor) {
+        var selected = draft.selectedDisplayIDs ?? []
+        selected.insert(display.id)
+        draft.selectedDisplayIDs = selected
+        draft.primaryDisplayID = display.id
+        draft.displayLayoutMode = .automatic
+    }
+
+    private func refreshDisplays() {
+        displays = DisplayManager().currentDisplays()
+        let available = Set(displays.map(\.id))
+        var selected = (draft.selectedDisplayIDs ?? []).intersection(available)
+        if selected.isEmpty {
+            let external = displays.filter { !$0.isBuiltIn }
+            selected = Set((external.isEmpty ? displays : external).map(\.id))
+        }
+        draft.selectedDisplayIDs = selected
+        if let primary = draft.primaryDisplayID, !selected.contains(primary) {
+            draft.primaryDisplayID = displays.first(where: { selected.contains($0.id) })?.id
+        }
     }
 }

--- a/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
@@ -337,6 +337,9 @@ struct CloudTeamHostsTests {
         personal.rdpWindowMode = .fixedWindow
         personal.windowWidth = 1
         personal.windowHeight = 99_999
+        personal.selectedDisplayIDs = ["display-a", "display-b"]
+        personal.primaryDisplayID = "display-b"
+        personal.displayLayoutMode = .automatic
         store.save(personal, for: host, endpoint: "https://cloud.example.test")
 
         let applied = store.appliedProfile(for: host, endpoint: "https://cloud.example.test")
@@ -345,9 +348,13 @@ struct CloudTeamHostsTests {
         #expect(applied.audioMode == .local)
         #expect(applied.windowWidth == 640)
         #expect(applied.windowHeight == 16_384)
+        #expect(applied.selectedDisplayIDs == ["display-a", "display-b"])
+        #expect(applied.primaryDisplayID == "display-b")
+        #expect(applied.displayLayoutMode == .automatic)
         #expect(host.profile.username == "shared-user")
         #expect(host.profile.clipboardMode == .disabled)
         #expect(host.profile.audioMode == .muted)
+        #expect(host.profile.selectedDisplayIDs.isEmpty)
 
         let restored = SelectiveRemoteTeamHostPersonalSettingsStore(
             defaults: defaults,

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -376,3 +376,18 @@ test("macOS Team Hosts nest teams and folders and expose SSH tools", async () =>
   assert.match(sftp, /let temporaryPassword: String\?/u);
   assert.match(sftp, /temporaryPassword: request\.temporaryPassword/u);
 });
+
+
+test("macOS Team Host personal settings preserve per-Mac display selection", async () => {
+  const personal = await readFile(
+    new URL("CloudTeamHostPersonalSettings.swift", sourceRoot),
+    "utf8",
+  );
+  assert.match(personal, /var selectedDisplayIDs: Set<String>\?/u);
+  assert.match(personal, /DisplayManager\(\)\.currentDisplays\(\)/u);
+  assert.match(personal, /MonitorMapView\(/u);
+  assert.match(personal, /profile\.selectedDisplayIDs = selectedDisplayIDs/u);
+  assert.match(personal, /profile\.primaryDisplayID = primaryDisplayID/u);
+  assert.match(personal, /private func toggleDisplay/u);
+  assert.match(personal, /guard selected\.count > 1/u);
+});


### PR DESCRIPTION
## Summary
- discover the current Mac display topology inside My Host Settings
- let each user select one or more physical displays and choose the primary display
- apply stable display IDs only to the runtime Team Host projection
- keep display choices local to this Mac and preserve the encrypted shared Host unchanged
- retain compatibility with personal-settings records created before display fields existed

## Stack
Depends on #84.