### PR TITLE
web: add Team Host credentials and SSH/SFTP actions

### DIFF
--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -107,6 +107,49 @@ export function teamHostRecordData({ title, target, folder, tags, description, b
   return data;
 }
 
+export function teamHostConnectionData({ protocol, host, port, username }) {
+  const normalizedProtocol = String(protocol ?? "").toLowerCase();
+  const normalizedHost = String(host ?? "").trim();
+  const normalizedUsername = String(username ?? "").trim();
+  const defaultPort = normalizedProtocol === "ssh" ? 22 : 3389;
+  const normalizedPort = Number(port || defaultPort);
+  if (!["ssh", "rdp"].includes(normalizedProtocol)
+    || !normalizedHost || normalizedHost.length > 2048 || /[\s/@]/u.test(normalizedHost)
+    || !Number.isSafeInteger(normalizedPort) || normalizedPort < 1 || normalizedPort > 65_535
+    || normalizedUsername.length > 256 || normalizedUsername.includes("\n")) {
+    throw new Error("invalid_team_host_connection");
+  }
+  const encodedUser = normalizedUsername ? `${encodeURIComponent(normalizedUsername)}@` : "";
+  const encodedHost = normalizedHost.includes(":") && !normalizedHost.startsWith("[")
+    ? `[${normalizedHost}]` : normalizedHost;
+  return {
+    protocol: normalizedProtocol, host: normalizedHost, port: normalizedPort,
+    username: normalizedUsername,
+    target: `${normalizedProtocol}://${encodedUser}${encodedHost}:${normalizedPort}`,
+  };
+}
+
+export function parseTeamHostConnection(data) {
+  const address = String(data?.address ?? "").trim();
+  const profileProtocol = String(data?.connectionType ?? "").toLowerCase();
+  try {
+    const parsed = new URL(address);
+    if (["ssh:", "rdp:"].includes(parsed.protocol) && parsed.hostname) {
+      return {
+        protocol: parsed.protocol.slice(0, -1), host: parsed.hostname,
+        port: Number(parsed.port || (parsed.protocol === "ssh:" ? 22 : 3389)),
+        username: decodeURIComponent(parsed.username || ""),
+      };
+    }
+  } catch { /* legacy address */ }
+  return {
+    protocol: ["ssh", "rdp"].includes(profileProtocol) ? profileProtocol : "rdp",
+    host: address,
+    port: profileProtocol === "ssh" ? 22 : 3389,
+    username: String(data?.username ?? ""),
+  };
+}
+
 export function localVaultRecordSummary(record) {
   const data = record?.data ?? {};
   let summary = "";
@@ -173,10 +216,17 @@ export async function initializeLocalVault({
   const hostDetailTitle = documentValue.querySelector("#host-detail-title");
   const hostDetailAddress = documentValue.querySelector("#host-detail-address");
   const hostDetailModified = documentValue.querySelector("#host-detail-modified");
+  const hostDetailProtocol = documentValue.querySelector("#host-detail-protocol");
+  const hostDetailPort = documentValue.querySelector("#host-detail-port");
+  const hostDetailUsername = documentValue.querySelector("#host-detail-username");
+  const hostDetailPasswordState = documentValue.querySelector("#host-detail-password-state");
   const hostDetailFolder = documentValue.querySelector("#host-detail-folder");
   const hostDetailTags = documentValue.querySelector("#host-detail-tags");
   const hostDetailDescription = documentValue.querySelector("#host-detail-description");
   const hostDetailEdit = documentValue.querySelector("#host-detail-edit");
+  const hostDetailCopyPassword = documentValue.querySelector("#host-detail-copy-password");
+  const hostDetailOpenSSH = documentValue.querySelector("#host-detail-open-ssh");
+  const hostDetailOpenSFTP = documentValue.querySelector("#host-detail-open-sftp");
   const filterButtons = [...documentValue.querySelectorAll("#personal-vault-filters [data-record-filter]")];
   const controller = createLocalVaultController({ repository });
   let conflictResetListener = () => {};
@@ -277,10 +327,18 @@ export async function initializeLocalVault({
           setText(hostDetailTitle, String(record.data.title ?? "Host"));
           setText(hostDetailAddress, String(record.data.address ?? "—"));
           setText(hostDetailModified, String(record.modifiedAt ?? "—"));
+          const connection = parseTeamHostConnection(record.data);
+          setText(hostDetailProtocol, connection.protocol.toUpperCase());
+          setText(hostDetailPort, String(connection.port));
+          setText(hostDetailUsername, connection.username || "—");
+          setText(hostDetailPasswordState, "Управляется приложением");
           setText(hostDetailFolder, "Личный Vault");
           setText(hostDetailTags, "—");
           setText(hostDetailDescription, "—");
           hostDetailEdit.hidden = true;
+          hostDetailCopyPassword.hidden = true;
+          hostDetailOpenSSH.hidden = true;
+          hostDetailOpenSFTP.hidden = true;
           hostDetail?.showModal();
         };
         card.addEventListener("click", (event) => {
@@ -478,6 +536,11 @@ export function initializeTeamWorkspace({
   const recordSecretLabel = documentValue.querySelector("#team-record-secret-label");
   const records = documentValue.querySelector("#team-vault-records");
   const hostFields = documentValue.querySelector("#team-host-fields");
+  const hostProtocol = documentValue.querySelector("#team-host-protocol");
+  const hostPort = documentValue.querySelector("#team-host-port");
+  const hostUsername = documentValue.querySelector("#team-host-username");
+  const hostPassword = documentValue.querySelector("#team-host-password");
+  const hostRemovePassword = documentValue.querySelector("#team-host-remove-password");
   const hostFolder = documentValue.querySelector("#team-host-folder");
   const hostFolderOptions = documentValue.querySelector("#team-host-folder-options");
   const hostTags = documentValue.querySelector("#team-host-tags");
@@ -488,12 +551,19 @@ export function initializeTeamWorkspace({
   const hostDetail = documentValue.querySelector("#host-detail-dialog");
   const hostDetailTitle = documentValue.querySelector("#host-detail-title");
   const hostDetailAddress = documentValue.querySelector("#host-detail-address");
+  const hostDetailProtocol = documentValue.querySelector("#host-detail-protocol");
+  const hostDetailPort = documentValue.querySelector("#host-detail-port");
+  const hostDetailUsername = documentValue.querySelector("#host-detail-username");
+  const hostDetailPasswordState = documentValue.querySelector("#host-detail-password-state");
   const hostDetailModified = documentValue.querySelector("#host-detail-modified");
   const hostDetailFolder = documentValue.querySelector("#host-detail-folder");
   const hostDetailTags = documentValue.querySelector("#host-detail-tags");
   const hostDetailDescription = documentValue.querySelector("#host-detail-description");
   const hostDetailCopy = documentValue.querySelector("#host-detail-copy");
   const hostDetailEdit = documentValue.querySelector("#host-detail-edit");
+  const hostDetailCopyPassword = documentValue.querySelector("#host-detail-copy-password");
+  const hostDetailOpenSSH = documentValue.querySelector("#host-detail-open-ssh");
+  const hostDetailOpenSFTP = documentValue.querySelector("#host-detail-open-sftp");
   const conflictPanel = documentValue.querySelector("#team-vault-conflicts");
   const conflictForm = documentValue.querySelector("#team-vault-conflicts-form");
   const conflictList = documentValue.querySelector("#team-vault-conflicts-list");
@@ -587,16 +657,25 @@ export function initializeTeamWorkspace({
   }
 
   function beginHostEdit(record) {
+    const connection = parseTeamHostConnection(record.data);
     editingHostID = record.id;
     recordType.value = "host";
     recordTitle.value = String(record.data.title ?? "");
-    recordTarget.value = String(record.data.address ?? "");
+    recordTarget.value = connection.host;
+    hostProtocol.value = connection.protocol;
+    hostPort.value = String(connection.port);
+    hostUsername.value = connection.username;
+    hostPassword.value = "";
+    hostRemovePassword.checked = false;
     hostFolder.value = String(record.data.folder ?? "");
     hostTags.value = Array.isArray(record.data.tags) ? record.data.tags.join(", ") : "";
     hostDescription.value = String(record.data.description ?? "");
     const advanced = Boolean(record.data.profile);
     recordTitle.disabled = advanced;
     recordTarget.disabled = advanced;
+    hostProtocol.disabled = advanced;
+    hostPort.disabled = advanced;
+    hostUsername.disabled = advanced;
     updateRecordLabels();
     recordEditor.open = true;
     recordEditor.scrollIntoView({ behavior: "smooth", block: "start" });
@@ -604,6 +683,17 @@ export function initializeTeamWorkspace({
     setText(workspaceStatus, advanced
       ? "Полный профиль создан в приложении: в браузере можно менять папку, теги и описание."
       : "Измените Host и сохраните зашифрованную запись.");
+  }
+
+  function hostCredentials(hostID) {
+    return controller?.document().records.filter((value) => value.type === "credential"
+      && value.data?.sourceID === hostID && ["ssh", "rdp"].includes(value.data?.kind)) ?? [];
+  }
+
+  function detailConnectionURL(protocol) {
+    const record = controller?.document().records.find((value) => value.id === detailedHostID);
+    if (!record) return null;
+    return teamHostConnectionData({ ...parseTeamHostConnection(record.data), protocol }).target;
   }
 
   function hostFolderName(record) {
@@ -682,6 +772,7 @@ export function initializeTeamWorkspace({
       remove.addEventListener("click", async () => {
         remove.disabled = true;
         try {
+          for (const credential of hostCredentials(record.id)) await controller.delete(credential.id);
           await controller.delete(record.id);
           clearConflicts();
           renderRecords();
@@ -696,15 +787,24 @@ export function initializeTeamWorkspace({
         card.tabIndex = 0;
         card.setAttribute("role", "button");
         const openHost = () => {
+          const connection = parseTeamHostConnection(record.data);
+          const credentials = hostCredentials(record.id);
           detailedHostID = record.id;
           setText(hostDetailTitle, String(record.data.title ?? "Host"));
           setText(hostDetailAddress, String(record.data.address ?? "—"));
           setText(hostDetailModified, String(record.modifiedAt ?? "—"));
+          setText(hostDetailProtocol, connection.protocol.toUpperCase());
+          setText(hostDetailPort, String(connection.port));
+          setText(hostDetailUsername, connection.username || "—");
+          setText(hostDetailPasswordState, credentials.length ? "Сохранён в E2EE Team Vault" : "Не сохранён");
           setText(hostDetailFolder, hostFolderName(record));
           setText(hostDetailTags, Array.isArray(record.data.tags) && record.data.tags.length ? record.data.tags.join(", ") : "—");
           setText(hostDetailDescription, String(record.data.description ?? "—"));
           hostDetailCopy.hidden = false;
           hostDetailEdit.hidden = !canEdit();
+          hostDetailCopyPassword.hidden = credentials.length === 0;
+          hostDetailOpenSSH.hidden = connection.protocol !== "ssh";
+          hostDetailOpenSFTP.hidden = connection.protocol !== "ssh";
           hostDetail?.showModal();
         };
         card.addEventListener("click", (event) => { if (event.target !== remove && event.target !== edit) openHost(); });
@@ -1498,6 +1598,9 @@ export function initializeTeamWorkspace({
   recordType.addEventListener("change", updateRecordLabels);
   hostSearch.addEventListener("input", renderRecords);
   hostFolderFilter.addEventListener("change", renderRecords);
+  hostProtocol.addEventListener("change", () => {
+    hostPort.value = hostProtocol.value === "ssh" ? "22" : "3389";
+  });
   hostDetailCopy.addEventListener("click", async () => {
     try {
       await documentValue.defaultView.navigator.clipboard.writeText(hostDetailAddress.textContent);
@@ -1509,6 +1612,22 @@ export function initializeTeamWorkspace({
     hostDetail.close();
     if (record) beginHostEdit(record);
   });
+  hostDetailCopyPassword.addEventListener("click", async () => {
+    const credential = hostCredentials(detailedHostID)[0];
+    if (!credential) return;
+    try {
+      await documentValue.defaultView.navigator.clipboard.writeText(String(credential.data.secret ?? ""));
+      setText(workspaceStatus, "Пароль Host скопирован локально. Cloud plaintext не получал.");
+    } catch { setText(workspaceStatus, "Браузер не разрешил доступ к буферу обмена."); }
+  });
+  hostDetailOpenSSH.addEventListener("click", () => {
+    const target = detailConnectionURL("ssh");
+    if (target) documentValue.defaultView.location.href = target;
+  });
+  hostDetailOpenSFTP.addEventListener("click", () => {
+    const target = detailConnectionURL("ssh");
+    if (target) documentValue.defaultView.location.href = target.replace(/^ssh:/u, "sftp:");
+  });
   recordForm.addEventListener("submit", async (event) => {
     event.preventDefault();
     const button = recordForm.querySelector("button");
@@ -1517,22 +1636,49 @@ export function initializeTeamWorkspace({
       const existingHost = editingHostID
         ? controller.document().records.find((value) => value.id === editingHostID && value.type === "host")
         : null;
-      await controller.upsert({
+      const connection = recordType.value === "host" && !existingHost?.data?.profile
+        ? teamHostConnectionData({
+            protocol: hostProtocol.value, host: recordTarget.value,
+            port: hostPort.value, username: hostUsername.value,
+          })
+        : null;
+      const hostID = await controller.upsert({
         ...(editingHostID ? { id: editingHostID } : {}),
         type: recordType.value,
         data: recordType.value === "host"
           ? teamHostRecordData({
-              title: recordTitle.value, target: recordTarget.value, folder: hostFolder.value,
+              title: recordTitle.value, target: connection?.target ?? recordTarget.value, folder: hostFolder.value,
               tags: hostTags.value, description: hostDescription.value, baseData: existingHost?.data,
             })
           : localVaultRecordData(recordType.value, {
               title: recordTitle.value, target: recordTarget.value, secret: recordSecret.value,
             }),
       });
+      if (recordType.value === "host") {
+        const credentials = hostCredentials(hostID);
+        if (hostRemovePassword.checked) {
+          for (const credential of credentials) await controller.delete(credential.id);
+        } else if (hostPassword.value) {
+          const connectionValue = connection ?? parseTeamHostConnection(existingHost?.data);
+          const retained = credentials[0];
+          await controller.upsert({
+            ...(retained ? { id: retained.id } : {}), type: "credential",
+            data: {
+              title: `${recordTitle.value.trim()} · ${connectionValue.protocol}`,
+              username: connectionValue.username, secret: hostPassword.value,
+              kind: connectionValue.protocol, sourceID: hostID,
+            },
+          });
+          for (const duplicate of credentials.slice(1)) await controller.delete(duplicate.id);
+        }
+      }
       recordForm.reset();
       editingHostID = null;
       recordTitle.disabled = false;
       recordTarget.disabled = false;
+      hostProtocol.disabled = false;
+      hostPort.disabled = false;
+      hostUsername.disabled = false;
       recordEditor.open = false;
       updateRecordLabels();
       clearConflicts();

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -279,6 +279,10 @@
             </div>
             <dl class="resource-detail-fields">
               <div><dt>Адрес</dt><dd id="host-detail-address">—</dd></div>
+              <div><dt>Протокол</dt><dd id="host-detail-protocol">—</dd></div>
+              <div><dt>Порт</dt><dd id="host-detail-port">—</dd></div>
+              <div><dt>Логин</dt><dd id="host-detail-username">—</dd></div>
+              <div><dt>Пароль</dt><dd id="host-detail-password-state">—</dd></div>
               <div><dt>Изменён</dt><dd id="host-detail-modified">—</dd></div>
               <div><dt>Папка</dt><dd id="host-detail-folder">—</dd></div>
               <div><dt>Теги</dt><dd id="host-detail-tags">—</dd></div>
@@ -287,6 +291,9 @@
             <div class="resource-detail-actions">
               <button type="button" id="host-detail-copy" class="secondary">Копировать адрес</button>
               <button type="button" id="host-detail-edit" class="secondary">Изменить</button>
+              <button type="button" id="host-detail-copy-password" class="secondary" hidden>Копировать пароль</button>
+              <button type="button" id="host-detail-open-ssh" class="secondary" hidden>Открыть SSH</button>
+              <button type="button" id="host-detail-open-sftp" class="secondary" hidden>Открыть SFTP</button>
             </div>
             <section class="resource-detail-next">
               <h4>Удалённое выполнение</h4>
@@ -482,6 +489,16 @@
             <label for="team-record-secret" id="team-record-secret-label">Дополнительные данные не требуются</label>
             <textarea id="team-record-secret" name="secret" maxlength="32768" rows="3"></textarea>
             <div class="team-host-fields" id="team-host-fields">
+              <label for="team-host-protocol">Протокол</label>
+              <select id="team-host-protocol" name="protocol"><option value="ssh">SSH</option><option value="rdp">RDP</option></select>
+              <label for="team-host-port">Порт</label>
+              <input id="team-host-port" name="port" type="number" min="1" max="65535" value="22" required>
+              <label for="team-host-username">Логин</label>
+              <input id="team-host-username" name="username" maxlength="256" autocomplete="username">
+              <label for="team-host-password">Пароль</label>
+              <input id="team-host-password" name="password" type="password" maxlength="16384" autocomplete="new-password" placeholder="Пусто — оставить существующий пароль">
+              <label for="team-host-remove-password">Удалить пароль</label>
+              <input id="team-host-remove-password" name="removePassword" type="checkbox">
               <label for="team-host-folder">Папка</label>
               <input id="team-host-folder" name="folder" maxlength="120" list="team-host-folder-options" placeholder="Например, Production">
               <datalist id="team-host-folder-options"></datalist>

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -7,6 +7,8 @@ import {
   localVaultConflictSideSummary,
   localVaultRecordData,
   localVaultRecordSummary,
+  parseTeamHostConnection,
+  teamHostConnectionData,
   teamHostRecordData,
   teamVaultRecoveryMode,
 } from "../public/app.js";
@@ -101,6 +103,24 @@ test("Team Host organization stays inside the encrypted record", () => {
   assert.throws(() => teamHostRecordData({
     title: "Changed", target: "rdp.invalid", folder: "", tags: "", description: "", baseData: advanced,
   }), /advanced_team_host_requires_native_editor/u);
+});
+
+test("Team Host connection fields produce password-free interoperable URLs", () => {
+  assert.deepEqual(teamHostConnectionData({
+    protocol: "ssh", host: "bastion.example.invalid", port: "2222", username: "deployer",
+  }), {
+    protocol: "ssh", host: "bastion.example.invalid", port: 2222, username: "deployer",
+    target: "ssh://deployer@bastion.example.invalid:2222",
+  });
+  assert.deepEqual(parseTeamHostConnection({ address: "rdp://operator@desktop.example.invalid:3390" }), {
+    protocol: "rdp", host: "desktop.example.invalid", port: 3390, username: "operator",
+  });
+  assert.deepEqual(parseTeamHostConnection({ address: "legacy.example.invalid" }), {
+    protocol: "rdp", host: "legacy.example.invalid", port: 3389, username: "",
+  });
+  assert.throws(() => teamHostConnectionData({
+    protocol: "ssh", host: "bad host", port: 22, username: "root",
+  }), /invalid_team_host_connection/u);
 });
 
 test("Team Vault routine automation exposes controls only for recoverable blockers", () => {
@@ -215,6 +235,13 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(html, /id="host-detail-dialog"/u);
   assert.match(html, /id="host-detail-copy"/u);
   assert.match(html, /id="host-detail-edit"/u);
+  assert.match(html, /id="host-detail-copy-password"/u);
+  assert.match(html, /id="host-detail-open-ssh"/u);
+  assert.match(html, /id="host-detail-open-sftp"/u);
+  assert.match(html, /id="team-host-protocol"/u);
+  assert.match(html, /id="team-host-port"/u);
+  assert.match(html, /id="team-host-username"/u);
+  assert.match(html, /id="team-host-password"[^>]*type="password"/u);
   assert.match(html, /data-workspace-target="workspace-settings"/u);
   assert.match(html, /id="account-delete-form"/u);
   assert.match(html, /autocomplete="current-password"/u);
@@ -253,6 +280,9 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(application, /hostDetail\?\.showModal\(\)/u);
   assert.match(application, /beginHostEdit/u);
   assert.match(application, /navigator\.clipboard\.writeText\(hostDetailAddress\.textContent\)/u);
+  assert.match(application, /navigator\.clipboard\.writeText\(String\(credential\.data\.secret/u);
+  assert.match(application, /target\.replace\(\/\^ssh:\/u, "sftp:"\)/u);
+  assert.match(application, /sourceID: hostID/u);
   assert.match(application, /resourceTitles/u);
   assert.match(application, /client\.deleteAccount/u);
   assert.match(application, /account_owns_teams/u);


### PR DESCRIPTION
## Что добавлено
- расширенная форма Team Host: SSH/RDP, порт, логин и пароль
- канонический password-free URI подключения для совместимости браузера и macOS
- пароль хранится отдельной связанной credential-записью внутри E2EE Team Vault
- пустое поле сохраняет прежний пароль, отдельный флаг удаляет его
- удаление Host удаляет связанные SSH/RDP credentials
- карточка показывает протокол, порт, логин и только состояние наличия пароля
- явное локальное копирование пароля
- открытие SSH и SFTP через системные URI без помещения пароля в URL
- расширенные профили macOS сохраняют защищённые параметры профиля неизменными

## Проверки
- `cd cloud && npm test`: 283 passed, 1 skipped (`TEST_DATABASE_URL` не настроен)

## Безопасность
Cloud хранит только зашифрованный Team Vault envelope. Пароль не рендерится как текст, не входит в адрес подключения и копируется только по явному действию пользователя.