### PR TITLE
Add encrypted credentials for Team Hosts

### DIFF
--- a/Sources/SelectiveRemote/CloudTeamHostEditor.swift
+++ b/Sources/SelectiveRemote/CloudTeamHostEditor.swift
@@ -14,7 +14,7 @@ struct SelectiveRemoteTeamHostMutationMessage: Identifiable {
 
 struct SelectiveRemoteTeamHostEditorView: View {
     let request: SelectiveRemoteTeamHostEditorRequest
-    let onSave: (ConnectionProfile) -> Void
+    let onSave: (ConnectionProfile, SelectiveRemoteTeamHostCredentials) -> Void
 
     @Environment(\.dismiss) private var dismiss
     @State private var title: String
@@ -25,10 +25,12 @@ struct SelectiveRemoteTeamHostEditorView: View {
     @State private var folder: String
     @State private var tagsText: String
     @State private var profileDescription: String
+    @State private var password: String
+    @State private var gatewayPassword: String
 
     init(
         request: SelectiveRemoteTeamHostEditorRequest,
-        onSave: @escaping (ConnectionProfile) -> Void
+        onSave: @escaping (ConnectionProfile, SelectiveRemoteTeamHostCredentials) -> Void
     ) {
         self.request = request
         self.onSave = onSave
@@ -41,6 +43,8 @@ struct SelectiveRemoteTeamHostEditorView: View {
         _folder = State(initialValue: profile?.group ?? "")
         _tagsText = State(initialValue: profile?.tags.joined(separator: ", ") ?? "")
         _profileDescription = State(initialValue: profile?.profileDescription ?? "")
+        _password = State(initialValue: request.host?.credentials.password ?? "")
+        _gatewayPassword = State(initialValue: request.host?.credentials.gatewayPassword ?? "")
     }
 
     private var isValid: Bool {
@@ -139,6 +143,24 @@ struct SelectiveRemoteTeamHostEditorView: View {
                         format: .number
                     )
                 }
+                if connectionType == .rdp || connectionType == .ssh {
+                    SecureField(
+                        UpdateLocalization.text(
+                            ru: "Общий пароль (Team Vault)",
+                            en: "Shared Password (Team Vault)"
+                        ),
+                        text: $password
+                    )
+                }
+                if connectionType == .rdp {
+                    SecureField(
+                        UpdateLocalization.text(
+                            ru: "Общий пароль Gateway (Team Vault)",
+                            en: "Shared Gateway Password (Team Vault)"
+                        ),
+                        text: $gatewayPassword
+                    )
+                }
                 TextField(
                     UpdateLocalization.text(ru: "Папка", en: "Folder"),
                     text: $folder
@@ -161,8 +183,8 @@ struct SelectiveRemoteTeamHostEditorView: View {
 
             Label(
                 UpdateLocalization.text(
-                    ru: "Пароли и ссылки на Personal Vault не сохраняются в Team Host.",
-                    en: "Passwords and Personal Vault references are not saved in a Team Host."
+                    ru: "Общие пароли шифруются внутри Team Vault. Пустое поле удаляет общий пароль; ссылки на Personal Vault не сохраняются.",
+                    en: "Shared passwords are encrypted inside Team Vault. An empty field removes the shared password; Personal Vault references are never saved."
                 ),
                 systemImage: "lock.shield"
             )
@@ -178,7 +200,13 @@ struct SelectiveRemoteTeamHostEditorView: View {
                     ? UpdateLocalization.text(ru: "Добавить", en: "Add")
                     : UpdateLocalization.text(ru: "Сохранить", en: "Save")
                 ) {
-                    onSave(profile())
+                    onSave(
+                        profile(),
+                        .init(
+                            password: password.isEmpty ? nil : password,
+                            gatewayPassword: gatewayPassword.isEmpty ? nil : gatewayPassword
+                        )
+                    )
                     dismiss()
                 }
                 .buttonStyle(.borderedProminent)

--- a/Sources/SelectiveRemote/CloudTeamHostMutation.swift
+++ b/Sources/SelectiveRemote/CloudTeamHostMutation.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 enum SelectiveRemoteTeamHostMutationError: LocalizedError, Equatable {
@@ -36,6 +37,7 @@ enum SelectiveRemoteTeamHostDocumentMutation {
 
     static func create(
         profile: ConnectionProfile,
+        credentials: SelectiveRemoteTeamHostCredentials = .empty,
         role: SelectiveRemoteCloudTeamRole,
         deviceID: UUID,
         modifiedAt: String
@@ -43,6 +45,7 @@ enum SelectiveRemoteTeamHostDocumentMutation {
         try mutate(
             document: .init(),
             profile: profile,
+            credentials: credentials,
             recordID: profile.id,
             role: role,
             deviceID: deviceID,
@@ -54,6 +57,7 @@ enum SelectiveRemoteTeamHostDocumentMutation {
     static func create(
         in document: SelectiveRemoteVaultDocument,
         profile: ConnectionProfile,
+        credentials: SelectiveRemoteTeamHostCredentials = .empty,
         role: SelectiveRemoteCloudTeamRole,
         deviceID: UUID,
         modifiedAt: String
@@ -64,6 +68,7 @@ enum SelectiveRemoteTeamHostDocumentMutation {
         return try mutate(
             document: document,
             profile: profile,
+            credentials: credentials,
             recordID: profile.id,
             role: role,
             deviceID: deviceID,
@@ -76,6 +81,7 @@ enum SelectiveRemoteTeamHostDocumentMutation {
         in document: SelectiveRemoteVaultDocument,
         recordID: UUID,
         profile: ConnectionProfile,
+        credentials: SelectiveRemoteTeamHostCredentials = .empty,
         role: SelectiveRemoteCloudTeamRole,
         deviceID: UUID,
         modifiedAt: String
@@ -83,6 +89,7 @@ enum SelectiveRemoteTeamHostDocumentMutation {
         try mutate(
             document: document,
             profile: profile,
+            credentials: credentials,
             recordID: recordID,
             role: role,
             deviceID: deviceID,
@@ -108,20 +115,30 @@ enum SelectiveRemoteTeamHostDocumentMutation {
         guard existing.type == .host else {
             throw SelectiveRemoteTeamHostMutationError.recordIsNotHost
         }
-        let tombstone = try SelectiveRemoteVaultTombstone(
-            id: recordID,
-            version: existing.version.incrementing(deviceID),
-            deletedAt: deletedAt
-        )
+        let removed = document.records.filter { record in
+            record.id == recordID || isCredential(record, for: recordID)
+        }
+        let tombstones = try removed.map { record in
+            try SelectiveRemoteVaultTombstone(
+                id: record.id,
+                version: record.version.incrementing(deviceID),
+                deletedAt: deletedAt
+            )
+        }
         return try .init(
-            records: document.records.filter { $0.id != recordID },
-            tombstones: document.tombstones.filter { $0.id != recordID } + [tombstone]
+            records: document.records.filter { record in
+                !removed.contains(where: { $0.id == record.id })
+            },
+            tombstones: document.tombstones.filter { tombstone in
+                !removed.contains(where: { $0.id == tombstone.id })
+            } + tombstones
         )
     }
 
     private static func mutate(
         document: SelectiveRemoteVaultDocument,
         profile: ConnectionProfile,
+        credentials: SelectiveRemoteTeamHostCredentials,
         recordID: UUID,
         role: SelectiveRemoteCloudTeamRole,
         deviceID: UUID,
@@ -156,10 +173,78 @@ enum SelectiveRemoteTeamHostDocumentMutation {
             modifiedAt: modifiedAt,
             data: exported.data
         )
-        return try .init(
-            records: document.records.filter { $0.id != recordID } + [record],
-            tombstones: document.tombstones.filter { $0.id != recordID }
+        let previous = document.records.filter { isCredential($0, for: recordID) }
+        let credentialRecords = try makeCredentials(
+            credentials,
+            profile: exportedProfile,
+            recordID: recordID,
+            previous: previous,
+            deviceID: deviceID,
+            modifiedAt: modifiedAt
         )
+        let currentIDs = Set(credentialRecords.map(\.id))
+        let credentialTombstones = try previous.filter { !currentIDs.contains($0.id) }.map {
+            try SelectiveRemoteVaultTombstone(
+                id: $0.id,
+                version: $0.version.incrementing(deviceID),
+                deletedAt: modifiedAt
+            )
+        }
+        let replacedIDs = Set([recordID] + previous.map(\.id))
+        return try .init(
+            records: document.records.filter { !replacedIDs.contains($0.id) }
+                + [record] + credentialRecords,
+            tombstones: document.tombstones.filter {
+                $0.id != recordID && !currentIDs.contains($0.id)
+            } + credentialTombstones
+        )
+    }
+
+    private static func makeCredentials(
+        _ value: SelectiveRemoteTeamHostCredentials,
+        profile: ConnectionProfile,
+        recordID: UUID,
+        previous: [SelectiveRemoteVaultRecord],
+        deviceID: UUID,
+        modifiedAt: String
+    ) throws -> [SelectiveRemoteVaultRecord] {
+        let inputs: [(KeychainCredentialKind, String)] = [
+            (profile.connectionType == .ssh ? .ssh : .rdp, value.password ?? ""),
+            (.gateway, value.gatewayPassword ?? "")
+        ]
+        return try inputs.compactMap { kind, secret in
+            guard !secret.isEmpty else { return nil }
+            let id = credentialID(sourceID: recordID, kind: kind)
+            let old = previous.first(where: { $0.id == id })
+            return try SelectiveRemoteVaultRecord(
+                id: id,
+                type: .credential,
+                version: try old?.version.incrementing(deviceID)
+                    ?? SelectiveRemoteVaultVersion([deviceID: 1]),
+                modifiedAt: modifiedAt,
+                data: .object([
+                    "title": .string("\(profile.friendlyName) · \(kind.rawValue)"),
+                    "username": .string(kind == .gateway ? profile.gatewayUsername : profile.username),
+                    "secret": .string(secret),
+                    "kind": .string(kind.rawValue),
+                    "sourceID": .string(recordID.canonicalCloudString)
+                ])
+            )
+        }
+    }
+
+    private static func credentialID(sourceID: UUID, kind: KeychainCredentialKind) -> UUID {
+        let value = "selective-remote/team-host-credential/v1\u{0}\(sourceID.canonicalCloudString)\u{0}\(kind.rawValue)"
+        var bytes = Array(SHA256.hash(data: Data(value.utf8)).prefix(16))
+        bytes[6] = (bytes[6] & 0x0f) | 0x50
+        bytes[8] = (bytes[8] & 0x3f) | 0x80
+        return UUID(uuid: (bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7], bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]))
+    }
+
+    private static func isCredential(_ record: SelectiveRemoteVaultRecord, for hostID: UUID) -> Bool {
+        guard record.type == .credential, case let .object(data) = record.data,
+              case let .string(source)? = data["sourceID"] else { return false }
+        return UUID(uuidString: source) == hostID
     }
 
     private static func requireWritable(_ role: SelectiveRemoteCloudTeamRole) throws {
@@ -180,8 +265,8 @@ struct SelectiveRemoteTeamHostVaultContext: Identifiable, Equatable {
 }
 
 enum SelectiveRemoteTeamHostMutationChange {
-    case create(ConnectionProfile)
-    case update(recordID: UUID, profile: ConnectionProfile)
+    case create(ConnectionProfile, SelectiveRemoteTeamHostCredentials)
+    case update(recordID: UUID, profile: ConnectionProfile, credentials: SelectiveRemoteTeamHostCredentials)
     case delete(recordID: UUID)
 }
 
@@ -247,10 +332,11 @@ final class SelectiveRemoteTeamHostMutationService {
             )
         case .empty:
             guard context.role == .owner || context.role == .admin,
-                  case let .create(profile) = change
+                  case let .create(profile, credentials) = change
             else { throw SelectiveRemoteTeamHostMutationError.hostNotFound }
             let document = try SelectiveRemoteTeamHostDocumentMutation.create(
                 profile: profile,
+                credentials: credentials,
                 role: context.role,
                 deviceID: identity.deviceID,
                 modifiedAt: timestamp
@@ -293,19 +379,21 @@ final class SelectiveRemoteTeamHostMutationService {
         timestamp: String
     ) throws -> SelectiveRemoteVaultDocument {
         switch change {
-        case let .create(profile):
+        case let .create(profile, credentials):
             try SelectiveRemoteTeamHostDocumentMutation.create(
                 in: document,
                 profile: profile,
+                credentials: credentials,
                 role: role,
                 deviceID: deviceID,
                 modifiedAt: timestamp
             )
-        case let .update(recordID, profile):
+        case let .update(recordID, profile, credentials):
             try SelectiveRemoteTeamHostDocumentMutation.update(
                 in: document,
                 recordID: recordID,
                 profile: profile,
+                credentials: credentials,
                 role: role,
                 deviceID: deviceID,
                 modifiedAt: timestamp

--- a/Sources/SelectiveRemote/CloudTeamHosts.swift
+++ b/Sources/SelectiveRemote/CloudTeamHosts.swift
@@ -26,6 +26,14 @@ struct SelectiveRemoteTeamHost: Identifiable, Equatable {
     let modifiedAt: String
     let address: String
     let profile: ConnectionProfile
+    let credentials: SelectiveRemoteTeamHostCredentials
+}
+
+struct SelectiveRemoteTeamHostCredentials: Equatable, Sendable {
+    var password: String?
+    var gatewayPassword: String?
+
+    static let empty = Self(password: nil, gatewayPassword: nil)
 }
 
 enum SelectiveRemoteTeamHostMaterializationError: Error, Equatable {
@@ -58,6 +66,7 @@ enum SelectiveRemoteTeamHostMaterializer {
             throw SelectiveRemoteTeamHostMaterializationError.invalidSnapshot
         }
 
+        let credentials = try materializedCredentials(document.records)
         return try document.records.compactMap { record in
             guard record.type == .host else { return nil }
             guard case let .object(data) = record.data,
@@ -124,9 +133,45 @@ enum SelectiveRemoteTeamHostMaterializer {
                         vaultID: snapshot.vaultID,
                         recordID: record.id
                     )
-                )
+                ),
+                credentials: credentials[record.id] ?? .empty
             )
         }
+    }
+
+    private static func materializedCredentials(
+        _ records: [SelectiveRemoteVaultRecord]
+    ) throws -> [UUID: SelectiveRemoteTeamHostCredentials] {
+        var result: [UUID: SelectiveRemoteTeamHostCredentials] = [:]
+        for record in records where record.type == .credential {
+            guard case let .object(data) = record.data,
+                  Set(data.keys) == Set(["title", "username", "secret", "kind", "sourceID"]),
+                  let source = string(data["sourceID"]),
+                  let sourceID = UUID(uuidString: source),
+                  sourceID.isSelectiveRemoteCloudUUID,
+                  let secret = string(data["secret"]),
+                  !secret.isEmpty,
+                  secret.utf8.count <= 16_384,
+                  let kind = string(data["kind"]),
+                  kind == KeychainCredentialKind.rdp.rawValue
+                    || kind == KeychainCredentialKind.ssh.rawValue
+                    || kind == KeychainCredentialKind.gateway.rawValue
+            else { throw SelectiveRemoteTeamHostMaterializationError.invalidHostRecord }
+            var value = result[sourceID] ?? .empty
+            if kind == KeychainCredentialKind.gateway.rawValue {
+                guard value.gatewayPassword == nil else {
+                    throw SelectiveRemoteTeamHostMaterializationError.invalidHostRecord
+                }
+                value.gatewayPassword = secret
+            } else {
+                guard value.password == nil else {
+                    throw SelectiveRemoteTeamHostMaterializationError.invalidHostRecord
+                }
+                value.password = secret
+            }
+            result[sourceID] = value
+        }
+        return result
     }
 
     static func scopedID(teamID: UUID, vaultID: UUID, recordID: UUID) -> UUID {
@@ -672,11 +717,11 @@ struct SelectiveRemoteTeamHostsView: View {
         }
         .onChange(of: selectedHostID) { _, _ in resetConnectionFields() }
         .sheet(item: $editorRequest) { request in
-            SelectiveRemoteTeamHostEditorView(request: request) { profile in
+            SelectiveRemoteTeamHostEditorView(request: request) { profile, credentials in
                 mutate(
                     request.host.map {
-                        .update(recordID: $0.recordID, profile: profile)
-                    } ?? .create(profile),
+                        .update(recordID: $0.recordID, profile: profile, credentials: credentials)
+                    } ?? .create(profile, credentials),
                     context: request.context,
                     selectedRecordID: profile.id
                 )
@@ -879,12 +924,12 @@ struct SelectiveRemoteTeamHostsView: View {
                             SecureField(
                                 host.profile.connectionType == .rdp
                                     ? UpdateLocalization.text(
-                                        ru: "Пароль RDP (не сохраняется)",
-                                        en: "RDP Password (not saved)"
+                                        ru: "Пароль RDP (общий или временный)",
+                                        en: "RDP Password (shared or temporary)"
                                     )
                                     : UpdateLocalization.text(
-                                        ru: "Пароль SSH, если нужен (не сохраняется)",
-                                        en: "SSH Password, if needed (not saved)"
+                                        ru: "Пароль SSH (общий или временный)",
+                                        en: "SSH Password (shared or temporary)"
                                     ),
                                 text: $password
                             )
@@ -894,8 +939,8 @@ struct SelectiveRemoteTeamHostsView: View {
                            !host.profile.gatewayHost.isEmpty {
                             SecureField(
                                 UpdateLocalization.text(
-                                    ru: "Пароль Gateway (не сохраняется)",
-                                    en: "Gateway Password (not saved)"
+                                    ru: "Пароль Gateway (общий или временный)",
+                                    en: "Gateway Password (shared or temporary)"
                                 ),
                                 text: $gatewayPassword
                             )
@@ -936,8 +981,8 @@ struct SelectiveRemoteTeamHostsView: View {
                                         username,
                                         password.isEmpty ? nil : password
                                     )
-                                    password = ""
-                                    gatewayPassword = ""
+                                    password = host.credentials.password ?? ""
+                                    gatewayPassword = host.credentials.gatewayPassword ?? ""
                                 }
                             }
                             Spacer()
@@ -945,8 +990,8 @@ struct SelectiveRemoteTeamHostsView: View {
 
                         Label(
                             UpdateLocalization.text(
-                                ru: "Общий профиль не добавляется в Personal Vault. Мои настройки хранятся только на этом Mac; введённые пароли не сохраняются.",
-                                en: "The shared profile is not added to Personal Vault. My settings stay on this Mac; entered passwords are not saved."
+                                ru: "Общие пароли приходят из зашифрованного Team Vault. Изменить или удалить их могут Owner, Admin и Editor через карточку Host; временно введённое значение не сохраняется.",
+                                en: "Shared passwords come from the encrypted Team Vault. Owners, Admins, and Editors can change or remove them in the Host editor; a temporary override is not saved."
                             ),
                             systemImage: "lock.shield"
                         )
@@ -1070,8 +1115,8 @@ struct SelectiveRemoteTeamHostsView: View {
         } else {
             onOpenTerminal(host, username, password.isEmpty ? nil : password)
         }
-        password = ""
-        gatewayPassword = ""
+        password = selectedHost?.credentials.password ?? ""
+        gatewayPassword = selectedHost?.credentials.gatewayPassword ?? ""
     }
 
     private func normalizeSelection() {
@@ -1087,8 +1132,8 @@ struct SelectiveRemoteTeamHostsView: View {
         username = selectedHost.map {
             personalSettingsStore.settings(for: $0, endpoint: endpoint).preferredUsername
         } ?? ""
-        password = ""
-        gatewayPassword = ""
+        password = selectedHost?.credentials.password ?? ""
+        gatewayPassword = selectedHost?.credentials.gatewayPassword ?? ""
     }
 
     private func roleTitle(_ role: SelectiveRemoteCloudTeamRole) -> String {

--- a/Sources/SelectiveRemote/CloudTeamHosts.swift
+++ b/Sources/SelectiveRemote/CloudTeamHosts.swift
@@ -67,6 +67,10 @@ enum SelectiveRemoteTeamHostMaterializer {
         }
 
         let credentials = try materializedCredentials(document.records)
+        let hostIDs = Set(document.records.filter { $0.type == .host }.map(\.id))
+        guard credentials.keys.allSatisfy(hostIDs.contains) else {
+            throw SelectiveRemoteTeamHostMaterializationError.invalidHostRecord
+        }
         return try document.records.compactMap { record in
             guard record.type == .host else { return nil }
             guard case let .object(data) = record.data,

--- a/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
@@ -260,6 +260,57 @@ struct CloudTeamHostsTests {
         #expect(mutated.records.count == original.records.count + 1)
     }
 
+    @MainActor
+    @Test("Team Host credentials are encrypted records, materialize for connection, and delete causally")
+    func sharedCredentialLifecycle() throws {
+        let deviceID = try #require(UUID(uuidString: "44444444-4444-4444-8444-444444444444"))
+        let recordID = try #require(UUID(uuidString: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"))
+        var profile = ConnectionProfile(connectionType: .rdp)
+        profile.id = recordID
+        profile.friendlyName = "Shared Desktop"
+        profile.host = "desktop.example.invalid"
+        profile.username = "operator"
+        profile.gatewayHost = "gateway.example.invalid"
+        profile.gatewayUsername = "gateway-user"
+
+        let created = try SelectiveRemoteTeamHostDocumentMutation.create(
+            profile: profile,
+            credentials: .init(password: "host-secret", gatewayPassword: "gateway-secret"),
+            role: .owner,
+            deviceID: deviceID,
+            modifiedAt: "2026-09-10T04:00:00.000Z"
+        )
+        #expect(created.records.filter { $0.type == .credential }.count == 2)
+
+        let store = SelectiveRemoteTeamHostStore()
+        store.replace(with: [Self.snapshot(payload: try created.encoded(), role: .owner)])
+        let host = try #require(store.hosts.first)
+        #expect(host.credentials.password == "host-secret")
+        #expect(host.credentials.gatewayPassword == "gateway-secret")
+
+        let updated = try SelectiveRemoteTeamHostDocumentMutation.update(
+            in: created,
+            recordID: recordID,
+            profile: profile,
+            credentials: .init(password: "rotated", gatewayPassword: nil),
+            role: .admin,
+            deviceID: deviceID,
+            modifiedAt: "2026-09-10T04:01:00.000Z"
+        )
+        #expect(updated.records.filter { $0.type == .credential }.count == 1)
+        #expect(updated.tombstones.count == 1)
+
+        let deleted = try SelectiveRemoteTeamHostDocumentMutation.delete(
+            from: updated,
+            recordID: recordID,
+            role: .editor,
+            deviceID: deviceID,
+            deletedAt: "2026-09-10T04:02:00.000Z"
+        )
+        #expect(deleted.records.isEmpty)
+        #expect(deleted.tombstones.count == 2)
+    }
+
 
     @MainActor
     @Test("store exposes valid Vault contexts and replaces one Vault without touching another")
@@ -323,7 +374,8 @@ struct CloudTeamHostsTests {
             keyGeneration: 3,
             modifiedAt: "2026-09-10T08:00:00.000Z",
             address: shared.host,
-            profile: shared
+            profile: shared,
+            credentials: .empty
         )
 
         let store = SelectiveRemoteTeamHostPersonalSettingsStore(

--- a/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
@@ -308,7 +308,7 @@ struct CloudTeamHostsTests {
             deletedAt: "2026-09-10T04:02:00.000Z"
         )
         #expect(deleted.records.isEmpty)
-        #expect(deleted.tombstones.count == 2)
+        #expect(deleted.tombstones.count == 3)
     }
 
 

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -313,17 +313,35 @@ test("macOS Team Host controls expose writes only through the encrypted role-awa
   ]);
   assert.match(hosts, /writableVaults[\s\S]*isWritable\(role:/u);
   assert.match(hosts, /if SelectiveRemoteTeamHostDocumentMutation\.isWritable\(role: host\.role\)/u);
-  assert.match(hosts, /\.create\(profile\)/u);
+  assert.match(hosts, /\.create\(profile, credentials\)/u);
   assert.match(hosts, /\.update\(recordID:/u);
   assert.match(hosts, /\.delete\(recordID:/u);
   assert.match(hosts, /store\.replaceVault\(with: snapshot\)/u);
   assert.doesNotMatch(hosts, /model\.profiles|profiles\.append/u);
-  assert.match(editor, /Passwords and Personal Vault references are not saved/u);
-  assert.doesNotMatch(editor, /SecureField|password/u);
+  assert.match(editor, /Shared passwords are encrypted inside Team Vault/u);
+  assert.match(editor, /SecureField/u);
   assert.match(mutation, /case \.readOnlyRole/u);
   assert.match(mutation, /coordinator\.refresh/u);
   assert.match(mutation, /coordinator\.stage/u);
   assert.match(mutation, /coordinator\.push/u);
+});
+
+
+test("macOS Team Host credentials stay inside the encrypted Team Vault lifecycle", async () => {
+  const [hosts, editor, mutation] = await Promise.all([
+    readFile(new URL("CloudTeamHosts.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudTeamHostEditor.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudTeamHostMutation.swift", sourceRoot), "utf8"),
+  ]);
+  assert.match(hosts, /let credentials: SelectiveRemoteTeamHostCredentials/u);
+  assert.match(hosts, /record\.type == \.credential/u);
+  assert.match(hosts, /host\.credentials\.password/u);
+  assert.match(editor, /Shared Password \(Team Vault\)/u);
+  assert.match(mutation, /selective-remote\/team-host-credential\/v1/u);
+  assert.match(mutation, /"sourceID": \.string\(recordID\.canonicalCloudString\)/u);
+  assert.match(mutation, /isCredential\(record, for: recordID\)/u);
+  assert.match(mutation, /credentialTombstones/u);
+  assert.doesNotMatch(mutation, /KeychainService\.savePassword/u);
 });
 
 

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -341,6 +341,7 @@ test("macOS Team Host credentials stay inside the encrypted Team Vault lifecycle
   assert.match(mutation, /"sourceID": \.string\(recordID\.canonicalCloudString\)/u);
   assert.match(mutation, /isCredential\(record, for: recordID\)/u);
   assert.match(mutation, /credentialTombstones/u);
+  assert.doesNotMatch(hosts, /KeychainService\.savePassword/u);
   assert.doesNotMatch(mutation, /KeychainService\.savePassword/u);
 });
 

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -335,6 +335,7 @@ test("macOS Team Host credentials stay inside the encrypted Team Vault lifecycle
   ]);
   assert.match(hosts, /let credentials: SelectiveRemoteTeamHostCredentials/u);
   assert.match(hosts, /record\.type == \.credential/u);
+  assert.match(hosts, /credentials\.keys\.allSatisfy\(hostIDs\.contains\)/u);
   assert.match(hosts, /host\.credentials\.password/u);
   assert.match(editor, /Shared Password \(Team Vault\)/u);
   assert.match(mutation, /selective-remote\/team-host-credential\/v1/u);


### PR DESCRIPTION
## Summary
- store shared RDP, SSH, and RDP Gateway passwords as credential records inside the encrypted Team Vault payload
- link each credential to its Team Host through `sourceID` without creating per-Host or per-Team Keychain items
- materialize shared credentials only after Team Vault decryption and use them automatically for RDP, SSH, and SFTP
- let Owner, Admin, and Editor add, rotate, or remove shared passwords in the Team Host editor
- delete linked credentials causally with tombstones when a password or Host is removed
- keep temporary connection overrides ephemeral and personal per-Mac settings secret-free

## Security
The Cloud service continues to receive ciphertext only. Shared secrets are not copied into Personal Vault or saved through `KeychainService`; they remain part of the existing E2EE Team Vault lifecycle.

## Tests
- Team Host credential create/materialize/rotate/remove/delete lifecycle
- source contract for encrypted storage, linkage, tombstones, and no per-Host Keychain persistence

## Stack
Depends on #86.