### PR TITLE
Decode Personal Vault for safe initial Mac download

### DIFF
--- a/Sources/SelectiveRemote/CloudPersonalVaultImport.swift
+++ b/Sources/SelectiveRemote/CloudPersonalVaultImport.swift
@@ -15,6 +15,10 @@ struct SelectiveRemotePersonalVaultImportSnapshot: Equatable {
 }
 
 enum SelectiveRemotePersonalVaultImporter {
+    private static let globalSnippetLibraryID = UUID(
+        uuidString: "5A17407D-9F03-4F7B-80FB-BD06D3FA50B1"
+    )!
+
     static func decode(_ document: SelectiveRemoteVaultDocument) throws
         -> SelectiveRemotePersonalVaultImportSnapshot
     {
@@ -103,7 +107,7 @@ enum SelectiveRemotePersonalVaultImporter {
         }
         return .init(
             id: record.id,
-            profileID: TerminalCommandHistoryStore.globalSnippetLibraryID,
+            profileID: globalSnippetLibraryID,
             title: string(data["title"]) ?? "Snippet",
             command: body,
             category: string(data["category"]) ?? "",

--- a/Sources/SelectiveRemote/CloudPersonalVaultImport.swift
+++ b/Sources/SelectiveRemote/CloudPersonalVaultImport.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+enum SelectiveRemotePersonalVaultImportError: Error, Equatable {
+    case invalidRecord(UUID)
+    case mismatchedRecordID(UUID)
+    case unsupportedWebForwarding(UUID)
+}
+
+struct SelectiveRemotePersonalVaultImportSnapshot: Equatable {
+    let profiles: [ConnectionProfile]
+    let credentials: [SelectiveRemotePersonalVaultCredentialInput]
+    let snippets: [TerminalCommandTemplate]
+    let forwarding: [IndependentPortForward]
+    let tombstoneIDs: Set<UUID>
+}
+
+enum SelectiveRemotePersonalVaultImporter {
+    static func decode(_ document: SelectiveRemoteVaultDocument) throws
+        -> SelectiveRemotePersonalVaultImportSnapshot
+    {
+        var profiles: [ConnectionProfile] = []
+        var credentials: [SelectiveRemotePersonalVaultCredentialInput] = []
+        var snippets: [TerminalCommandTemplate] = []
+        var forwarding: [IndependentPortForward] = []
+        for record in document.records {
+            guard case let .object(data) = record.data else {
+                throw SelectiveRemotePersonalVaultImportError.invalidRecord(record.id)
+            }
+            switch record.type {
+            case .host:
+                profiles.append(try profile(record: record, data: data))
+            case .credential:
+                credentials.append(try credential(record: record, data: data))
+            case .snippet:
+                snippets.append(try snippet(record: record, data: data))
+            case .forwarding:
+                forwarding.append(try forward(record: record, data: data))
+            }
+        }
+        return .init(
+            profiles: profiles,
+            credentials: credentials,
+            snippets: snippets,
+            forwarding: forwarding,
+            tombstoneIDs: Set(document.tombstones.map(\.id))
+        )
+    }
+
+    private static func profile(
+        record: SelectiveRemoteVaultRecord,
+        data: [String: SelectiveRemoteJSONValue]
+    ) throws -> ConnectionProfile {
+        if let encoded = string(data["profile"]) {
+            let value: ConnectionProfile = try decode(encoded, recordID: record.id)
+            guard value.id == record.id else {
+                throw SelectiveRemotePersonalVaultImportError.mismatchedRecordID(record.id)
+            }
+            return value
+        }
+        guard let address = string(data["address"]), !address.isEmpty else {
+            throw SelectiveRemotePersonalVaultImportError.invalidRecord(record.id)
+        }
+        let type = string(data["connectionType"]).flatMap(ConnectionType.init(rawValue:)) ?? .ssh
+        var value = ConnectionProfile(connectionType: type)
+        value.id = record.id
+        value.friendlyName = string(data["title"]) ?? address
+        value.username = string(data["username"]) ?? ""
+        if type == .serial { value.serialDevicePath = address } else { value.host = address }
+        return value
+    }
+
+    private static func credential(
+        record: SelectiveRemoteVaultRecord,
+        data: [String: SelectiveRemoteJSONValue]
+    ) throws -> SelectiveRemotePersonalVaultCredentialInput {
+        guard let source = string(data["sourceID"]), let sourceID = UUID(uuidString: source),
+              let kindText = string(data["kind"]), let kind = KeychainCredentialKind(rawValue: kindText),
+              kind != .sshKeyAuthorization,
+              let secret = string(data["secret"]), !secret.isEmpty
+        else { throw SelectiveRemotePersonalVaultImportError.invalidRecord(record.id) }
+        return .init(
+            sourceID: sourceID,
+            kind: kind,
+            title: string(data["title"]) ?? kindText,
+            username: string(data["username"]) ?? "",
+            secret: secret
+        )
+    }
+
+    private static func snippet(
+        record: SelectiveRemoteVaultRecord,
+        data: [String: SelectiveRemoteJSONValue]
+    ) throws -> TerminalCommandTemplate {
+        if let encoded = string(data["template"]) {
+            let value: TerminalCommandTemplate = try decode(encoded, recordID: record.id)
+            guard value.id == record.id else {
+                throw SelectiveRemotePersonalVaultImportError.mismatchedRecordID(record.id)
+            }
+            return value
+        }
+        guard let body = string(data["body"]), !body.isEmpty else {
+            throw SelectiveRemotePersonalVaultImportError.invalidRecord(record.id)
+        }
+        return .init(
+            id: record.id,
+            profileID: TerminalCommandHistoryStore.globalSnippetLibraryID,
+            title: string(data["title"]) ?? "Snippet",
+            command: body,
+            category: string(data["category"]) ?? "",
+            targets: [.localTerminal],
+            isExplicitlyUngrouped: true,
+            updatedAt: ISO8601DateFormatter().date(from: record.modifiedAt) ?? Date(timeIntervalSince1970: 0)
+        )
+    }
+
+    private static func forward(
+        record: SelectiveRemoteVaultRecord,
+        data: [String: SelectiveRemoteJSONValue]
+    ) throws -> IndependentPortForward {
+        guard let encoded = string(data["configuration"]) else {
+            throw SelectiveRemotePersonalVaultImportError.unsupportedWebForwarding(record.id)
+        }
+        let value: IndependentPortForward = try decode(encoded, recordID: record.id)
+        guard value.id == record.id, value.rule.id == record.id else {
+            throw SelectiveRemotePersonalVaultImportError.mismatchedRecordID(record.id)
+        }
+        return value
+    }
+
+    private static func string(_ value: SelectiveRemoteJSONValue?) -> String? {
+        guard case let .string(result)? = value else { return nil }
+        return result
+    }
+
+    private static func decode<T: Decodable>(_ value: String, recordID: UUID) throws -> T {
+        guard let data = Data(selectiveRemoteBase64URL: value) else {
+            throw SelectiveRemotePersonalVaultImportError.invalidRecord(recordID)
+        }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        do { return try decoder.decode(T.self, from: data) }
+        catch { throw SelectiveRemotePersonalVaultImportError.invalidRecord(recordID) }
+    }
+}

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -1492,6 +1492,56 @@ struct AccountPasswordPersonalVaultEnrollmentTests {
     }
 }
 
+@Suite("Personal Vault initial download decoder")
+struct PersonalVaultInitialDownloadDecoderTests {
+    @Test("macOS export round-trips into typed local resources")
+    func exportedResourcesRoundTrip() throws {
+        var profile = ConnectionProfile(connectionType: .ssh)
+        profile.host = "host.example"
+        profile.friendlyName = "Production"
+        let snippet = TerminalCommandTemplate(
+            id: UUID(), profileID: TerminalCommandHistoryStore.globalSnippetLibraryID,
+            title: "Uptime", command: "uptime", category: "Ops",
+            targets: [.localTerminal], updatedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        let forward = IndependentPortForward(
+            connection: .custom(host: "jump.example", username: "root", port: 22),
+            kind: .local
+        )
+        let exported = try SelectiveRemotePersonalVaultExporter.makeExport(
+            profiles: [profile], credentials: [], snippets: [snippet], forwarding: [forward],
+            deviceID: UUID(uuidString: "22222222-2222-4222-8222-222222222222")!
+        )
+
+        let decoded = try SelectiveRemotePersonalVaultImporter.decode(exported.document)
+        #expect(decoded.profiles == [profile])
+        #expect(decoded.snippets == [snippet])
+        #expect(decoded.forwarding == [forward])
+        #expect(decoded.credentials.isEmpty)
+    }
+
+    @Test("web Host and Snippet receive bounded local defaults")
+    func webRecords() throws {
+        let version = try SelectiveRemoteVaultVersion([
+            UUID(uuidString: "33333333-3333-4333-8333-333333333333")!: 1
+        ])
+        let hostID = UUID(uuidString: "44444444-4444-4444-8444-444444444444")!
+        let snippetID = UUID(uuidString: "55555555-5555-4555-8555-555555555555")!
+        let document = try SelectiveRemoteVaultDocument(records: [
+            try .init(id: hostID, type: .host, version: version, modifiedAt: "2026-09-10T00:00:00.000Z", data: .object([
+                "title": .string("Web Host"), "address": .string("web.example"), "username": .string("admin")
+            ])),
+            try .init(id: snippetID, type: .snippet, version: version, modifiedAt: "2026-09-10T00:00:00.000Z", data: .object([
+                "title": .string("Status"), "body": .string("uptime")
+            ]))
+        ])
+        let decoded = try SelectiveRemotePersonalVaultImporter.decode(document)
+        #expect(decoded.profiles.first?.id == hostID)
+        #expect(decoded.profiles.first?.connectionType == .ssh)
+        #expect(decoded.snippets.first?.id == snippetID)
+    }
+}
+
 private final class CloudHTTPStub: @unchecked Sendable {
     let handler: @Sendable (URLRequest) throws -> (Data, URLResponse)
 

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -1514,7 +1514,10 @@ struct PersonalVaultInitialDownloadDecoderTests {
         )
 
         let decoded = try SelectiveRemotePersonalVaultImporter.decode(exported.document)
-        #expect(decoded.profiles == [profile])
+        #expect(decoded.profiles.first?.id == profile.id)
+        #expect(decoded.profiles.first?.friendlyName == profile.friendlyName)
+        #expect(decoded.profiles.first?.host == profile.host)
+        #expect(decoded.profiles.first?.connectionType == profile.connectionType)
         #expect(decoded.snippets == [snippet])
         #expect(decoded.forwarding == [forward])
         #expect(decoded.credentials.isEmpty)

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -1500,7 +1500,7 @@ struct PersonalVaultInitialDownloadDecoderTests {
         profile.host = "host.example"
         profile.friendlyName = "Production"
         let snippet = TerminalCommandTemplate(
-            id: UUID(), profileID: TerminalCommandHistoryStore.globalSnippetLibraryID,
+            id: UUID(), profileID: UUID(uuidString: "5A17407D-9F03-4F7B-80FB-BD06D3FA50B1")!,
             title: "Uptime", command: "uptime", category: "Ops",
             targets: [.localTerminal], updatedAt: Date(timeIntervalSince1970: 1_700_000_000)
         )


### PR DESCRIPTION
## Summary
- decode encrypted Personal Vault documents into typed macOS Hosts, credentials, Snippets, and Forwarding resources
- round-trip full macOS-exported resource payloads without losing per-host settings
- support safe defaults for simplified Hosts and Snippets created in the web portal
- preserve remote tombstone IDs for the upcoming conflict-aware apply phase
- reject mismatched embedded IDs, invalid credentials, and incomplete web Forwarding records instead of fabricating connection settings

## Data safety
This PR is intentionally decode-only. It does not mutate local profiles or enable the upload gate introduced in #90. The next slice can compare the complete typed snapshot with local state before an atomic user-visible apply.

## Tests
- full macOS Host/Snippet/Forwarding export round-trip
- simplified web Host/Snippet decoding
- existing macOS and Cloud suites

## Stack
Starts from merged main at ca9564984cdbbd182057a805b26caf923ec09f55.