### PR TITLE
Fix macOS Cloud login and credential-safe Personal Vault auto-sync

### DIFF
--- a/Sources/SelectiveRemote/CloudAPIClient.swift
+++ b/Sources/SelectiveRemote/CloudAPIClient.swift
@@ -894,7 +894,12 @@ actor SelectiveRemoteCloudAPIClient {
     }
 
     private static func validUserObject(_ value: Any?) -> Bool {
-        exactKeys(value, expected: ["id", "email", "username", "displayName"])
+        guard exactKeys(
+            value,
+            expected: ["id", "email", "username", "displayName", "createdAt"]
+        ), let createdAt = (value as? [String: Any])?["createdAt"] as? String
+        else { return false }
+        return !createdAt.isEmpty && createdAt.count <= 64
     }
 
     private static func validUserJSON(_ data: Data) -> Bool {

--- a/Sources/SelectiveRemote/CloudPersonalVaultAutoSync.swift
+++ b/Sources/SelectiveRemote/CloudPersonalVaultAutoSync.swift
@@ -37,10 +37,18 @@ protocol SelectiveRemotePersonalVaultKeyStore: Sendable {
 }
 
 struct SelectiveRemotePersonalVaultKeychainStore: SelectiveRemotePersonalVaultKeyStore {
-    static let service = "local.selectiveremote.cloud.personal-vault-key.v1"
+    static let legacyService = "local.selectiveremote.cloud.personal-vault-key.v1"
+    static let service = legacyService
+    private let envelopeStore = SelectiveRemoteCloudSecureEnvelopeStore()
 
     func material(endpoint: URL, deviceID: UUID) throws -> SelectiveRemotePersonalVaultKeyMaterial? {
-        let query = baseQuery(endpoint: endpoint, deviceID: deviceID).merging([
+        let key = deviceID.uuidString.lowercased()
+        if let data = try envelopeStore.envelope(for: endpoint)?
+            .personalVaultKeyMaterials[key] {
+            do { return try JSONDecoder().decode(SelectiveRemotePersonalVaultKeyMaterial.self, from: data) }
+            catch { throw KeychainError.invalidData }
+        }
+        let query = legacyQuery(endpoint: endpoint, deviceID: deviceID).merging([
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne
         ]) { _, new in new }
@@ -50,35 +58,42 @@ struct SelectiveRemotePersonalVaultKeychainStore: SelectiveRemotePersonalVaultKe
         guard status == errSecSuccess, let data = result as? Data else {
             throw status == errSecSuccess ? KeychainError.invalidData : KeychainError.unexpectedStatus(status)
         }
-        do { return try JSONDecoder().decode(SelectiveRemotePersonalVaultKeyMaterial.self, from: data) }
+        do {
+            let material = try JSONDecoder().decode(SelectiveRemotePersonalVaultKeyMaterial.self, from: data)
+            try save(material, endpoint: endpoint, deviceID: deviceID)
+            try? removeLegacy(endpoint: endpoint, deviceID: deviceID)
+            return material
+        } catch let error as KeychainError { throw error }
         catch { throw KeychainError.invalidData }
     }
 
     func save(_ material: SelectiveRemotePersonalVaultKeyMaterial, endpoint: URL, deviceID: UUID) throws {
         let data = try JSONEncoder().encode(material)
-        let query = baseQuery(endpoint: endpoint, deviceID: deviceID)
-        let updateStatus = SecItemUpdate(query as CFDictionary, [kSecValueData as String: data] as CFDictionary)
-        if updateStatus == errSecSuccess { return }
-        guard updateStatus == errSecItemNotFound else { throw KeychainError.unexpectedStatus(updateStatus) }
-        let item = query.merging([
-            kSecValueData as String: data,
-            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
-        ]) { _, new in new }
-        let addStatus = SecItemAdd(item as CFDictionary, nil)
-        guard addStatus == errSecSuccess else { throw KeychainError.unexpectedStatus(addStatus) }
+        let key = deviceID.uuidString.lowercased()
+        try envelopeStore.update(for: endpoint) {
+            $0.personalVaultKeyMaterials[key] = data
+        }
     }
 
     func remove(endpoint: URL, deviceID: UUID) throws {
-        let status = SecItemDelete(baseQuery(endpoint: endpoint, deviceID: deviceID) as CFDictionary)
+        let key = deviceID.uuidString.lowercased()
+        try envelopeStore.update(for: endpoint) {
+            $0.personalVaultKeyMaterials.removeValue(forKey: key)
+        }
+        try? removeLegacy(endpoint: endpoint, deviceID: deviceID)
+    }
+
+    private func removeLegacy(endpoint: URL, deviceID: UUID) throws {
+        let status = SecItemDelete(legacyQuery(endpoint: endpoint, deviceID: deviceID) as CFDictionary)
         guard status == errSecSuccess || status == errSecItemNotFound else {
             throw KeychainError.unexpectedStatus(status)
         }
     }
 
-    private func baseQuery(endpoint: URL, deviceID: UUID) -> [String: Any] {
+    private func legacyQuery(endpoint: URL, deviceID: UUID) -> [String: Any] {
         [
             kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: Self.service,
+            kSecAttrService as String: Self.legacyService,
             kSecAttrAccount as String: "\(endpoint.absoluteString)|\(deviceID.uuidString.lowercased())"
         ]
     }
@@ -126,7 +141,6 @@ actor SelectiveRemotePersonalVaultAutoSync {
         forwarding: [IndependentPortForward]
     ) async throws {
         guard var material = try keyStore.material(endpoint: endpoint, deviceID: deviceID),
-              !material.includesCredentials,
               await client.hasStoredSession(endpoint: endpoint)
         else { return }
         let exported = try SelectiveRemotePersonalVaultExporter.makeExport(
@@ -137,14 +151,20 @@ actor SelectiveRemotePersonalVaultAutoSync {
             deviceID: deviceID,
             allowEmpty: true
         )
-        let documentHash = Data(SHA256.hash(data: try exported.document.encoded()))
-        guard documentHash != material.documentHash else { return }
         let remote = try await client.personalVault(endpoint: endpoint)
         guard remote.id == material.vaultID, remote.revision == material.revision else {
             throw SelectiveRemotePersonalVaultError.uploadConflict(remote.revision)
         }
+        let document = try mergedDocument(
+            local: exported.document,
+            remote: remote,
+            vaultKey: material.vaultKey,
+            profileIDs: Set(profiles.map(\.id))
+        )
+        let documentHash = Data(SHA256.hash(data: try document.encoded()))
+        guard documentHash != material.documentHash else { return }
         let envelope = try SelectiveRemotePersonalVaultCrypto.reseal(
-            exported.document,
+            document,
             vaultKey: material.vaultKey,
             wrappedKey: material.wrappedKey,
             baseRevision: remote.revision
@@ -156,5 +176,31 @@ actor SelectiveRemotePersonalVaultAutoSync {
         material.revision = result.revision
         material.documentHash = documentHash
         try keyStore.save(material, endpoint: endpoint, deviceID: deviceID)
+    }
+
+    private func mergedDocument(
+        local: SelectiveRemoteVaultDocument,
+        remote: SelectiveRemoteCloudPersonalVault,
+        vaultKey: Data,
+        profileIDs: Set<UUID>
+    ) throws -> SelectiveRemoteVaultDocument {
+        guard let envelope = remote.envelope else {
+            throw SelectiveRemotePersonalVaultError.invalidEnvelope
+        }
+        let current = try SelectiveRemotePersonalVaultCrypto.open(envelope, vaultKey: vaultKey)
+        let credentials = current.records.filter {
+            $0.type == .credential && credentialSourceID($0).map(profileIDs.contains) == true
+        }
+        return try .init(
+            records: local.records + credentials,
+            tombstones: current.tombstones
+        )
+    }
+
+    private func credentialSourceID(_ record: SelectiveRemoteVaultRecord) -> UUID? {
+        guard case let .object(data) = record.data,
+              case let .string(source)? = data["sourceID"]
+        else { return nil }
+        return UUID(uuidString: source)
     }
 }

--- a/Sources/SelectiveRemote/CloudPersonalVaultSync.swift
+++ b/Sources/SelectiveRemote/CloudPersonalVaultSync.swift
@@ -346,6 +346,36 @@ enum SelectiveRemotePersonalVaultCrypto {
         }
     }
 
+    static func open(
+        _ envelope: SelectiveRemotePersonalVaultEnvelope,
+        vaultKey: Data
+    ) throws -> SelectiveRemoteVaultDocument {
+        guard vaultKey.count == 32,
+              let nonce = Data(selectiveRemoteBase64URL: envelope.nonce, expectedLength: 12),
+              let ciphertext = Data(selectiveRemoteBase64URL: envelope.ciphertext),
+              let authTag = Data(selectiveRemoteBase64URL: envelope.authTag, expectedLength: 16)
+        else {
+            throw SelectiveRemotePersonalVaultError.invalidEnvelope
+        }
+        do {
+            let box = try AES.GCM.SealedBox(
+                nonce: AES.GCM.Nonce(data: nonce),
+                ciphertext: ciphertext,
+                tag: authTag
+            )
+            let plaintext = try AES.GCM.open(
+                box,
+                using: SymmetricKey(data: vaultKey),
+                authenticating: additionalData
+            )
+            return try SelectiveRemoteVaultDocument.decode(plaintext)
+        } catch let error as SelectiveRemotePersonalVaultError {
+            throw error
+        } catch {
+            throw SelectiveRemotePersonalVaultError.cryptoFailure
+        }
+    }
+
     static func wrapRFC3394(_ value: Data, keyEncryptionKey: Data) throws -> Data {
         guard keyEncryptionKey.count == 32, value.count >= 16, value.count.isMultiple(of: 8) else {
             throw SelectiveRemotePersonalVaultError.invalidEnvelope

--- a/Sources/SelectiveRemote/CloudSecureEnvelopeStore.swift
+++ b/Sources/SelectiveRemote/CloudSecureEnvelopeStore.swift
@@ -4,17 +4,39 @@ import Security
 struct SelectiveRemoteCloudSecureEnvelope: Codable, Equatable {
     var sessionToken: String?
     var teamDevicePrivateKeys: [String: Data]
+    var personalVaultKeyMaterials: [String: Data]
 
     init(
         sessionToken: String? = nil,
-        teamDevicePrivateKeys: [String: Data] = [:]
+        teamDevicePrivateKeys: [String: Data] = [:],
+        personalVaultKeyMaterials: [String: Data] = [:]
     ) {
         self.sessionToken = sessionToken
         self.teamDevicePrivateKeys = teamDevicePrivateKeys
+        self.personalVaultKeyMaterials = personalVaultKeyMaterials
     }
 
     var isEmpty: Bool {
-        sessionToken == nil && teamDevicePrivateKeys.isEmpty
+        sessionToken == nil
+            && teamDevicePrivateKeys.isEmpty
+            && personalVaultKeyMaterials.isEmpty
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case sessionToken, teamDevicePrivateKeys, personalVaultKeyMaterials
+    }
+
+    init(from decoder: any Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        sessionToken = try values.decodeIfPresent(String.self, forKey: .sessionToken)
+        teamDevicePrivateKeys = try values.decodeIfPresent(
+            [String: Data].self,
+            forKey: .teamDevicePrivateKeys
+        ) ?? [:]
+        personalVaultKeyMaterials = try values.decodeIfPresent(
+            [String: Data].self,
+            forKey: .personalVaultKeyMaterials
+        ) ?? [:]
     }
 }
 

--- a/Sources/SelectiveRemote/CloudSettingsView.swift
+++ b/Sources/SelectiveRemote/CloudSettingsView.swift
@@ -579,7 +579,6 @@ struct CloudSettingsView: View {
                 let material = try? personalVaultKeyStore.material(endpoint: url, deviceID: deviceID)
                 personalVaultAutoSyncConfigured = material?.vaultID == personalVault.id
                     && material?.revision == personalVault.revision
-                    && material?.includesCredentials == false
             }
         } catch {
             if error as? SelectiveRemoteCloudError == .authenticationRequired {
@@ -803,15 +802,11 @@ struct CloudSettingsView: View {
                     includesCredentials: !credentials.isEmpty
                 )
                 try personalVaultKeyStore.save(material, endpoint: url, deviceID: resolvedDeviceID())
-                personalVaultAutoSyncConfigured = credentials.isEmpty
+                personalVaultAutoSyncConfigured = true
                 personalVaultRevision = result.revision
                 personalVaultMessage = UpdateLocalization.text(
-                    ru: credentials.isEmpty
-                        ? "Защищённая автосинхронизация включена. Первая ревизия r\(result.revision) отправлена."
-                        : "Ревизия r\(result.revision) отправлена с паролями. Фоновая синхронизация для неё отключена, чтобы не удалить секреты без подтверждения.",
-                    en: credentials.isEmpty
-                        ? "Secure automatic sync is enabled. Initial revision r\(result.revision) was uploaded."
-                        : "Revision r\(result.revision) was uploaded with passwords. Background sync is disabled for it so secrets cannot be removed without confirmation."
+                    ru: "Защищённая автосинхронизация включена. Первая ревизия r\(result.revision) отправлена; сохранённые credential-записи будут сохраняться при фоновых обновлениях.",
+                    en: "Secure automatic sync is enabled. Initial revision r\(result.revision) was uploaded; stored credential records will be preserved during background updates."
                 )
                 personalVaultMessageIsError = false
                 personalVaultUploading = false

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -21,7 +21,13 @@ struct CloudMacOSFoundationTests {
                 #expect(object["password"] as? String == "synthetic-password")
                 return Self.response(request, status: 200, json: [
                     "token": token,
-                    "user": ["id": userID.uuidString.lowercased(), "email": "user@example.invalid", "username": "user", "displayName": "User"],
+                    "user": [
+                        "id": userID.uuidString.lowercased(),
+                        "email": "user@example.invalid",
+                        "username": "user",
+                        "displayName": "User",
+                        "createdAt": "2026-09-10T00:00:00.000Z"
+                    ],
                     "deviceID": deviceID.uuidString.lowercased()
                 ])
             case ("GET", "/v1/me"):
@@ -1708,7 +1714,8 @@ struct CloudSecureEnvelopeModelTests {
         let key = Data(repeating: 0x2a, count: 32)
         let input = SelectiveRemoteCloudSecureEnvelope(
             sessionToken: "session-token",
-            teamDevicePrivateKeys: ["device-id": key]
+            teamDevicePrivateKeys: ["device-id": key],
+            personalVaultKeyMaterials: ["device-id": Data([4, 5, 6])]
         )
         let encoded = try JSONEncoder().encode(input)
         let decoded = try JSONDecoder().decode(
@@ -1718,10 +1725,25 @@ struct CloudSecureEnvelopeModelTests {
         #expect(decoded == input)
         #expect(!decoded.isEmpty)
         #expect(decoded.teamDevicePrivateKeys["device-id"] == key)
+        #expect(decoded.personalVaultKeyMaterials["device-id"] == Data([4, 5, 6]))
     }
 
     @Test("empty envelope is removable")
     func emptyEnvelope() {
         #expect(SelectiveRemoteCloudSecureEnvelope().isEmpty)
+    }
+
+    @Test("older unified envelopes decode before Personal Vault material is added")
+    func legacyEnvelopeDecoding() throws {
+        let legacy = try JSONSerialization.data(withJSONObject: [
+            "sessionToken": "token",
+            "teamDevicePrivateKeys": [String: String]()
+        ])
+        let decoded = try JSONDecoder().decode(
+            SelectiveRemoteCloudSecureEnvelope.self,
+            from: legacy
+        )
+        #expect(decoded.sessionToken == "token")
+        #expect(decoded.personalVaultKeyMaterials.isEmpty)
     }
 }

--- a/Tests/SelectiveRemoteTests/CloudPersonalVaultSyncTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudPersonalVaultSyncTests.swift
@@ -166,6 +166,10 @@ struct CloudPersonalVaultSyncTests {
         #expect(next.nonce != first.nonce)
         #expect(next.ciphertext != first.ciphertext)
         #expect(next.authTag != first.authTag)
+        #expect(try SelectiveRemotePersonalVaultCrypto.open(
+            next,
+            vaultKey: Data(repeating: 0x11, count: 32)
+        ) == firstDocument)
     }
 
     @Test("automatic export can represent deletion of every local record")

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -447,6 +447,7 @@ test("macOS Personal Vault auto-sync preserves encrypted credentials without ext
   assert.match(sync, /\$0\.type == \.credential/u);
   assert.match(sync, /personalVaultKeyMaterials/u);
   assert.match(sync, /legacyService = "local\.selectiveremote\.cloud\.personal-vault-key\.v1"/u);
+  assert.match(sync, /removeLegacy\(endpoint:/u);
   assert.match(crypto, /static func open\(/u);
   assert.match(settings, /personalVaultAutoSyncConfigured = true/u);
   assert.doesNotMatch(settings, /Background sync is disabled/u);

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -189,6 +189,7 @@ test("macOS Cloud settings expose device-bound sign-in and native Team managemen
   assert.match(client, /v1\/auth\/register/);
   assert.match(client, /verificationRequired/);
   assert.match(client, /validLoginJSON/);
+  assert.match(client, /"displayName", "createdAt"/u);
   assert.match(client, /validTeamsJSON/);
   assert.match(client, /validTeamMembersJSON/);
   assert.match(client, /deviceID/);
@@ -425,10 +426,28 @@ test("macOS Cloud session and Team device key share one Keychain envelope", asyn
   assert.match(envelope, /local\.selectiveremote\.cloud\.secure-envelope\.v1/u);
   assert.match(envelope, /var sessionToken: String\?/u);
   assert.match(envelope, /var teamDevicePrivateKeys: \[String: Data\]/u);
+  assert.match(envelope, /var personalVaultKeyMaterials: \[String: Data\]/u);
   assert.match(envelope, /kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly/u);
   assert.match(session, /SelectiveRemoteCloudSecureEnvelopeStore/u);
   assert.match(session, /legacyService = "local\.selectiveremote\.cloud\.session\.v1"/u);
   assert.match(teamDevice, /SelectiveRemoteCloudSecureEnvelopeStore/u);
   assert.match(teamDevice, /legacyService = "local\.selectiveremote\.cloud\.team-device-key\.v1"/u);
   assert.doesNotMatch(envelope, /teamID|vaultID|hostID/u);
+});
+
+
+test("macOS Personal Vault auto-sync preserves encrypted credentials without extra Keychain items", async () => {
+  const [sync, crypto, settings] = await Promise.all([
+    readFile(new URL("CloudPersonalVaultAutoSync.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudPersonalVaultSync.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudSettingsView.swift", sourceRoot), "utf8"),
+  ]);
+  assert.doesNotMatch(sync, /!material\.includesCredentials/u);
+  assert.match(sync, /SelectiveRemotePersonalVaultCrypto\.open/u);
+  assert.match(sync, /\$0\.type == \.credential/u);
+  assert.match(sync, /personalVaultKeyMaterials/u);
+  assert.match(sync, /legacyService = "local\.selectiveremote\.cloud\.personal-vault-key\.v1"/u);
+  assert.match(crypto, /static func open\(/u);
+  assert.match(settings, /personalVaultAutoSyncConfigured = true/u);
+  assert.doesNotMatch(settings, /Background sync is disabled/u);
 });


### PR DESCRIPTION
## Summary
- accept the deployed login user contract including `createdAt`, fixing the macOS `Cloud returned an invalid response` failure before session persistence
- decrypt the current Personal Vault locally during background sync and preserve credential records while updating Hosts, Snippets, and Forwarding
- keep automatic sync enabled when the initial Personal Vault contains credentials instead of disabling it
- migrate Personal Vault key material into the existing endpoint-scoped unified Cloud Keychain envelope
- decode pre-migration unified envelopes compatibly and remove the legacy Personal Vault Keychain item after migration

## Security
The server continues to receive ciphertext only. Background sync uses the device-local Vault key to preserve already encrypted credentials; it does not copy secrets to UserDefaults or create per-Host Keychain records.

## Scope
This fixes sign-in and safe automatic uploads on an already enrolled Mac. Cross-device Personal Vault enrollment/pull without a routine Recovery phrase remains the next account-key/browser-enrollment slice.

## Tests
- deployed login response shape
- Personal Vault AES-GCM open/reseal round trip
- unified-envelope backward compatibility and Personal Vault key material
- source contracts for credential-preserving auto-sync and legacy migration

## Stack
Depends on #87.