### PR TITLE
web: split workspace into routed pages

### DIFF
--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -517,6 +517,10 @@ export function initializeTeamWorkspace({
     if (!selectedTeam) return;
     if (activeView === "teams") {
       setText(message, `Team «${selectedTeam.name}» · участников: ${teamMembers.length}.`);
+    } else if (activeView === "members") {
+      setText(message, `Команда «${selectedTeam.name}» · участники и приглашения.`);
+    } else if (activeView === "management") {
+      setText(message, `Команда «${selectedTeam.name}» · управление.`);
     } else if (activeView === "vaults") {
       setText(message, `Команда «${selectedTeam.name}» · папок: ${vaults.length}.`);
     } else {
@@ -1065,13 +1069,16 @@ export function initializeTeamWorkspace({
   }
 
   function setView(view) {
-    activeView = ["teams", "vaults", "hosts"].includes(view) ? view : "teams";
+    activeView = ["teams", "members", "vaults", "hosts", "management"].includes(view) ? view : "teams";
     section.dataset.teamView = activeView;
-    setText(sectionTitle, { teams: "Команды", vaults: "Командные хранилища", hosts: "Командные хосты" }[activeView]);
+    setText(sectionTitle, {
+      teams: "Команды", members: "Участники команд", vaults: "Папки команд",
+      hosts: "Хосты команд", management: "Управление командой",
+    }[activeView]);
     onboarding.hidden = activeView !== "teams";
-    membersView.hidden = activeView !== "teams";
-    vaultDirectoryView.hidden = activeView === "teams";
-    lifecyclePanel.hidden = activeView !== "teams" || selectedTeam?.role !== "owner";
+    membersView.hidden = activeView !== "members";
+    vaultDirectoryView.hidden = !["vaults", "hosts"].includes(activeView);
+    lifecyclePanel.hidden = activeView !== "management" || selectedTeam?.role !== "owner";
     createVaultForm.hidden = !["vaults", "hosts"].includes(activeView) || !canManage();
     workspace.hidden = activeView === "teams" || !controller;
     if (activeView === "hosts") recordType.value = "host";
@@ -1141,7 +1148,7 @@ export function initializeTeamWorkspace({
       inviteForm.elements.role.value = "viewer";
     }
     createVaultForm.hidden = !["vaults", "hosts"].includes(activeView) || !canManage();
-    lifecyclePanel.hidden = activeView !== "teams" || selectedTeam.role !== "owner";
+    lifecyclePanel.hidden = activeView !== "management" || selectedTeam.role !== "owner";
     renameTeamForm.elements.name.value = selectedTeam.name;
     archiveTeamForm.reset();
     transferOwnershipForm.reset();
@@ -2033,8 +2040,27 @@ export function initializePortalNavigation({
     forwarding: "Forwarding",
     all: "Personal Vault",
   };
-  const teamTitles = { teams: "Команды", vaults: "Team Vaults", hosts: "Team Hosts" };
+  const teamTitles = {
+    teams: "Команды", members: "Участники команд", vaults: "Папки команд",
+    hosts: "Хосты команд", management: "Управление командой",
+  };
+  const workspaceRoutes = {
+    "/app": ["workspace-overview", null, null],
+    "/app/hosts": ["local-vault", "host", null],
+    "/app/snippets": ["local-vault", "snippet", null],
+    "/app/credentials": ["local-vault", "credential", null],
+    "/app/forwarding": ["local-vault", "forwarding", null],
+    "/app/personal-vault": ["local-vault", "all", null],
+    "/app/teams": ["team-vault", null, "teams"],
+    "/app/team-members": ["team-vault", null, "members"],
+    "/app/team-folders": ["team-vault", null, "vaults"],
+    "/app/team-hosts": ["team-vault", null, "hosts"],
+    "/app/team-management": ["team-vault", null, "management"],
+    "/app/devices": ["workspace-devices", null, null],
+    "/app/settings": ["workspace-settings", null, null],
+  };
   let sessionActive = false;
+  let requestedWorkspaceRoute = "/app";
 
   function setPath(path, replace = false) {
     if (locationValue.pathname === path) return;
@@ -2058,6 +2084,18 @@ export function initializePortalNavigation({
       : panelID === "team-vault" ? teamTitles[teamView || "teams"] : titles[panelID]);
     if (recordFilter) vaultUI?.setFilter(recordFilter);
     if (panelID === "team-vault") teamUI?.setView(teamView || "teams");
+  }
+
+  function routeForWorkspace(target, recordFilter = null, teamView = null) {
+    const normalizedFilter = target === "local-vault" ? recordFilter || "all" : null;
+    const normalizedTeamView = target === "team-vault" ? teamView || "teams" : null;
+    return Object.entries(workspaceRoutes).find(([, value]) => value[0] === target
+      && value[1] === normalizedFilter && value[2] === normalizedTeamView)?.[0] ?? "/app";
+  }
+
+  function selectWorkspaceRoute(pathname) {
+    const [target, recordFilter, teamView] = workspaceRoutes[pathname] ?? workspaceRoutes["/app"];
+    selectWorkspacePanel(target, recordFilter, teamView);
   }
 
   function showLanding({ replace = false } = {}) {
@@ -2096,8 +2134,12 @@ export function initializePortalNavigation({
     publicGrid.hidden = true;
     publicAccess.hidden = true;
     workspace.hidden = false;
-    selectWorkspacePanel("workspace-overview");
-    setPath("/app", replace);
+    const route = Object.hasOwn(workspaceRoutes, locationValue.pathname)
+      ? locationValue.pathname
+      : requestedWorkspaceRoute;
+    requestedWorkspaceRoute = route;
+    selectWorkspaceRoute(route);
+    setPath(route, replace);
   }
 
   for (const button of documentValue.querySelectorAll("[data-open-auth]")) {
@@ -2105,11 +2147,15 @@ export function initializePortalNavigation({
   }
   authBack.addEventListener("click", () => showLanding());
   for (const button of workspaceButtons) {
-    button.addEventListener("click", () => selectWorkspacePanel(
-      button.dataset.workspaceTarget,
-      button.dataset.recordFilter || null,
-      button.dataset.teamView || null,
-    ));
+    button.addEventListener("click", () => {
+      const target = button.dataset.workspaceTarget;
+      const recordFilter = button.dataset.recordFilter || null;
+      const teamView = button.dataset.teamView || null;
+      selectWorkspacePanel(target, recordFilter, teamView);
+      requestedWorkspaceRoute = routeForWorkspace(target, recordFilter, teamView);
+      setPath(requestedWorkspaceRoute);
+      workspace.scrollIntoView?.({ block: "start" });
+    });
   }
 
   const view = {
@@ -2134,13 +2180,14 @@ export function initializePortalNavigation({
     showAuthentication(requestedAuthMode, { replace: true });
     return view;
   }
-  if (initialPath === "/login" || initialPath === "/app") {
-    showAuthentication("login", { replace: initialPath === "/app" });
+  if (initialPath === "/login" || Object.hasOwn(workspaceRoutes, initialPath)) {
+    if (Object.hasOwn(workspaceRoutes, initialPath)) requestedWorkspaceRoute = initialPath;
+    showAuthentication("login", { replace: false });
   } else {
     showLanding({ replace: initialPath !== "/" });
   }
   documentValue.defaultView?.addEventListener("popstate", () => {
-    if (sessionActive && locationValue.pathname === "/app") showWorkspace({ replace: true });
+    if (sessionActive && Object.hasOwn(workspaceRoutes, locationValue.pathname)) showWorkspace({ replace: true });
     else if (locationValue.pathname === "/login") showAuthentication("login", { replace: true });
     else showLanding({ replace: true });
   });

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -151,8 +151,10 @@
           <p class="workspace-nav-label">Хранилища</p>
           <button type="button" data-workspace-target="local-vault" data-record-filter="all">Personal Vault</button>
           <button type="button" data-workspace-target="team-vault" data-team-view="teams">Команды</button>
+          <button type="button" data-workspace-target="team-vault" data-team-view="members">Участники команд</button>
           <button type="button" data-workspace-target="team-vault" data-team-view="vaults">Папки команд</button>
           <button type="button" data-workspace-target="team-vault" data-team-view="hosts">Хосты команд</button>
+          <button type="button" data-workspace-target="team-vault" data-team-view="management">Управление командой</button>
           <p class="workspace-nav-label">Аккаунт</p>
           <button type="button" data-workspace-target="workspace-devices">Устройства</button>
           <button type="button" data-workspace-target="workspace-settings">Настройки</button>

--- a/cloud/src/server.mjs
+++ b/cloud/src/server.mjs
@@ -441,7 +441,9 @@ async function readJSON(request, maximumBytes = maxBodyBytes) {
 }
 
 async function serveStatic(pathname, response, head) {
-  const relative = ["/", "/login", "/app"].includes(pathname) ? "index.html" : pathname.slice(1);
+  const relative = ["/", "/login"].includes(pathname) || /^\/app(?:\/[^/]+)?$/u.test(pathname)
+    ? "index.html"
+    : pathname.slice(1);
   if (!/^[a-zA-Z0-9._/-]+$/.test(relative) || relative.includes("..")) return sendError(response, 404, "not_found");
   try {
     const data = await readFile(join(publicDirectory, relative));

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -197,6 +197,7 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(html, /data-workspace-target="local-vault" data-record-filter="snippet">Сниппеты/u);
   assert.match(html, /data-workspace-target="local-vault" data-record-filter="credential">Учётные данные/u);
   assert.match(html, /data-workspace-target="team-vault" data-team-view="teams">Команды/u);
+  assert.match(html, /data-workspace-target="team-vault" data-team-view="members">Участники команд/u);
   assert.match(html, /data-workspace-target="team-vault" data-team-view="vaults">Папки команд/u);
   assert.match(html, /data-workspace-target="team-vault" data-team-view="hosts">Хосты команд/u);
   assert.match(html, /id="team-record-editor"/u);
@@ -235,8 +236,10 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(application, /URLSearchParams\(locationValue\.search\)/u);
   assert.match(application, /requestedAuthMode === "login" \|\| requestedAuthMode === "registration"/u);
   assert.match(application, /setPath\("\/login"/u);
-  assert.match(application, /setPath\("\/app"/u);
-  assert.match(server, /\["\/", "\/login", "\/app"\]\.includes\(pathname\)/u);
+  assert.match(application, /"\/app": \["workspace-overview", null, null\]/u);
+  assert.match(application, /"\/app\/team-hosts": \["team-vault", null, "hosts"\]/u);
+  assert.match(application, /routeForWorkspace/u);
+  assert.match(server, /\^\\\/app\(\?:\\\/\[\^\/\]\+\)\?\$/u);
   assert.match(application, /createAuthenticatedVaultClient/u);
   assert.match(application, /synchronizeVault/u);
   assert.match(application, /unlockAndSyncPersonalVault\(password\)/u);


### PR DESCRIPTION
## Исправление
- каждый пункт workspace получил отдельный `/app/...` URL
- Back/Forward и прямые ссылки восстанавливают выбранный экран
- сервер отдаёт SPA shell для безопасно ограниченных `/app/{page}` маршрутов
- Team management разделён на пять страниц: команды, участники, папки, хосты и управление
- переход по меню возвращает viewport к началу страницы

## Проверка
- `node --test cloud/tests/public-vault-ui.test.mjs cloud/tests/image-pinning.test.mjs`
- 13/13 успешно

API, E2EE payload и схема БД не изменены.