### PR TITLE
Unify Cloud session and Team device Keychain access

### DIFF
--- a/Sources/SelectiveRemote/CloudSecureEnvelopeStore.swift
+++ b/Sources/SelectiveRemote/CloudSecureEnvelopeStore.swift
@@ -1,0 +1,110 @@
+import Foundation
+import Security
+
+struct SelectiveRemoteCloudSecureEnvelope: Codable, Equatable {
+    var sessionToken: String?
+    var teamDevicePrivateKeys: [String: Data]
+
+    init(
+        sessionToken: String? = nil,
+        teamDevicePrivateKeys: [String: Data] = [:]
+    ) {
+        self.sessionToken = sessionToken
+        self.teamDevicePrivateKeys = teamDevicePrivateKeys
+    }
+
+    var isEmpty: Bool {
+        sessionToken == nil && teamDevicePrivateKeys.isEmpty
+    }
+}
+
+struct SelectiveRemoteCloudSecureEnvelopeStore {
+    static let service = "local.selectiveremote.cloud.secure-envelope.v1"
+    private static let lock = NSLock()
+
+    func envelope(for endpoint: URL) throws -> SelectiveRemoteCloudSecureEnvelope? {
+        try Self.synchronized {
+            try readUnlocked(endpoint: endpoint)
+        }
+    }
+
+    func update(
+        for endpoint: URL,
+        _ mutation: (inout SelectiveRemoteCloudSecureEnvelope) throws -> Void
+    ) throws {
+        try Self.synchronized {
+            var envelope = try readUnlocked(endpoint: endpoint) ?? .init()
+            try mutation(&envelope)
+            if envelope.isEmpty {
+                try deleteUnlocked(endpoint: endpoint)
+            } else {
+                try writeUnlocked(envelope, endpoint: endpoint)
+            }
+        }
+    }
+
+    private func readUnlocked(endpoint: URL) throws -> SelectiveRemoteCloudSecureEnvelope? {
+        var query = baseQuery(endpoint: endpoint)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound { return nil }
+        guard status == errSecSuccess else {
+            throw KeychainError.unexpectedStatus(status)
+        }
+        guard let data = result as? Data,
+              let envelope = try? JSONDecoder().decode(
+                  SelectiveRemoteCloudSecureEnvelope.self,
+                  from: data
+              )
+        else { throw KeychainError.invalidData }
+        return envelope
+    }
+
+    private func writeUnlocked(
+        _ envelope: SelectiveRemoteCloudSecureEnvelope,
+        endpoint: URL
+    ) throws {
+        let data = try JSONEncoder().encode(envelope)
+        let query = baseQuery(endpoint: endpoint)
+        let update = SecItemUpdate(
+            query as CFDictionary,
+            [kSecValueData as String: data] as CFDictionary
+        )
+        if update == errSecSuccess { return }
+        guard update == errSecItemNotFound else {
+            throw KeychainError.unexpectedStatus(update)
+        }
+
+        var addition = query
+        addition[kSecValueData as String] = data
+        addition[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        let add = SecItemAdd(addition as CFDictionary, nil)
+        guard add == errSecSuccess else {
+            throw KeychainError.unexpectedStatus(add)
+        }
+    }
+
+    private func deleteUnlocked(endpoint: URL) throws {
+        let status = SecItemDelete(baseQuery(endpoint: endpoint) as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+
+    private func baseQuery(endpoint: URL) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.service,
+            kSecAttrAccount as String: endpoint.absoluteString
+        ]
+    }
+
+    private static func synchronized<T>(_ body: () throws -> T) rethrows -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return try body()
+    }
+}

