### PR TITLE
web: separate Team folders from Team Hosts

### DIFF
--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -1137,15 +1137,15 @@ export function initializeTeamWorkspace({
     membersView.hidden = activeView !== "members";
     vaultDirectoryView.hidden = !["vaults", "hosts"].includes(activeView);
     lifecyclePanel.hidden = activeView !== "management" || selectedTeam?.role !== "owner";
-    createVaultForm.hidden = !["vaults", "hosts"].includes(activeView) || !canManage();
-    workspace.hidden = activeView === "teams" || !controller;
+    createVaultForm.hidden = activeView !== "vaults" || !canManage();
+    workspace.hidden = activeView !== "hosts" || !controller;
     if (activeView === "hosts") recordType.value = "host";
     updateRecordLabels();
     if (controller) {
       clearConflicts();
       renderRecords();
       setWorkspaceControls(false);
-    } else if (activeView !== "teams" && vaults.length > 0) {
+    } else if (activeView === "hosts" && vaults.length > 0) {
       void openSelectedVault();
     }
     updateTeamMessage();
@@ -1162,7 +1162,7 @@ export function initializeTeamWorkspace({
       identity,
       scope,
     });
-    workspace.hidden = activeView === "teams";
+    workspace.hidden = activeView !== "hosts";
     rotateButton.hidden = !vault.rotationRequired || !canManage();
     rotateButton.disabled = !vault.rotationRequired || !canManage();
     setRecoveryControls("none");
@@ -1205,7 +1205,7 @@ export function initializeTeamWorkspace({
     if (selectedTeam.role !== "owner" && inviteForm.elements.role.value === "admin") {
       inviteForm.elements.role.value = "viewer";
     }
-    createVaultForm.hidden = !["vaults", "hosts"].includes(activeView) || !canManage();
+    createVaultForm.hidden = activeView !== "vaults" || !canManage();
     lifecyclePanel.hidden = activeView !== "management" || selectedTeam.role !== "owner";
     renameTeamForm.elements.name.value = selectedTeam.name;
     archiveTeamForm.reset();
@@ -1222,7 +1222,7 @@ export function initializeTeamWorkspace({
     renderTeamInvitations();
     populateVaults();
     updateTeamMessage();
-    if (activeView !== "teams" && vaults.length > 0) await openSelectedVault();
+    if (activeView === "hosts" && vaults.length > 0) await openSelectedVault();
   }
 
   async function loadTeams(preferredID = null) {
@@ -1420,8 +1420,7 @@ export function initializeTeamWorkspace({
       createVaultForm.reset();
       await loadSelectedTeam();
       vaultSelect.value = vault.id;
-      await openSelectedVault();
-      setText(message, "Папка команды создана и открыта.");
+      setText(message, "Папка команды создана. Перейдите в «Хосты команд», чтобы добавить или открыть Host.");
     } catch {
       setText(message, "Shared Vault не создан или не инициализирован. Проверьте роль и одобрение устройства.");
     } finally {
@@ -1436,7 +1435,13 @@ export function initializeTeamWorkspace({
   });
   teamRefresh.addEventListener("click", () => loadTeams(selectedTeam?.id).catch(() => setText(message, "Не удалось обновить Teams.")));
   devicesRefresh.addEventListener("click", () => loadDevices().catch(() => setText(message, "Не удалось обновить устройства.")));
-  vaultOpen.addEventListener("click", () => openSelectedVault());
+  vaultOpen.addEventListener("click", () => {
+    if (activeView === "vaults") {
+      documentValue.querySelector('[data-workspace-target="team-vault"][data-team-view="hosts"]')?.click();
+      return;
+    }
+    void openSelectedVault();
+  });
   rotateButton.addEventListener("click", async () => {
     if (!controller || !selectedVault || !canManage() || vaultOperation) return;
     if (!confirmValue("Зашифровать полную текущую Team-ревизию новым ключом и выдать wrappers всем актуальным авторизованным устройствам?")) return;

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -408,7 +408,7 @@
             </section>
           </div>
           <div id="team-vault-directory-view">
-            <h3>Папки команды</h3>
+            <h3 class="team-vault-directory-heading">Папки команды</h3>
             <form id="team-vault-create-form">
               <label for="team-vault-create-name">Название папки</label>
               <input id="team-vault-create-name" name="name" maxlength="120" required>

--- a/cloud/public/styles.css
+++ b/cloud/public/styles.css
@@ -145,6 +145,8 @@ body { margin:0; min-height:100vh; background:var(--body-bg); color:var(--ink); 
 #team-vault-workspace>.team-host-browser { order:2; }
 #team-vault-workspace>.vault-records { order:3; }
 #team-vault-workspace>.vault-conflicts { order:5; }
+#team-vault[data-team-view="hosts"] .team-vault-directory-heading { display:none; }
+#team-vault[data-team-view="hosts"] #team-vault-directory-view { padding-bottom:18px; border-bottom:1px solid var(--line); }
 .vault-records article { display:grid; grid-template-columns:1fr auto; gap:8px 16px; align-items:center; padding:20px; border:1px solid var(--line); border-radius:14px; background:#08110e; }
 .vault-records h4,.vault-records p { margin:0; overflow-wrap:anywhere; }.vault-records p,.vault-records small,.vault-empty { color:var(--muted); }.vault-records small { font-family:ui-monospace,monospace; }
 :root[data-theme="light"] .workspace-layout,:root[data-theme="light"] .workspace-sidebar,:root[data-theme="light"] .workspace-stats button,:root[data-theme="light"] .workspace-devices>.vault-heading,:root[data-theme="light"] .team-onboarding form,:root[data-theme="light"] .team-columns>div,:root[data-theme="light"] .team-devices-panel,:root[data-theme="light"] .team-lifecycle,:root[data-theme="light"] .vault-records article,:root[data-theme="light"] .team-invitations article { background:var(--panel); }

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -235,6 +235,11 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(application, /teamUI\?\.setView\(teamView \|\| "teams"\)/u);
   assert.match(application, /Team «\$\{selectedTeam\.name\}» · участников: \$\{teamMembers\.length\}/u);
   assert.match(application, /Команда «\$\{selectedTeam\.name\}» · папок: \$\{vaults\.length\}/u);
+  assert.match(application, /createVaultForm\.hidden = activeView !== "vaults" \|\| !canManage\(\)/u);
+  assert.match(application, /workspace\.hidden = activeView !== "hosts" \|\| !controller/u);
+  assert.match(application, /activeView === "hosts" && vaults\.length > 0/u);
+  assert.match(application, /data-team-view="hosts"/u);
+  assert.match(styles, /#team-vault\[data-team-view="hosts"\] \.team-vault-directory-heading/u);
   assert.match(application, /выберите папку для просмотра хостов/u);
   assert.match(application, /await openSelectedVault\(\)/u);
   assert.match(application, /value\.type !== "host" \|\| \(folder !== "all"/u);


### PR DESCRIPTION
## Исправление
- `/app/team-folders` показывает только создание и выбор папок Team Vault
- `/app/team-hosts` показывает выбор папки и содержимое Host, без формы создания папки
- открытие папки переводит пользователя на отдельную страницу Team Hosts
- создание папки больше не раскрывает Host workspace на странице папок

## Проверка
- `cd cloud && npm test`: 282 passed, 1 skipped (`TEST_DATABASE_URL` не настроен)

Исправляет ситуацию, когда два разных пункта левого меню фактически отображали одну длинную страницу.