### PR TITLE
cloud: normalize runtime source permissions

### DIFF
--- a/cloud/Dockerfile
+++ b/cloud/Dockerfile
@@ -13,6 +13,8 @@ COPY migrations ./migrations
 COPY public ./public
 COPY scripts ./scripts
 COPY src ./src
+RUN chmod -R a=rX ./migrations ./public ./scripts ./src \
+    && chmod a=r ./package.json
 USER cloud
 EXPOSE 8080
 CMD ["sh", "-c", "node scripts/migrate.mjs && exec node src/server.mjs"]

--- a/cloud/tests/image-pinning.test.mjs
+++ b/cloud/tests/image-pinning.test.mjs
@@ -18,6 +18,14 @@ test("Dockerfile pins every build and runtime stage to the reviewed Node image",
   assert.deepEqual(images, [expectedNode, expectedNode]);
 });
 
+test("runtime sources are readable regardless of checkout umask", () => {
+  assert.match(
+    dockerfile,
+    /RUN chmod -R a=rX \.\/migrations \.\/public \.\/scripts \.\/src[\s\\]*&& chmod a=r \.\/package\.json/u,
+  );
+  assert.ok(dockerfile.indexOf("RUN chmod -R a=rX") < dockerfile.indexOf("USER cloud"));
+});
+
 test("Compose pins every external runtime image to its reviewed digest", () => {
   const images = [...compose.matchAll(/^\s+image:\s+(\S+)\s*$/gm)].map((match) => match[1]);
   assert.deepEqual(images, [expectedPostgres, expectedCaddy]);


### PR DESCRIPTION
## Причина
Git хранит только executable-бит, поэтому checkout с локальным режимом `0600` мог попасть в Docker build context. Контейнер затем не мог прочитать миграцию после `USER cloud`.

## Исправление
- runtime sources получают детерминированные read/traverse permissions во время сборки образа
- нормализация выполняется до `USER cloud`
- добавлен source-contract тест против регрессии

## Проверка
- `node --test cloud/tests/image-pinning.test.mjs cloud/tests/public-vault-ui.test.mjs`
- 13/13 успешно

Staging failure: `EACCES /app/migrations/008_usernames.sql`; миграция не запускалась, PostgreSQL не повреждён.