--- a/Sources/SelectiveRemote/CloudSessionStore.swift
+++ b/Sources/SelectiveRemote/CloudSessionStore.swift
@@ -8,62 +8,62 @@ protocol SelectiveRemoteCloudTokenStore: Sendable {
 }
 
 struct SelectiveRemoteCloudKeychainTokenStore: SelectiveRemoteCloudTokenStore {
-    static let service = "local.selectiveremote.cloud.session.v1"
+    static let legacyService = "local.selectiveremote.cloud.session.v1"
+    private let envelopeStore = SelectiveRemoteCloudSecureEnvelopeStore()
 
     func token(for endpoint: URL) throws -> String? {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: Self.service,
-            kSecAttrAccount as String: account(for: endpoint),
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne
-        ]
+        if let token = try envelopeStore.envelope(for: endpoint)?.sessionToken {
+            return token
+        }
+        guard let legacy = try legacyToken(for: endpoint) else { return nil }
+        try saveToken(legacy, for: endpoint)
+        try? removeLegacyToken(for: endpoint)
+        return legacy
+    }
+
+    func saveToken(_ token: String, for endpoint: URL) throws {
+        guard !token.isEmpty else { throw KeychainError.invalidData }
+        try envelopeStore.update(for: endpoint) {
+            $0.sessionToken = token
+        }
+    }
+
+    func removeToken(for endpoint: URL) throws {
+        try envelopeStore.update(for: endpoint) {
+            $0.sessionToken = nil
+        }
+        try? removeLegacyToken(for: endpoint)
+    }
+
+    private func legacyToken(for endpoint: URL) throws -> String? {
+        var query = legacyQuery(for: endpoint)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
         var result: CFTypeRef?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
         if status == errSecItemNotFound { return nil }
-        guard status == errSecSuccess else { throw KeychainError.unexpectedStatus(status) }
+        guard status == errSecSuccess else {
+            throw KeychainError.unexpectedStatus(status)
+        }
         guard let data = result as? Data,
               let token = String(data: data, encoding: .utf8)
         else { throw KeychainError.invalidData }
         return token
     }
 
-    func saveToken(_ token: String, for endpoint: URL) throws {
-        guard let data = token.data(using: .utf8) else { throw KeychainError.invalidData }
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: Self.service,
-            kSecAttrAccount as String: account(for: endpoint)
-        ]
-        let updateStatus = SecItemUpdate(
-            query as CFDictionary,
-            [kSecValueData as String: data] as CFDictionary
-        )
-        if updateStatus == errSecSuccess { return }
-        guard updateStatus == errSecItemNotFound else {
-            throw KeychainError.unexpectedStatus(updateStatus)
-        }
-        var addition = query
-        addition[kSecValueData as String] = data
-        addition[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
-        let addStatus = SecItemAdd(addition as CFDictionary, nil)
-        guard addStatus == errSecSuccess else { throw KeychainError.unexpectedStatus(addStatus) }
-    }
-
-    func removeToken(for endpoint: URL) throws {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: Self.service,
-            kSecAttrAccount as String: account(for: endpoint)
-        ]
-        let status = SecItemDelete(query as CFDictionary)
+    private func removeLegacyToken(for endpoint: URL) throws {
+        let status = SecItemDelete(legacyQuery(for: endpoint) as CFDictionary)
         guard status == errSecSuccess || status == errSecItemNotFound else {
             throw KeychainError.unexpectedStatus(status)
         }
     }
 
-    private func account(for endpoint: URL) -> String {
-        endpoint.absoluteString
+    private func legacyQuery(for endpoint: URL) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.legacyService,
+            kSecAttrAccount as String: endpoint.absoluteString
+        ]
     }
 }
 

