### PR TITLE
Enroll macOS Personal Vault with the account password

### DIFF
--- a/Sources/SelectiveRemote/CloudAccountViews.swift
+++ b/Sources/SelectiveRemote/CloudAccountViews.swift
@@ -74,8 +74,8 @@ struct SelectiveRemoteCloudSignInView: View {
 
                         Label(
                             UpdateLocalization.text(
-                                ru: "Сессия хранится в Keychain только на этом Mac. Пароль существует только в этой форме и не становится ключом Vault.",
-                                en: "The session is stored in Keychain on this Mac only. The password exists only in this form and never becomes a Vault key."
+                                ru: "Сессия и ключ Personal Vault сохраняются в единой защищённой записи Keychain этого Mac. Пароль используется в памяти только во время входа.",
+                                en: "The session and Personal Vault key are stored in this Mac's unified protected Keychain entry. The password is used in memory only while signing in."
                             ),
                             systemImage: "lock.shield"
                         )

--- a/Sources/SelectiveRemote/CloudPersonalVaultAutoSync.swift
+++ b/Sources/SelectiveRemote/CloudPersonalVaultAutoSync.swift
@@ -9,6 +9,9 @@ struct SelectiveRemotePersonalVaultKeyMaterial: Codable, Equatable, Sendable {
     var revision: Int
     var documentHash: Data
     let includesCredentials: Bool
+    let requiresInitialDownload: Bool?
+
+    var allowsUpload: Bool { requiresInitialDownload != true }
 
     init(
         vaultID: UUID,
@@ -16,7 +19,8 @@ struct SelectiveRemotePersonalVaultKeyMaterial: Codable, Equatable, Sendable {
         wrappedKey: SelectiveRemotePersonalVaultWrappedKey,
         revision: Int,
         documentHash: Data,
-        includesCredentials: Bool = false
+        includesCredentials: Bool = false,
+        requiresInitialDownload: Bool = false
     ) throws {
         guard vaultID.isSelectiveRemoteCloudUUID, vaultKey.count == 32,
               revision > 0, documentHash.count == 32
@@ -27,6 +31,7 @@ struct SelectiveRemotePersonalVaultKeyMaterial: Codable, Equatable, Sendable {
         self.revision = revision
         self.documentHash = documentHash
         self.includesCredentials = includesCredentials
+        self.requiresInitialDownload = requiresInitialDownload
     }
 }
 
@@ -99,6 +104,78 @@ struct SelectiveRemotePersonalVaultKeychainStore: SelectiveRemotePersonalVaultKe
     }
 }
 
+struct SelectiveRemotePersonalVaultAccountEnrollment {
+    let client: SelectiveRemoteCloudAPIClient
+    let keyStore: any SelectiveRemotePersonalVaultKeyStore
+
+    init(
+        client: SelectiveRemoteCloudAPIClient = .init(),
+        keyStore: any SelectiveRemotePersonalVaultKeyStore = SelectiveRemotePersonalVaultKeychainStore()
+    ) {
+        self.client = client
+        self.keyStore = keyStore
+    }
+
+    func enrollOrCreate(
+        endpoint: URL,
+        deviceID: UUID,
+        password: String,
+        profiles: [ConnectionProfile],
+        snippets: [TerminalCommandTemplate],
+        forwarding: [IndependentPortForward]
+    ) async throws -> Int {
+        let passphrase = try SelectiveRemotePersonalVaultCrypto.accountPassphrase(password)
+        let remote = try await client.personalVault(endpoint: endpoint)
+        let material: SelectiveRemotePersonalVaultKeyMaterial
+        if remote.revision == 0 {
+            let exported = try SelectiveRemotePersonalVaultExporter.makeExport(
+                profiles: profiles,
+                credentials: [],
+                snippets: snippets,
+                forwarding: forwarding,
+                deviceID: deviceID,
+                allowEmpty: true
+            )
+            let setup = try SelectiveRemotePersonalVaultCrypto.createSetup(
+                exported.document,
+                recoveryPhrase: passphrase,
+                baseRevision: 0
+            )
+            let result = try await client.putPersonalVault(endpoint: endpoint, envelope: setup.envelope)
+            guard !result.conflict, result.revision == 1 else {
+                throw SelectiveRemotePersonalVaultError.uploadConflict(result.revision)
+            }
+            material = try .init(
+                vaultID: remote.id,
+                vaultKey: setup.vaultKey,
+                wrappedKey: setup.envelope.wrappedKey,
+                revision: result.revision,
+                documentHash: Data(SHA256.hash(data: try exported.document.encoded()))
+            )
+        } else {
+            guard let envelope = remote.envelope else {
+                throw SelectiveRemotePersonalVaultError.invalidEnvelope
+            }
+            let vaultKey = try SelectiveRemotePersonalVaultCrypto.unwrapVaultKey(
+                envelope.wrappedKey,
+                passphrase: passphrase
+            )
+            let document = try SelectiveRemotePersonalVaultCrypto.open(envelope, vaultKey: vaultKey)
+            material = try .init(
+                vaultID: remote.id,
+                vaultKey: vaultKey,
+                wrappedKey: envelope.wrappedKey,
+                revision: remote.revision,
+                documentHash: Data(SHA256.hash(data: try document.encoded())),
+                includesCredentials: document.records.contains { $0.type == .credential },
+                requiresInitialDownload: true
+            )
+        }
+        try keyStore.save(material, endpoint: endpoint, deviceID: deviceID)
+        return material.revision
+    }
+}
+
 actor SelectiveRemotePersonalVaultAutoSync {
     private let client: SelectiveRemoteCloudAPIClient
     private let keyStore: any SelectiveRemotePersonalVaultKeyStore
@@ -141,6 +218,7 @@ actor SelectiveRemotePersonalVaultAutoSync {
         forwarding: [IndependentPortForward]
     ) async throws {
         guard var material = try keyStore.material(endpoint: endpoint, deviceID: deviceID),
+              material.allowsUpload,
               await client.hasStoredSession(endpoint: endpoint)
         else { return }
         let exported = try SelectiveRemotePersonalVaultExporter.makeExport(

--- a/Sources/SelectiveRemote/CloudPersonalVaultSync.swift
+++ b/Sources/SelectiveRemote/CloudPersonalVaultSync.swift
@@ -255,6 +255,28 @@ enum SelectiveRemotePersonalVaultCrypto {
     static let recoveryIterations: UInt32 = 600_000
     private static let additionalData = Data("selective-remote:vault-envelope:v1".utf8)
 
+    static func accountPassphrase(_ password: String) throws -> String {
+        let normalized = password.precomposedStringWithCanonicalMapping
+        guard (12...1_024).contains(normalized.utf8.count) else {
+            throw SelectiveRemotePersonalVaultError.invalidRecoveryPhrase
+        }
+        return "selective-remote:account-password:v1:\(normalized)"
+    }
+
+    static func unwrapVaultKey(
+        _ wrappedKey: SelectiveRemotePersonalVaultWrappedKey,
+        passphrase: String
+    ) throws -> Data {
+        guard wrappedKey.algorithm == "PBKDF2-SHA256+A256KW",
+              wrappedKey.iterations == Int(recoveryIterations),
+              let salt = Data(selectiveRemoteBase64URL: wrappedKey.salt, expectedLength: 16),
+              let value = Data(selectiveRemoteBase64URL: wrappedKey.value, expectedLength: 40)
+        else { throw SelectiveRemotePersonalVaultError.invalidEnvelope }
+        let normalized = passphrase.precomposedStringWithCanonicalMapping
+        let keyEncryptionKey = try deriveKey(password: Data(normalized.utf8), salt: salt)
+        return try unwrapRFC3394(value, keyEncryptionKey: keyEncryptionKey)
+    }
+
     static func seal(
         _ document: SelectiveRemoteVaultDocument,
         recoveryPhrase: String,
@@ -400,6 +422,33 @@ enum SelectiveRemotePersonalVaultCrypto {
         return blocks.reduce(into: accumulator) { $0.append($1) }
     }
 
+    static func unwrapRFC3394(_ value: Data, keyEncryptionKey: Data) throws -> Data {
+        guard keyEncryptionKey.count == 32, value.count >= 24, value.count.isMultiple(of: 8) else {
+            throw SelectiveRemotePersonalVaultError.invalidEnvelope
+        }
+        let blockCount = value.count / 8 - 1
+        var accumulator = Data(value.prefix(8))
+        var blocks = stride(from: 8, to: value.count, by: 8).map { offset in
+            Data(value[offset..<offset + 8])
+        }
+        for round in stride(from: 5, through: 0, by: -1) {
+            for index in stride(from: blockCount - 1, through: 0, by: -1) {
+                var counter = UInt64(blockCount * round + index + 1).bigEndian
+                var masked = accumulator
+                withUnsafeBytes(of: &counter) { counterBytes in
+                    for offset in 0..<8 { masked[offset] ^= counterBytes[offset] }
+                }
+                let decrypted = try decryptAESBlock(masked + blocks[index], key: keyEncryptionKey)
+                accumulator = Data(decrypted.prefix(8))
+                blocks[index] = Data(decrypted.suffix(8))
+            }
+        }
+        guard accumulator == Data(repeating: 0xa6, count: 8) else {
+            throw SelectiveRemotePersonalVaultError.invalidRecoveryPhrase
+        }
+        return blocks.reduce(into: Data()) { $0.append($1) }
+    }
+
     private static func deriveKey(password: Data, salt: Data) throws -> Data {
         var derived = Data(count: 32)
         let outputLength = derived.count
@@ -446,6 +495,30 @@ enum SelectiveRemotePersonalVaultCrypto {
                         outputBytes.baseAddress,
                         outputCapacity,
                         &moved
+                    )
+                }
+            }
+        }
+        guard status == kCCSuccess, moved == kCCBlockSizeAES128 else {
+            throw SelectiveRemotePersonalVaultError.cryptoFailure
+        }
+        return output
+    }
+
+    private static func decryptAESBlock(_ block: Data, key: Data) throws -> Data {
+        guard block.count == kCCBlockSizeAES128, key.count == kCCKeySizeAES256 else {
+            throw SelectiveRemotePersonalVaultError.invalidEnvelope
+        }
+        var output = Data(count: kCCBlockSizeAES128)
+        var moved = 0
+        let outputCapacity = output.count
+        let status = output.withUnsafeMutableBytes { outputBytes in
+            block.withUnsafeBytes { blockBytes in
+                key.withUnsafeBytes { keyBytes in
+                    CCCrypt(
+                        CCOperation(kCCDecrypt), CCAlgorithm(kCCAlgorithmAES), CCOptions(kCCOptionECBMode),
+                        keyBytes.baseAddress, key.count, nil, blockBytes.baseAddress, block.count,
+                        outputBytes.baseAddress, outputCapacity, &moved
                     )
                 }
             }

--- a/Sources/SelectiveRemote/CloudSettingsView.swift
+++ b/Sources/SelectiveRemote/CloudSettingsView.swift
@@ -506,9 +506,32 @@ struct CloudSettingsView: View {
                     device: .thisMac(id: deviceID, publicKey: identity.publicKey)
                 )
                 accountEndpoint = url.absoluteString
+                var enrollmentError: String?
+                let enrollment = SelectiveRemotePersonalVaultAccountEnrollment(
+                    client: client,
+                    keyStore: personalVaultKeyStore
+                )
+                do {
+                    _ = try await enrollment.enrollOrCreate(
+                        endpoint: url,
+                        deviceID: deviceID,
+                        password: password,
+                        profiles: model.profiles,
+                        snippets: TerminalCommandHistoryStore.shared.templates(),
+                        forwarding: model.independentPortForwards
+                    )
+                } catch {
+                    enrollmentError = error.localizedDescription
+                }
                 accountPhase = .signedIn
                 showsAccountSheet = false
                 await loadInventory(endpoint: url)
+                if let enrollmentError {
+                    personalVaultLoadErrorMessage = UpdateLocalization.text(
+                        ru: "Вход выполнен, но Personal Vault не подключён автоматически: \(enrollmentError)",
+                        en: "Sign-in succeeded, but Personal Vault was not enrolled automatically: \(enrollmentError)"
+                    )
+                }
             } catch {
                 accountPhase = .signedOut
                 accountErrorMessage = error.localizedDescription
@@ -579,6 +602,7 @@ struct CloudSettingsView: View {
                 let material = try? personalVaultKeyStore.material(endpoint: url, deviceID: deviceID)
                 personalVaultAutoSyncConfigured = material?.vaultID == personalVault.id
                     && material?.revision == personalVault.revision
+                    && material?.allowsUpload == true
             }
         } catch {
             if error as? SelectiveRemoteCloudError == .authenticationRequired {

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -1487,6 +1487,7 @@ struct AccountPasswordPersonalVaultEnrollmentTests {
             documentHash: Data(repeating: 4, count: 32),
             requiresInitialDownload: true
         )
+        #expect(material.requiresInitialDownload == true)
         #expect(!material.allowsUpload)
     }
 }

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -1441,6 +1441,56 @@ struct CloudMacOSFoundationTests {
     }
 }
 
+@Suite("Account-password Personal Vault enrollment")
+struct AccountPasswordPersonalVaultEnrollmentTests {
+    @Test("macOS derives the browser-compatible passphrase and unwraps the Vault key")
+    func accountPasswordRoundTrip() throws {
+        let password = "correct horse battery"
+        let passphrase = try SelectiveRemotePersonalVaultCrypto.accountPassphrase(password)
+        #expect(passphrase == "selective-remote:account-password:v1:correct horse battery")
+        let document = try SelectiveRemoteVaultDocument(records: [], tombstones: [])
+        let setup = try SelectiveRemotePersonalVaultCrypto.createSetup(
+            document,
+            recoveryPhrase: passphrase,
+            baseRevision: 0
+        )
+
+        let unwrapped = try SelectiveRemotePersonalVaultCrypto.unwrapVaultKey(
+            setup.envelope.wrappedKey,
+            passphrase: passphrase
+        )
+        #expect(unwrapped == setup.vaultKey)
+        #expect(try SelectiveRemotePersonalVaultCrypto.open(setup.envelope, vaultKey: unwrapped) == document)
+        #expect(throws: SelectiveRemotePersonalVaultError.self) {
+            try SelectiveRemotePersonalVaultCrypto.unwrapVaultKey(
+                setup.envelope.wrappedKey,
+                passphrase: "selective-remote:account-password:v1:different password"
+            )
+        }
+    }
+
+    @Test("canonically equivalent account passwords derive the same passphrase")
+    func unicodeNormalization() throws {
+        #expect(
+            try SelectiveRemotePersonalVaultCrypto.accountPassphrase("mot-de-passe-café")
+                == SelectiveRemotePersonalVaultCrypto.accountPassphrase("mot-de-passe-cafe\u{301}")
+        )
+    }
+
+    @Test("a newly enrolled remote Vault cannot upload before initial download")
+    func remoteEnrollmentUploadGate() throws {
+        let material = try SelectiveRemotePersonalVaultKeyMaterial(
+            vaultID: UUID(uuidString: "11111111-1111-4111-8111-111111111111")!,
+            vaultKey: Data(repeating: 1, count: 32),
+            wrappedKey: .init(salt: Data(repeating: 2, count: 16), value: Data(repeating: 3, count: 40)),
+            revision: 2,
+            documentHash: Data(repeating: 4, count: 32),
+            requiresInitialDownload: true
+        )
+        #expect(!material.allowsUpload)
+    }
+}
+
 private final class CloudHTTPStub: @unchecked Sendable {
     let handler: @Sendable (URLRequest) throws -> (Data, URLResponse)
 


### PR DESCRIPTION
## Summary
- derive the exact browser-compatible domain-separated Personal Vault passphrase during macOS sign-in
- add RFC 3394 AES-KW unwrap support and validate the unwrapped key by opening the authenticated Vault envelope
- automatically create an account-password-enrolled Personal Vault when Cloud is empty
- enroll an existing remote Vault key into the unified per-endpoint Cloud Keychain envelope
- keep successful account sign-in independent from Vault enrollment failures
- block background upload for a newly enrolled non-empty remote Vault until safe initial download/merge is implemented

## Security
The raw account password exists only in the sign-in task and is never written to Keychain. Keychain receives the random Vault key and wrapped-key metadata inside the existing unified Cloud secure envelope. Wrong passwords, malformed wrappers, and failed AES-KW integrity checks fail closed.

## Data safety
A new Mac must not treat its local Hosts as authoritative over an existing Cloud Vault. Existing remote Vault enrollment therefore sets an explicit initial-download gate; auto-upload remains disabled until the next PR performs a conflict-aware import/merge.

## Tests
- browser-compatible account-password derivation
- Unicode normalization
- AES-KW wrap/unwrap and authenticated Vault open
- wrong-passphrase rejection
- initial-download upload gate

## Stack
Depends on #89.