### PR TITLE
Unlock and sync web Personal Vault with the account password

### DIFF
--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -1494,6 +1494,7 @@ export async function initializeCloudAccount({
   const teamDeviceRepository = createIndexedDBTeamDeviceRepository();
   let activeConflicts = null;
   let backgroundSyncing = false;
+  let accountVaultMigrationPassphrase = null;
   vaultUI.setConflictResetListener(() => {
     activeConflicts = null;
     conflictApply.disabled = true;
@@ -1692,6 +1693,7 @@ export async function initializeCloudAccount({
     button.disabled = true;
     try {
       const password = form.elements.password.value;
+      accountVaultMigrationPassphrase = accountVaultPassphrase(password);
       const deviceID = await vault.deviceID();
       let identity = null;
       try {
@@ -1709,6 +1711,7 @@ export async function initializeCloudAccount({
       try {
         await unlockAndSyncPersonalVault(password);
         personalVaultReady = true;
+        accountVaultMigrationPassphrase = null;
       } catch {
         // Vaults created before account-password enrollment retain Recovery fallback.
       }
@@ -1843,11 +1846,16 @@ export async function initializeCloudAccount({
     button.disabled = true;
     try {
       const result = await synchronizeVault({ client, vault, recoveryPassphrase: passphrase });
+      if (accountVaultMigrationPassphrase) {
+        await vault.rewrap(accountVaultMigrationPassphrase);
+        await synchronizeVault({ client, vault });
+        accountVaultMigrationPassphrase = null;
+      }
       recoveryForm.reset();
       await vaultUI.hideRecoveryAndRestoreMode();
       vaultUI.mode("unlocked");
       vaultUI.render();
-      setText(vaultMessage, `Зашифрованная ревизия ${result.revision} восстановлена и расшифрована только в этой вкладке.`);
+      setText(vaultMessage, `Зашифрованная ревизия ${result.revision} восстановлена и переведена на автоматическую разблокировку паролем аккаунта.`);
     } catch (error) {
       recoveryForm.elements.passphrase.value = "";
       if (String(error?.message ?? "") === "authentication_required") {

--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -1447,6 +1447,12 @@ export function initializeTeamWorkspace({
   };
 }
 
+export function accountVaultPassphrase(password) {
+  const normalized = String(password ?? "").normalize("NFC");
+  if (new TextEncoder().encode(normalized).length < 12) throw new Error("invalid_account_password");
+  return `selective-remote:account-password:v1:${normalized}`;
+}
+
 export async function initializeCloudAccount({
   documentValue = document,
   vaultUI,
@@ -1487,6 +1493,7 @@ export async function initializeCloudAccount({
   const teamWorkspace = initializeTeamWorkspace({ documentValue, client, initialInvitationToken: initialTeamInvitationToken });
   const teamDeviceRepository = createIndexedDBTeamDeviceRepository();
   let activeConflicts = null;
+  let backgroundSyncing = false;
   vaultUI.setConflictResetListener(() => {
     activeConflicts = null;
     conflictApply.disabled = true;
@@ -1497,6 +1504,44 @@ export async function initializeCloudAccount({
     message.classList.toggle("error", tone === "error");
     message.classList.toggle("success", tone === "success");
   }
+
+  async function unlockAndSyncPersonalVault(password) {
+    const passphrase = accountVaultPassphrase(password);
+    let status = await vault.status();
+    if (status === "locked") {
+      await vault.unlock(passphrase);
+      status = "unlocked";
+    }
+    let result = await synchronizeVault({ client, vault, recoveryPassphrase: passphrase });
+    if (status === "empty" && result.status === "empty") {
+      await vault.create(passphrase);
+      result = await synchronizeVault({ client, vault });
+    }
+    vaultUI.mode("unlocked");
+    vaultUI.render();
+    return result;
+  }
+
+  async function backgroundPersonalVaultSync() {
+    if (backgroundSyncing || !client.session() || await vault.status() !== "unlocked") return;
+    backgroundSyncing = true;
+    try {
+      const result = await synchronizeVault({ client, vault });
+      if (result.status === "conflict") renderConflicts(result);
+      else if (result.status !== "remote_changed") hideConflicts();
+      vaultUI.render();
+    } catch {
+      // Manual sync keeps the actionable error path; background failures never discard local state.
+    } finally {
+      backgroundSyncing = false;
+    }
+  }
+
+  const personalVaultTimer = globalThis.setInterval(
+    () => { void backgroundPersonalVaultSync(); },
+    15_000
+  );
+  personalVaultTimer?.unref?.();
 
   function setAuthMode(mode) {
     const registrationAvailable = metadata?.registrationEnabled === true;
@@ -1660,6 +1705,13 @@ export async function initializeCloudAccount({
         deviceID,
         publicKey: identity?.publicKey ?? null,
       });
+      let personalVaultReady = false;
+      try {
+        await unlockAndSyncPersonalVault(password);
+        personalVaultReady = true;
+      } catch {
+        // Vaults created before account-password enrollment retain Recovery fallback.
+      }
       if (identity) {
         try {
           await client.bootstrapDeviceKey({
@@ -1683,6 +1735,12 @@ export async function initializeCloudAccount({
           setText(message, "Вход выполнен. Team-раздел временно недоступен; личный Vault и сессия продолжают работать.");
         }
       }
+      setText(
+        vaultMessage,
+        personalVaultReady
+          ? "Personal Vault открыт паролем аккаунта и синхронизируется автоматически."
+          : "Для ранее созданного Personal Vault один раз введите Recovery-фразу; новые входы используют пароль аккаунта."
+      );
     } catch (error) {
       const code = String(error?.message ?? "");
       const messages = {
@@ -1701,6 +1759,7 @@ export async function initializeCloudAccount({
     try {
       await client.logout();
     } finally {
+      vault.lock();
       showSession(null);
       teamWorkspace?.deactivate();
       hideConflicts();
@@ -1726,6 +1785,7 @@ export async function initializeCloudAccount({
       deleteAccountForm.reset();
       teamWorkspace?.deactivate();
       hideConflicts();
+      vault.lock();
       await vaultUI.hideRecoveryAndRestoreMode();
       showSession(null);
       setAccountMessage("Аккаунт удалён. Все Cloud-сессии завершены.", "success");

--- a/cloud/public/vault-local.js
+++ b/cloud/public/vault-local.js
@@ -244,6 +244,26 @@ export function createLocalVaultController({
       pendingConflicts = null;
     },
 
+    async rewrap(passphrase) {
+      requireUnlocked();
+      const wrappedKey = await wrapVaultKey(vaultKey, passphrase, cryptoValue);
+      const envelope = await encryptVaultPayload({
+        vaultKey,
+        payload: document,
+        baseRevision: snapshot.revision,
+        wrappedKey,
+        cryptoValue,
+      });
+      const nextSnapshot = validatedSnapshot({
+        revision: snapshot.revision + 1,
+        deviceID: snapshot.deviceID,
+        envelope,
+      });
+      await repository.save(nextSnapshot);
+      snapshot = nextSnapshot;
+      return clone(document);
+    },
+
     document() {
       requireUnlocked();
       return clone(document);

--- a/cloud/tests/public-vault-local.test.mjs
+++ b/cloud/tests/public-vault-local.test.mjs
@@ -61,6 +61,21 @@ test("lock drops the in-memory key and wrong recovery passphrases fail closed", 
   assert.throws(() => vault.document(), /local_vault_locked/);
 });
 
+test("rewrap migrates an unlocked Vault to a new account passphrase", async () => {
+  const repository = memoryRepository();
+  const vault = controller(repository);
+  await vault.create(passphrase);
+  await vault.upsert({ type: "credential", data: { title: "Admin", secret: "synthetic-secret" } });
+  const previousRevision = repository.snapshot().revision;
+  const accountPassphrase = "selective-remote:account-password:v1:strong account password";
+
+  await vault.rewrap(accountPassphrase);
+  assert.equal(repository.snapshot().revision, previousRevision + 1);
+  vault.lock();
+  await assert.rejects(vault.unlock(passphrase), /invalid_recovery_passphrase/);
+  assert.equal((await vault.unlock(accountPassphrase)).records[0].data.secret, "synthetic-secret");
+});
+
 test("all personal record types round-trip and every mutation advances the encrypted revision", async () => {
   const repository = memoryRepository();
   const vault = controller(repository);

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -16,6 +16,10 @@ test("account password is domain-separated before it unlocks Personal Vault", ()
     "selective-remote:account-password:v1:correct horse battery",
   );
   assert.throws(() => accountVaultPassphrase("too-short"), /invalid_account_password/u);
+  assert.equal(
+    accountVaultPassphrase("mot-de-passe-café"),
+    accountVaultPassphrase("mot-de-passe-cafe\u0301"),
+  );
 });
 
 test("appearance defaults to graphite and synchronizes every visible selector", () => {

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -224,6 +224,7 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(application, /backgroundPersonalVaultSync/u);
   assert.match(application, /15_000/u);
   assert.match(application, /vault\.lock\(\)/u);
+  assert.match(application, /vault\.rewrap\(accountVaultMigrationPassphrase\)/u);
   assert.match(application, /Personal Vault открыт паролем аккаунта/u);
   assert.match(application, /ensureTeamDeviceIdentity/u);
   assert.match(application, /synchronizeTeamVault/u);

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -2,12 +2,21 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 import {
+  accountVaultPassphrase,
   initializeAppearance,
   localVaultConflictSideSummary,
   localVaultRecordData,
   localVaultRecordSummary,
   teamVaultRecoveryMode,
 } from "../public/app.js";
+
+test("account password is domain-separated before it unlocks Personal Vault", () => {
+  assert.equal(
+    accountVaultPassphrase("correct horse battery"),
+    "selective-remote:account-password:v1:correct horse battery",
+  );
+  assert.throws(() => accountVaultPassphrase("too-short"), /invalid_account_password/u);
+});
 
 test("appearance defaults to graphite and synchronizes every visible selector", () => {
   const listeners = [];
@@ -207,6 +216,11 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(server, /\["\/", "\/login", "\/app"\]\.includes\(pathname\)/u);
   assert.match(application, /createAuthenticatedVaultClient/u);
   assert.match(application, /synchronizeVault/u);
+  assert.match(application, /unlockAndSyncPersonalVault\(password\)/u);
+  assert.match(application, /backgroundPersonalVaultSync/u);
+  assert.match(application, /15_000/u);
+  assert.match(application, /vault\.lock\(\)/u);
+  assert.match(application, /Personal Vault открыт паролем аккаунта/u);
   assert.match(application, /ensureTeamDeviceIdentity/u);
   assert.match(application, /synchronizeTeamVault/u);
   assert.match(application, /provisionTeamVaultWrappers/u);

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -225,6 +225,7 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(application, /15_000/u);
   assert.match(application, /vault\.lock\(\)/u);
   assert.match(application, /vault\.rewrap\(accountVaultMigrationPassphrase\)/u);
+  assert.match(application, /переведена на автоматическую разблокировку паролем аккаунта/u);
   assert.match(application, /Personal Vault открыт паролем аккаунта/u);
   assert.match(application, /ensureTeamDeviceIdentity/u);
   assert.match(application, /synchronizeTeamVault/u);


### PR DESCRIPTION
## Summary
- domain-separate the account password into a browser-only Personal Vault passphrase
- automatically import/unlock an account-password-enrolled Personal Vault immediately after login
- initialize and upload a new empty Personal Vault without asking for a routine Recovery phrase
- run safe background Personal Vault synchronization every 15 seconds while signed in and unlocked
- clear the in-memory Personal Vault key on logout and account deletion
- migrate legacy Recovery-wrapped Vaults after one successful Recovery entry by rewrapping the existing Vault key for account-password unlock

## Security
The raw account password and derived passphrase are not persisted in localStorage, sessionStorage, IndexedDB, or sent as Vault material. PBKDF2/AES-KW and AES-GCM remain client-side; the server stores ciphertext and wrapped key only. Legacy migration rewraps the existing random Vault key and does not re-encrypt or expose record plaintext server-side.

## Compatibility
Existing Recovery-wrapped Vaults fail closed until their owner enters Recovery once, then the new wrapper is uploaded for future automatic account-password unlock. New browser Vaults use account-password enrollment automatically. Password-change rewrap and macOS second-device enrollment remain follow-up slices.

## Tests
- account-password domain separation, minimum validation, and Unicode normalization
- legacy Vault rewrap rejects the old passphrase and preserves encrypted records under the new passphrase
- existing browser crypto, import, merge, conflict, and tamper suites
- UI source contracts for automatic unlock, 15-second sync, migration, and key removal on logout

## Stack
Depends on #88.