### PR TITLE
Apply initial Personal Vault download safely on macOS

### DIFF
--- a/Sources/SelectiveRemote/CloudPersonalVaultAutoSync.swift
+++ b/Sources/SelectiveRemote/CloudPersonalVaultAutoSync.swift
@@ -9,7 +9,7 @@ struct SelectiveRemotePersonalVaultKeyMaterial: Codable, Equatable, Sendable {
     var revision: Int
     var documentHash: Data
     let includesCredentials: Bool
-    let requiresInitialDownload: Bool?
+    var requiresInitialDownload: Bool?
 
     var allowsUpload: Bool { requiresInitialDownload != true }
 

--- a/Sources/SelectiveRemote/CloudPersonalVaultImport.swift
+++ b/Sources/SelectiveRemote/CloudPersonalVaultImport.swift
@@ -1,9 +1,30 @@
 import Foundation
 
-enum SelectiveRemotePersonalVaultImportError: Error, Equatable {
+enum SelectiveRemotePersonalVaultImportError: LocalizedError, Equatable {
     case invalidRecord(UUID)
     case mismatchedRecordID(UUID)
     case unsupportedWebForwarding(UUID)
+    case conflicts([UUID])
+
+    var errorDescription: String? {
+        switch self {
+        case let .conflicts(ids):
+            UpdateLocalization.text(
+                ru: "Initial download остановлен: локальные и Cloud-данные конфликтуют (\(ids.count)). Ничего не перезаписано.",
+                en: "Initial download stopped because local and Cloud data conflict (\(ids.count)). Nothing was overwritten."
+            )
+        case .unsupportedWebForwarding:
+            UpdateLocalization.text(
+                ru: "Forwarding с сайта не содержит полной конфигурации и не был применён.",
+                en: "A web Forwarding record has no complete configuration and was not applied."
+            )
+        case .invalidRecord, .mismatchedRecordID:
+            UpdateLocalization.text(
+                ru: "Personal Vault содержит некорректную запись; импорт остановлен.",
+                en: "Personal Vault contains an invalid record; import was stopped."
+            )
+        }
+    }
 }
 
 struct SelectiveRemotePersonalVaultImportSnapshot: Equatable {
@@ -12,6 +33,16 @@ struct SelectiveRemotePersonalVaultImportSnapshot: Equatable {
     let snippets: [TerminalCommandTemplate]
     let forwarding: [IndependentPortForward]
     let tombstoneIDs: Set<UUID>
+}
+
+struct SelectiveRemotePersonalVaultImportPlan: Equatable {
+    let profiles: [ConnectionProfile]
+    let credentials: [SelectiveRemotePersonalVaultCredentialInput]
+    let snippets: [TerminalCommandTemplate]
+    let forwarding: [IndependentPortForward]
+    let conflictIDs: [UUID]
+
+    var canApply: Bool { conflictIDs.isEmpty }
 }
 
 enum SelectiveRemotePersonalVaultImporter {
@@ -48,6 +79,45 @@ enum SelectiveRemotePersonalVaultImporter {
             forwarding: forwarding,
             tombstoneIDs: Set(document.tombstones.map(\.id))
         )
+    }
+
+    static func plan(
+        snapshot: SelectiveRemotePersonalVaultImportSnapshot,
+        localProfiles: [ConnectionProfile],
+        localSnippets: [TerminalCommandTemplate],
+        localForwarding: [IndependentPortForward]
+    ) -> SelectiveRemotePersonalVaultImportPlan {
+        let profiles = additions(remote: snapshot.profiles, local: localProfiles)
+        let snippets = additions(remote: snapshot.snippets, local: localSnippets)
+        let forwarding = additions(remote: snapshot.forwarding, local: localForwarding)
+        var conflicts = Set(profiles.conflicts + snippets.conflicts + forwarding.conflicts)
+        let localIDs = Set(localProfiles.map(\.id) + localSnippets.map(\.id) + localForwarding.map(\.id))
+        conflicts.formUnion(snapshot.tombstoneIDs.intersection(localIDs))
+        let existingProfileIDs = Set(localProfiles.map(\.id))
+        conflicts.formUnion(snapshot.credentials.lazy.map(\.sourceID).filter(existingProfileIDs.contains))
+        return .init(
+            profiles: profiles.values,
+            credentials: snapshot.credentials.filter { !conflicts.contains($0.sourceID) },
+            snippets: snippets.values,
+            forwarding: forwarding.values,
+            conflictIDs: conflicts.sorted { $0.uuidString < $1.uuidString }
+        )
+    }
+
+    private static func additions<T: Identifiable & Equatable>(remote: [T], local: [T])
+        -> (values: [T], conflicts: [UUID]) where T.ID == UUID
+    {
+        let localByID = Dictionary(uniqueKeysWithValues: local.map { ($0.id, $0) })
+        var values: [T] = []
+        var conflicts: [UUID] = []
+        for value in remote {
+            if let existing = localByID[value.id] {
+                if existing != value { conflicts.append(value.id) }
+            } else {
+                values.append(value)
+            }
+        }
+        return (values, conflicts)
     }
 
     private static func profile(

--- a/Sources/SelectiveRemote/CloudSettingsView.swift
+++ b/Sources/SelectiveRemote/CloudSettingsView.swift
@@ -526,6 +526,14 @@ struct CloudSettingsView: View {
                 accountPhase = .signedIn
                 showsAccountSheet = false
                 await loadInventory(endpoint: url)
+                if enrollmentError == nil {
+                    do {
+                        try await applyInitialPersonalVaultDownload(endpoint: url, deviceID: deviceID)
+                        await loadInventory(endpoint: url)
+                    } catch {
+                        enrollmentError = error.localizedDescription
+                    }
+                }
                 if let enrollmentError {
                     personalVaultLoadErrorMessage = UpdateLocalization.text(
                         ru: "Вход выполнен, но Personal Vault не подключён автоматически: \(enrollmentError)",
@@ -652,6 +660,35 @@ struct CloudSettingsView: View {
                 accountErrorMessage = error.localizedDescription
             }
         }
+    }
+
+    @MainActor
+    private func applyInitialPersonalVaultDownload(endpoint url: URL, deviceID: UUID) async throws {
+        guard var material = try personalVaultKeyStore.material(endpoint: url, deviceID: deviceID),
+              material.requiresInitialDownload == true
+        else { return }
+        let remote = try await client.personalVault(endpoint: url)
+        guard remote.id == material.vaultID, remote.revision == material.revision,
+              let envelope = remote.envelope
+        else { throw SelectiveRemotePersonalVaultError.invalidEnvelope }
+        let document = try SelectiveRemotePersonalVaultCrypto.open(envelope, vaultKey: material.vaultKey)
+        let snapshot = try SelectiveRemotePersonalVaultImporter.decode(document)
+        let history = TerminalCommandHistoryStore.shared
+        let plan = SelectiveRemotePersonalVaultImporter.plan(
+            snapshot: snapshot,
+            localProfiles: model.profiles,
+            localSnippets: history.templates(),
+            localForwarding: model.independentPortForwards
+        )
+        guard plan.canApply else {
+            throw SelectiveRemotePersonalVaultImportError.conflicts(plan.conflictIDs)
+        }
+        try KeychainService.savePasswords(plan.credentials)
+        model.profiles.append(contentsOf: plan.profiles)
+        model.independentPortForwards.append(contentsOf: plan.forwarding)
+        history.importTemplates(plan.snippets)
+        material.requiresInitialDownload = false
+        try personalVaultKeyStore.save(material, endpoint: url, deviceID: deviceID)
     }
 
     @MainActor

--- a/Sources/SelectiveRemote/KeychainService.swift
+++ b/Sources/SelectiveRemote/KeychainService.swift
@@ -341,6 +341,15 @@ enum KeychainService {
         try UnifiedCredentialVault.shared.save(password, reference: reference)
     }
 
+    static func savePasswords(_ credentials: [SelectiveRemotePersonalVaultCredentialInput]) throws {
+        try UnifiedCredentialVault.shared.save(credentials.map {
+            (
+                reference: credentialReference(profileID: $0.sourceID, kind: $0.kind),
+                secret: $0.secret
+            )
+        })
+    }
+
     static var unifiedVaultEntryCount: Int {
         UnifiedCredentialVault.shared.entryCount
     }

--- a/Sources/SelectiveRemote/TerminalCommandHistory.swift
+++ b/Sources/SelectiveRemote/TerminalCommandHistory.swift
@@ -389,6 +389,16 @@ final class TerminalCommandHistoryStore: ObservableObject {
             .sorted { $0.updatedAt > $1.updatedAt }
     }
 
+    func importTemplates(_ values: [TerminalCommandTemplate]) {
+        let existing = Set(storedTemplates.map(\.id))
+        storedTemplates.append(contentsOf: values.filter { !existing.contains($0.id) })
+        if storedTemplates.count > 500 {
+            storedTemplates.sort { $0.updatedAt > $1.updatedAt }
+            storedTemplates = Array(storedTemplates.prefix(500))
+        }
+        persistTemplates()
+    }
+
     func templates(in groupID: UUID) -> [TerminalCommandTemplate] {
         templates().filter { $0.groupID == groupID }
     }

--- a/Sources/SelectiveRemote/UnifiedCredentialVault.swift
+++ b/Sources/SelectiveRemote/UnifiedCredentialVault.swift
@@ -75,6 +75,24 @@ final class UnifiedCredentialVault: @unchecked Sendable {
         suppressedLegacy = suppressed
     }
 
+    func save(_ entries: [(reference: KeychainCredentialReference, secret: String)]) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        var secrets = try loadIfNeeded()
+        var updatedIndex = index
+        var suppressed = suppressedLegacy
+        for entry in entries {
+            let key = Self.entryKey(for: entry.reference)
+            secrets[key] = entry.secret
+            updatedIndex.insert(key)
+            suppressed.remove(key)
+        }
+        try persist(secrets)
+        cachedSecrets = secrets
+        index = updatedIndex
+        suppressedLegacy = suppressed
+    }
+
     func delete(reference: KeychainCredentialReference) throws {
         lock.lock()
         defer { lock.unlock() }

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -1543,6 +1543,42 @@ struct PersonalVaultInitialDownloadDecoderTests {
         #expect(decoded.profiles.first?.connectionType == .ssh)
         #expect(decoded.snippets.first?.id == snippetID)
     }
+
+    @Test("empty Mac accepts additions while an ID collision blocks the whole plan")
+    func conflictAwarePlan() throws {
+        var remote = ConnectionProfile(connectionType: .ssh)
+        remote.host = "remote.example"
+        let snapshot = SelectiveRemotePersonalVaultImportSnapshot(
+            profiles: [remote], credentials: [], snippets: [], forwarding: [], tombstoneIDs: []
+        )
+        let clean = SelectiveRemotePersonalVaultImporter.plan(
+            snapshot: snapshot, localProfiles: [], localSnippets: [], localForwarding: []
+        )
+        #expect(clean.canApply)
+        #expect(clean.profiles == [remote])
+
+        var local = remote
+        local.host = "local.example"
+        let blocked = SelectiveRemotePersonalVaultImporter.plan(
+            snapshot: snapshot, localProfiles: [local], localSnippets: [], localForwarding: []
+        )
+        #expect(!blocked.canApply)
+        #expect(blocked.conflictIDs == [remote.id])
+        #expect(blocked.profiles.isEmpty)
+    }
+
+    @Test("remote tombstones never silently delete local resources")
+    func tombstoneCollision() {
+        let local = ConnectionProfile(connectionType: .rdp)
+        let snapshot = SelectiveRemotePersonalVaultImportSnapshot(
+            profiles: [], credentials: [], snippets: [], forwarding: [], tombstoneIDs: [local.id]
+        )
+        let plan = SelectiveRemotePersonalVaultImporter.plan(
+            snapshot: snapshot, localProfiles: [local], localSnippets: [], localForwarding: []
+        )
+        #expect(!plan.canApply)
+        #expect(plan.conflictIDs == [local.id])
+    }
 }
 
 private final class CloudHTTPStub: @unchecked Sendable {


### PR DESCRIPTION
## Summary
- build a no-mutation import plan before applying an enrolled remote Personal Vault on macOS
- add only missing Hosts, Snippets, and Forwarding records
- treat differing IDs, local credential ownership, and remote tombstones against local resources as blocking conflicts
- write all imported credentials in one unified Keychain Vault update
- preserve exact imported Snippet IDs through a batch import path
- clear the initial-download upload gate only after every planned resource is applied successfully
- keep successful account sign-in independent from a blocked Personal Vault import

## Data safety
Any conflict blocks the entire resource apply and leaves automatic upload disabled. Remote tombstones never silently delete local resources. The Cloud revision and Vault ID must still match the enrolled Keychain material immediately before decryption and apply.

## Tests
- clean empty-Mac addition plan
- same-ID divergence blocks the plan
- tombstone collision blocks the plan
- existing Personal Vault crypto, decoder, Cloud, and Keychain suites

## Stack
Starts from merged main at 6d6183a01a210abd0a228bd9e1ae496d0ba56a22.