--- a/Sources/SelectiveRemote/CloudSessionStore.swift
+++ b/Sources/SelectiveRemote/CloudSessionStore.swift
@@ -9,6 +9,7 @@ protocol SelectiveRemoteCloudTokenStore: Sendable {
 
 struct SelectiveRemoteCloudKeychainTokenStore: SelectiveRemoteCloudTokenStore {
     static let legacyService = "local.selectiveremote.cloud.session.v1"
+    static let service = legacyService
     private let envelopeStore = SelectiveRemoteCloudSecureEnvelopeStore()
 
     func token(for endpoint: URL) throws -> String? {

--- a/Sources/SelectiveRemote/CloudTeamDeviceIdentity.swift
+++ b/Sources/SelectiveRemote/CloudTeamDeviceIdentity.swift
@@ -59,6 +59,7 @@ actor SelectiveRemoteTeamDeviceIdentityManager {
 
 struct SelectiveRemoteTeamDeviceKeychainStore: SelectiveRemoteTeamDeviceKeyStore {
     static let legacyService = "local.selectiveremote.cloud.team-device-key.v1"
+    static let service = legacyService
     private let envelopeStore = SelectiveRemoteCloudSecureEnvelopeStore()
 
     func privateKeyRepresentation(for endpoint: URL, deviceID: UUID) throws -> Data? {

--- a/Sources/SelectiveRemote/CloudTeamDeviceIdentity.swift
+++ b/Sources/SelectiveRemote/CloudTeamDeviceIdentity.swift
@@ -58,22 +58,25 @@ actor SelectiveRemoteTeamDeviceIdentityManager {
 }
 
 struct SelectiveRemoteTeamDeviceKeychainStore: SelectiveRemoteTeamDeviceKeyStore {
-    static let service = "local.selectiveremote.cloud.team-device-key.v1"
+    static let legacyService = "local.selectiveremote.cloud.team-device-key.v1"
+    private let envelopeStore = SelectiveRemoteCloudSecureEnvelopeStore()
 
     func privateKeyRepresentation(for endpoint: URL, deviceID: UUID) throws -> Data? {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: Self.service,
-            kSecAttrAccount as String: account(endpoint: endpoint, deviceID: deviceID),
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne
-        ]
-        var result: CFTypeRef?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
-        if status == errSecItemNotFound { return nil }
-        guard status == errSecSuccess else { throw KeychainError.unexpectedStatus(status) }
-        guard let data = result as? Data else { throw KeychainError.invalidData }
-        return data
+        let key = deviceID.uuidString.lowercased()
+        if let representation = try envelopeStore.envelope(for: endpoint)?
+            .teamDevicePrivateKeys[key] {
+            return representation
+        }
+        guard let legacy = try legacyPrivateKey(for: endpoint, deviceID: deviceID) else {
+            return nil
+        }
+        let saved = try savePrivateKeyIfAbsent(
+            legacy,
+            for: endpoint,
+            deviceID: deviceID
+        )
+        try? removeLegacyPrivateKey(for: endpoint, deviceID: deviceID)
+        return saved
     }
 
     func savePrivateKeyIfAbsent(
@@ -81,37 +84,61 @@ struct SelectiveRemoteTeamDeviceKeychainStore: SelectiveRemoteTeamDeviceKeyStore
         for endpoint: URL,
         deviceID: UUID
     ) throws -> Data {
-        guard representation.count == 32 else { throw SelectiveRemoteTeamCryptoError.invalidPrivateKey }
-        let item: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: Self.service,
-            kSecAttrAccount as String: account(endpoint: endpoint, deviceID: deviceID),
-            kSecValueData as String: representation,
-            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
-        ]
-        let status = SecItemAdd(item as CFDictionary, nil)
-        if status == errSecSuccess { return representation }
-        if status == errSecDuplicateItem,
-           let existing = try privateKeyRepresentation(for: endpoint, deviceID: deviceID) {
-            return existing
+        guard representation.count == 32 else {
+            throw SelectiveRemoteTeamCryptoError.invalidPrivateKey
         }
-        throw KeychainError.unexpectedStatus(status)
+        let key = deviceID.uuidString.lowercased()
+        var result = representation
+        try envelopeStore.update(for: endpoint) { envelope in
+            if let existing = envelope.teamDevicePrivateKeys[key] {
+                result = existing
+            } else {
+                envelope.teamDevicePrivateKeys[key] = representation
+            }
+        }
+        return result
     }
 
     func removePrivateKey(for endpoint: URL, deviceID: UUID) throws {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: Self.service,
-            kSecAttrAccount as String: account(endpoint: endpoint, deviceID: deviceID)
-        ]
-        let status = SecItemDelete(query as CFDictionary)
+        let key = deviceID.uuidString.lowercased()
+        try envelopeStore.update(for: endpoint) {
+            $0.teamDevicePrivateKeys.removeValue(forKey: key)
+        }
+        try? removeLegacyPrivateKey(for: endpoint, deviceID: deviceID)
+    }
+
+    private func legacyPrivateKey(for endpoint: URL, deviceID: UUID) throws -> Data? {
+        var query = legacyQuery(endpoint: endpoint, deviceID: deviceID)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound { return nil }
+        guard status == errSecSuccess else {
+            throw KeychainError.unexpectedStatus(status)
+        }
+        guard let data = result as? Data, data.count == 32 else {
+            throw KeychainError.invalidData
+        }
+        return data
+    }
+
+    private func removeLegacyPrivateKey(for endpoint: URL, deviceID: UUID) throws {
+        let status = SecItemDelete(
+            legacyQuery(endpoint: endpoint, deviceID: deviceID) as CFDictionary
+        )
         guard status == errSecSuccess || status == errSecItemNotFound else {
             throw KeychainError.unexpectedStatus(status)
         }
     }
 
-    private func account(endpoint: URL, deviceID: UUID) -> String {
-        "\(endpoint.absoluteString)|\(deviceID.uuidString.lowercased())"
+    private func legacyQuery(endpoint: URL, deviceID: UUID) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.legacyService,
+            kSecAttrAccount as String:
+                "\(endpoint.absoluteString)|\(deviceID.uuidString.lowercased())"
+        ]
     }
 }
 

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -1699,3 +1699,29 @@ private actor TeamVaultMaterializedSnapshotSink {
         values
     }
 }
+
+
+@Suite("Unified Cloud Keychain envelope")
+struct CloudSecureEnvelopeModelTests {
+    @Test("session and one device key round-trip in a single envelope")
+    func roundTrip() throws {
+        let key = Data(repeating: 0x2a, count: 32)
+        let input = SelectiveRemoteCloudSecureEnvelope(
+            sessionToken: "session-token",
+            teamDevicePrivateKeys: ["device-id": key]
+        )
+        let encoded = try JSONEncoder().encode(input)
+        let decoded = try JSONDecoder().decode(
+            SelectiveRemoteCloudSecureEnvelope.self,
+            from: encoded
+        )
+        #expect(decoded == input)
+        #expect(!decoded.isEmpty)
+        #expect(decoded.teamDevicePrivateKeys["device-id"] == key)
+    }
+
+    @Test("empty envelope is removable")
+    func emptyEnvelope() {
+        #expect(SelectiveRemoteCloudSecureEnvelope().isEmpty)
+    }
+}

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -6,22 +6,24 @@ import { validateVaultDocument } from "../public/vault-model.js";
 const sourceRoot = new URL("../../Sources/SelectiveRemote/", import.meta.url);
 
 test("macOS Cloud foundation keeps sessions in device-only Keychain storage", async () => {
-  const [client, store] = await Promise.all([
+  const [client, store, envelope] = await Promise.all([
     readFile(new URL("CloudAPIClient.swift", sourceRoot), "utf8"),
     readFile(new URL("CloudSessionStore.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudSecureEnvelopeStore.swift", sourceRoot), "utf8"),
   ]);
   assert.match(store, /local\.selectiveremote\.cloud\.session\.v1/);
-  assert.match(store, /kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly/);
-  assert.doesNotMatch(store, /UserDefaults/);
+  assert.match(envelope, /kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly/);
+  assert.doesNotMatch(store + envelope, /UserDefaults/);
   assert.match(client, /Bearer.*Authorization/);
   assert.match(client, /http\.statusCode == 401[\s\S]*removeToken/);
   assert.match(client, /no-store.*Cache-Control/);
 });
 
 test("macOS Team crypto source pins the browser protocol labels and strict JWK shape", async () => {
-  const [source, identity] = await Promise.all([
+  const [source, identity, envelope] = await Promise.all([
     readFile(new URL("CloudTeamCrypto.swift", sourceRoot), "utf8"),
     readFile(new URL("CloudTeamDeviceIdentity.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudSecureEnvelopeStore.swift", sourceRoot), "utf8"),
   ]);
   assert.match(source, /selective-remote\/team-device-key\/v1/);
   assert.match(source, /selective-remote\/team-vault-wrapper\/v1/);
@@ -32,7 +34,7 @@ test("macOS Team crypto source pins the browser protocol labels and strict JWK s
   assert.match(source, /hkdfDerivedSymmetricKey/);
   assert.match(source, /AES\.GCM\.(seal|SealedBox)/);
   assert.match(identity, /local\.selectiveremote\.cloud\.team-device-key\.v1/);
-  assert.match(identity, /kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly/);
+  assert.match(envelope, /kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly/);
   assert.match(identity, /savePrivateKeyIfAbsent/);
   assert.doesNotMatch(identity, /UserDefaults/);
 });
@@ -146,12 +148,13 @@ test("macOS exposes a complete-choice conflict review without rendering secrets"
 });
 
 test("macOS Cloud settings expose device-bound sign-in and native Team management", async () => {
-  const [settings, accountViews, teamManagement, client, sessions] = await Promise.all([
+  const [settings, accountViews, teamManagement, client, sessions, envelope] = await Promise.all([
     readFile(new URL("CloudSettingsView.swift", sourceRoot), "utf8"),
     readFile(new URL("CloudAccountViews.swift", sourceRoot), "utf8"),
     readFile(new URL("CloudTeamManagementView.swift", sourceRoot), "utf8"),
     readFile(new URL("CloudAPIClient.swift", sourceRoot), "utf8"),
     readFile(new URL("CloudSessionStore.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudSecureEnvelopeStore.swift", sourceRoot), "utf8"),
   ]);
   assert.match(accountViews, /SecureField/);
   assert.doesNotMatch(accountViews, /@AppStorage/);
@@ -189,8 +192,8 @@ test("macOS Cloud settings expose device-bound sign-in and native Team managemen
   assert.match(client, /validTeamsJSON/);
   assert.match(client, /validTeamMembersJSON/);
   assert.match(client, /deviceID/);
-  assert.match(sessions, /kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly/);
-  assert.doesNotMatch(sessions, /UserDefaults/);
+  assert.match(envelope, /kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly/);
+  assert.doesNotMatch(sessions + envelope, /UserDefaults/);
 });
 
 test("connection checks preserve the signed-in account and inventory failures stay isolated", async () => {

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -391,3 +391,21 @@ test("macOS Team Host personal settings preserve per-Mac display selection", asy
   assert.match(personal, /private func toggleDisplay/u);
   assert.match(personal, /guard selected\.count > 1/u);
 });
+
+
+test("macOS Cloud session and Team device key share one Keychain envelope", async () => {
+  const [envelope, session, teamDevice] = await Promise.all([
+    readFile(new URL("CloudSecureEnvelopeStore.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudSessionStore.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudTeamDeviceIdentity.swift", sourceRoot), "utf8"),
+  ]);
+  assert.match(envelope, /local\.selectiveremote\.cloud\.secure-envelope\.v1/u);
+  assert.match(envelope, /var sessionToken: String\?/u);
+  assert.match(envelope, /var teamDevicePrivateKeys: \[String: Data\]/u);
+  assert.match(envelope, /kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly/u);
+  assert.match(session, /SelectiveRemoteCloudSecureEnvelopeStore/u);
+  assert.match(session, /legacyService = "local\.selectiveremote\.cloud\.session\.v1"/u);
+  assert.match(teamDevice, /SelectiveRemoteCloudSecureEnvelopeStore/u);
+  assert.match(teamDevice, /legacyService = "local\.selectiveremote\.cloud\.team-device-key\.v1"/u);
+  assert.doesNotMatch(envelope, /teamID|vaultID|hostID/u);
+});


### PR DESCRIPTION
## Summary
- store the Cloud session token and Team device private key in one endpoint-scoped Keychain envelope
- keep one Team device key regardless of how many teams and Team Vaults the account joins
- migrate the two legacy Keychain services on first successful access and remove migrated legacy items
- serialize envelope read-modify-write operations and retain ThisDeviceOnly accessibility
- remove the envelope only when both session and device-key state are empty

## Security and UX
This is the first single-unlock slice. It collapses the two Cloud-specific prompts into one item. Personal host credentials remain in their existing credential store, while future Team Host credentials remain encrypted inside Team Vault rather than creating one Keychain item per Host or Team.

## Stack
Depends on #85.