### PR TITLE
web: simplify the team workspace

### DIFF
--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -454,6 +454,7 @@ export function initializeTeamWorkspace({
   const grantWrappersButton = documentValue.querySelector("#team-vault-grant-wrappers");
   const lockButton = documentValue.querySelector("#team-vault-lock");
   const recordForm = documentValue.querySelector("#team-vault-record-form");
+  const recordEditorSummary = documentValue.querySelector("#team-record-editor-summary");
   const recordType = documentValue.querySelector("#team-record-type");
   const recordTitle = documentValue.querySelector("#team-record-title");
   const recordTarget = documentValue.querySelector("#team-record-target");
@@ -517,11 +518,11 @@ export function initializeTeamWorkspace({
     if (activeView === "teams") {
       setText(message, `Team «${selectedTeam.name}» · участников: ${teamMembers.length}.`);
     } else if (activeView === "vaults") {
-      setText(message, `Team «${selectedTeam.name}» · хранилищ: ${vaults.length}.`);
+      setText(message, `Команда «${selectedTeam.name}» · папок: ${vaults.length}.`);
     } else {
       setText(message, selectedVault
-        ? `Team «${selectedTeam.name}» · Vault «${selectedVault.name}».`
-        : `Team «${selectedTeam.name}» · выберите Vault для просмотра хостов.`);
+        ? `Команда «${selectedTeam.name}» · папка «${selectedVault.name}».`
+        : `Команда «${selectedTeam.name}» · выберите папку для просмотра хостов.`);
     }
   }
 
@@ -556,6 +557,7 @@ export function initializeTeamWorkspace({
     recordSecret.required = ["credential", "snippet"].includes(recordType.value);
     hostFields.hidden = recordType.value !== "host";
     hostBrowser.hidden = activeView !== "hosts";
+    setText(recordEditorSummary, activeView === "hosts" ? "Добавить Host" : "Добавить запись");
   }
 
   function hostFolderName(record) {
@@ -598,7 +600,7 @@ export function initializeTeamWorkspace({
       empty.className = "vault-empty";
       empty.textContent = activeView === "hosts"
         ? "В выбранном Team Vault пока нет хостов."
-        : "Shared Vault пока пуст.";
+        : "Папка команды пока пуста.";
       records.append(empty);
       return;
     }
@@ -1070,7 +1072,7 @@ export function initializeTeamWorkspace({
     membersView.hidden = activeView !== "teams";
     vaultDirectoryView.hidden = activeView === "teams";
     lifecyclePanel.hidden = activeView !== "teams" || selectedTeam?.role !== "owner";
-    createVaultForm.hidden = activeView !== "vaults" || !canManage();
+    createVaultForm.hidden = !["vaults", "hosts"].includes(activeView) || !canManage();
     workspace.hidden = activeView === "teams" || !controller;
     if (activeView === "hosts") recordType.value = "host";
     updateRecordLabels();
@@ -1078,6 +1080,8 @@ export function initializeTeamWorkspace({
       clearConflicts();
       renderRecords();
       setWorkspaceControls(false);
+    } else if (activeView !== "teams" && vaults.length > 0) {
+      void openSelectedVault();
     }
     updateTeamMessage();
   }
@@ -1136,7 +1140,7 @@ export function initializeTeamWorkspace({
     if (selectedTeam.role !== "owner" && inviteForm.elements.role.value === "admin") {
       inviteForm.elements.role.value = "viewer";
     }
-    createVaultForm.hidden = activeView !== "vaults" || !canManage();
+    createVaultForm.hidden = !["vaults", "hosts"].includes(activeView) || !canManage();
     lifecyclePanel.hidden = activeView !== "teams" || selectedTeam.role !== "owner";
     renameTeamForm.elements.name.value = selectedTeam.name;
     archiveTeamForm.reset();
@@ -1153,6 +1157,7 @@ export function initializeTeamWorkspace({
     renderTeamInvitations();
     populateVaults();
     updateTeamMessage();
+    if (activeView !== "teams" && vaults.length > 0) await openSelectedVault();
   }
 
   async function loadTeams(preferredID = null) {
@@ -1351,7 +1356,7 @@ export function initializeTeamWorkspace({
       await loadSelectedTeam();
       vaultSelect.value = vault.id;
       await openSelectedVault();
-      setText(message, "Shared Vault создан. Состояние криптографической инициализации показано ниже.");
+      setText(message, "Папка команды создана и открыта.");
     } catch {
       setText(message, "Shared Vault не создан или не инициализирован. Проверьте роль и одобрение устройства.");
     } finally {

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -151,8 +151,8 @@
           <p class="workspace-nav-label">Хранилища</p>
           <button type="button" data-workspace-target="local-vault" data-record-filter="all">Personal Vault</button>
           <button type="button" data-workspace-target="team-vault" data-team-view="teams">Команды</button>
-          <button type="button" data-workspace-target="team-vault" data-team-view="vaults">Team Vaults</button>
-          <button type="button" data-workspace-target="team-vault" data-team-view="hosts">Team Hosts</button>
+          <button type="button" data-workspace-target="team-vault" data-team-view="vaults">Папки команд</button>
+          <button type="button" data-workspace-target="team-vault" data-team-view="hosts">Хосты команд</button>
           <p class="workspace-nav-label">Аккаунт</p>
           <button type="button" data-workspace-target="workspace-devices">Устройства</button>
           <button type="button" data-workspace-target="workspace-settings">Настройки</button>
@@ -400,14 +400,14 @@
             </section>
           </div>
           <div id="team-vault-directory-view">
-            <h3>Shared Vaults</h3>
+            <h3>Папки команды</h3>
             <form id="team-vault-create-form">
-              <label for="team-vault-create-name">Название Vault</label>
+              <label for="team-vault-create-name">Название папки</label>
               <input id="team-vault-create-name" name="name" maxlength="120" required>
-              <button type="submit">Создать Vault</button>
+              <button type="submit">Создать папку</button>
             </form>
             <div class="team-picker compact">
-              <label for="team-vault-select">Vault</label>
+              <label for="team-vault-select">Папка</label>
               <select id="team-vault-select"></select>
               <button type="button" id="team-vault-open" disabled>Открыть</button>
             </div>
@@ -446,9 +446,9 @@
         <div class="vault-workspace" id="team-vault-workspace" hidden>
           <div class="vault-toolbar">
             <div>
-              <h3 id="team-vault-workspace-title">Shared Vault</h3>
+              <h3 id="team-vault-workspace-title">Папка команды</h3>
               <p id="team-vault-workspace-status" aria-live="polite">Vault заблокирован.</p>
-              <small>После открытия изменения и wrappers синхронизируются автоматически. Recovery-действия появляются только при безопасно устранимом блокере.</small>
+              <small>Изменения синхронизируются автоматически. Дополнительные действия появятся только при устранимой ошибке доступа.</small>
             </div>
             <div class="vault-actions">
               <button type="button" class="danger" id="team-vault-rotate" hidden>Завершить ротацию</button>
@@ -457,6 +457,8 @@
               <button type="button" class="secondary" id="team-vault-lock">Заблокировать</button>
             </div>
           </div>
+          <details class="team-record-editor" id="team-record-editor">
+            <summary id="team-record-editor-summary">Добавить запись</summary>
           <form class="record-form" id="team-vault-record-form">
             <label for="team-record-type">Тип записи</label>
             <select id="team-record-type" name="type">
@@ -482,6 +484,7 @@
             </div>
             <button type="submit">Зашифровать локально</button>
           </form>
+          </details>
           <div class="team-host-browser" id="team-host-browser">
             <label for="team-host-search">Найти Host</label>
             <input id="team-host-search" type="search" maxlength="120" placeholder="Название, адрес, тег или описание">

--- a/cloud/public/styles.css
+++ b/cloud/public/styles.css
@@ -138,6 +138,13 @@ body { margin:0; min-height:100vh; background:var(--body-bg); color:var(--ink); 
 .team-host-browser label { color:var(--muted); font-size:13px; }
 .team-host-browser input,.team-host-browser select { width:100%; border:1px solid var(--line); border-radius:10px; padding:12px 14px; background:#07100d; color:var(--ink); font:inherit; }
 .team-host-folder-heading { grid-column:1/-1; margin:12px 0 0; padding-bottom:8px; border-bottom:1px solid var(--line); }
+.team-record-editor { order:4; margin-top:24px; padding:16px 20px; border:1px solid var(--line); border-radius:14px; background:#08110e; }
+.team-record-editor summary { cursor:pointer; font-weight:750; }
+#team-vault-workspace { display:flex; flex-direction:column; }
+#team-vault-workspace>.vault-toolbar { order:1; }
+#team-vault-workspace>.team-host-browser { order:2; }
+#team-vault-workspace>.vault-records { order:3; }
+#team-vault-workspace>.vault-conflicts { order:5; }
 .vault-records article { display:grid; grid-template-columns:1fr auto; gap:8px 16px; align-items:center; padding:20px; border:1px solid var(--line); border-radius:14px; background:#08110e; }
 .vault-records h4,.vault-records p { margin:0; overflow-wrap:anywhere; }.vault-records p,.vault-records small,.vault-empty { color:var(--muted); }.vault-records small { font-family:ui-monospace,monospace; }
 :root[data-theme="light"] .workspace-layout,:root[data-theme="light"] .workspace-sidebar,:root[data-theme="light"] .workspace-stats button,:root[data-theme="light"] .workspace-devices>.vault-heading,:root[data-theme="light"] .team-onboarding form,:root[data-theme="light"] .team-columns>div,:root[data-theme="light"] .team-devices-panel,:root[data-theme="light"] .team-lifecycle,:root[data-theme="light"] .vault-records article,:root[data-theme="light"] .team-invitations article { background:var(--panel); }

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -182,8 +182,8 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(html, /autocomplete="current-password"/u);
   assert.match(html, /id="team-devices"/u);
   assert.match(html, /id="team-vault-rotate"[^>]*hidden/u);
-  assert.match(html, /изменения и wrappers синхронизируются автоматически/u);
-  assert.match(html, /Recovery-действия появляются только при безопасно устранимом блокере/u);
+  assert.match(html, /Изменения синхронизируются автоматически/u);
+  assert.match(html, /Дополнительные действия появятся только при устранимой ошибке доступа/u);
   assert.match(html, /id="team-vault-grant-wrappers"[^>]*hidden[^>]*>Повторить безопасную выдачу wrappers/u);
   assert.match(html, /id="team-vault-sync"[^>]*hidden[^>]*>Повторить безопасную синхронизацию/u);
   assert.equal((html.match(/aria-describedby="team-vault-workspace-status"/gu) ?? []).length, 2);
@@ -197,8 +197,9 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(html, /data-workspace-target="local-vault" data-record-filter="snippet">Сниппеты/u);
   assert.match(html, /data-workspace-target="local-vault" data-record-filter="credential">Учётные данные/u);
   assert.match(html, /data-workspace-target="team-vault" data-team-view="teams">Команды/u);
-  assert.match(html, /data-workspace-target="team-vault" data-team-view="vaults">Team Vaults/u);
-  assert.match(html, /data-workspace-target="team-vault" data-team-view="hosts">Team Hosts/u);
+  assert.match(html, /data-workspace-target="team-vault" data-team-view="vaults">Папки команд/u);
+  assert.match(html, /data-workspace-target="team-vault" data-team-view="hosts">Хосты команд/u);
+  assert.match(html, /id="team-record-editor"/u);
   assert.match(html, /id="host-detail-dialog"/u);
   assert.match(html, /data-workspace-target="workspace-settings"/u);
   assert.match(html, /id="account-delete-form"/u);
@@ -219,8 +220,9 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(application, /initializePortalNavigation/u);
   assert.match(application, /teamUI\?\.setView\(teamView \|\| "teams"\)/u);
   assert.match(application, /Team «\$\{selectedTeam\.name\}» · участников: \$\{teamMembers\.length\}/u);
-  assert.match(application, /Team «\$\{selectedTeam\.name\}» · хранилищ: \$\{vaults\.length\}/u);
-  assert.match(application, /выберите Vault для просмотра хостов/u);
+  assert.match(application, /Команда «\$\{selectedTeam\.name\}» · папок: \$\{vaults\.length\}/u);
+  assert.match(application, /выберите папку для просмотра хостов/u);
+  assert.match(application, /await openSelectedVault\(\)/u);
   assert.match(application, /value\.type !== "host" \|\| \(folder !== "all"/u);
   assert.match(html, /id="team-host-search"/u);
   assert.match(html, /id="team-host-folder-filter"/u);


### PR DESCRIPTION
## UX
- переименованы технические Team Vault пункты в папки и хосты команд
- существующая папка автоматически открывается при переходе
- поиск и список Host показываются раньше формы создания
- форма добавления записи свернута до явного действия пользователя
- обычные статусы больше не рассказывают пользователю о wrappers

## Безопасность
- E2EE payload, роли, wrappers и серверный API не изменены
- recovery controls остаются доступными только при блокере

## Проверка
- `node --test cloud/tests/public-vault-ui.test.mjs cloud/tests/image-pinning.test.mjs`
- 13/13 успешно