### PR TITLE
cloud: make Team invitation emails human-friendly

### DIFF
--- a/cloud/src/mailer.mjs
+++ b/cloud/src/mailer.mjs
@@ -28,6 +28,18 @@ function message(config, recipient, subject, text, html) {
   return { from: `Selective Remote <${config.smtp.from}>`, to: recipient, subject, disableFileAccess: true, disableUrlAccess: true, text, html };
 }
 
+function invitationRole(role) {
+  return ({ admin: "Администратор", editor: "Редактор", operator: "Оператор", viewer: "Наблюдатель" })[role] ?? role;
+}
+
+function invitationExpiry(value) {
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return value;
+  return new Intl.DateTimeFormat("ru-RU", {
+    dateStyle: "long", timeStyle: "short", timeZone: "UTC",
+  }).format(date) + " UTC";
+}
+
 export function createVerificationMailer(config, createTransport = nodemailer.createTransport) {
   if (!config.smtp) throw new Error("smtp_not_configured");
   const transport = createTransport({
@@ -55,13 +67,20 @@ export function createVerificationMailer(config, createTransport = nodemailer.cr
       const html = emailHTML({ preview: "Безопасная ссылка для смены пароля Selective Remote.", eyebrow: "Безопасность аккаунта", title: "Сброс пароля", body: `Мы получили запрос на смену пароля. Ссылка действует <strong style="color:${COLORS.white}">${escapeHTML(config.passwordResetTTLHours)} ч.</strong> и предназначена только для вас.`, buttonLabel: "Задать новый пароль", url });
       return transport.sendMail(message(config, recipient, "Сброс пароля Selective Remote", text, html));
     },
-    async sendTeamInvitation({ recipient, token, teamID, role, expiresAt }) {
+    async sendTeamInvitation({ recipient, token, teamID, teamName, invitedBy, role, expiresAt }) {
       const target = new URL("/", config.publicOrigin);
       target.hash = `accept-team-invitation?${new URLSearchParams({ token })}`;
       const url = target.toString();
-      const text = ["Вас пригласили в команду Selective Remote.", url, "", `Роль: ${role}. Идентификатор команды: ${teamID}.`, `Приглашение действует до ${expiresAt} и может быть использовано один раз.`, "Если вы не ожидали приглашение, проигнорируйте это письмо."].join("\n");
-      const html = emailHTML({ preview: "Вас пригласили в команду Selective Remote.", eyebrow: "Командная работа", title: "Вас пригласили в команду", body: "Примите приглашение, чтобы получить защищённый доступ к общим хостам и ресурсам команды.", buttonLabel: "Принять приглашение", url, details: [{ label: "Роль", value: role }, { label: "Команда", value: teamID }, { label: "Действует до", value: expiresAt }] });
-      return transport.sendMail(message(config, recipient, "Приглашение в команду Selective Remote", text, html));
+      const displayTeam = teamName || teamID;
+      const displayRole = invitationRole(role);
+      const displayExpiry = invitationExpiry(expiresAt);
+      const inviterLine = invitedBy ? `Пригласил: @${invitedBy}.` : "";
+      const text = [`Вас пригласили в команду «${displayTeam}» в Selective Remote.`, inviterLine, url, "", `Роль: ${displayRole}.`, `Приглашение действует до ${displayExpiry} и может быть использовано один раз.`, "Если вы не ожидали приглашение, проигнорируйте это письмо."].filter(Boolean).join("\n");
+      const details = [{ label: "Команда", value: displayTeam }, { label: "Роль", value: displayRole }];
+      if (invitedBy) details.push({ label: "Пригласил", value: `@${invitedBy}` });
+      details.push({ label: "Действует до", value: displayExpiry });
+      const html = emailHTML({ preview: `Вас пригласили в команду «${displayTeam}».`, eyebrow: "Командная работа", title: "Приглашение в команду", body: "Примите приглашение, чтобы получить защищённый доступ к общим хостам и ресурсам команды.", buttonLabel: "Принять приглашение", url, details });
+      return transport.sendMail(message(config, recipient, `Приглашение в команду «${displayTeam}»`, text, html));
     },
   });
 }

--- a/cloud/src/service.mjs
+++ b/cloud/src/service.mjs
@@ -360,11 +360,17 @@ export class CloudService {
     const role = validateTeamRole(input?.role, { invitation: true });
     const token = createTeamInvitationToken();
     const expiresAt = this.teamInvitationExpiry();
+    const invitationTeam = invitationType === "email"
+      ? (await this.store.listTeams(session.user_id)).find((team) => team.id === teamID)
+      : null;
+    if (invitationType === "email" && !invitationTeam) throw new Error("team_not_found");
     const outboxEnvelope = invitationType === "email" ? encryptOutboxPayload(
       {
         recipient: email,
         token,
         teamID,
+        teamName: invitationTeam.name,
+        invitedBy: session.username,
         role,
         expiresAt: expiresAt.toISOString(),
       },

--- a/cloud/tests/mailer.test.mjs
+++ b/cloud/tests/mailer.test.mjs
@@ -89,6 +89,8 @@ test("Team invitation mail carries one opaque fragment token and bounded metadat
     recipient: "member@example.com",
     token: "opaque-team-token",
     teamID: "84f6c860-0d26-4ef5-8652-27cb8b991b70",
+    teamName: "Operations & Security",
+    invitedBy: "owner.name",
     role: "viewer",
     expiresAt: "2030-01-03T00:00:00.000Z",
   });
@@ -96,10 +98,14 @@ test("Team invitation mail carries one opaque fragment token and bounded metadat
   assert.equal(message.to, "member@example.com");
   assert.match(message.subject, /Приглашение в команду/);
   assert.match(message.text, /#accept-team-invitation\?token=opaque-team-token/);
-  assert.match(message.text, /Роль: viewer/);
+  assert.match(message.text, /Роль: Наблюдатель/);
   assert.match(message.html, /Принять приглашение/);
-  assert.match(message.html, /viewer/);
-  assert.match(message.html, /84f6c860-0d26-4ef5-8652-27cb8b991b70/);
+  assert.match(message.subject, /Operations & Security/);
+  assert.match(message.html, /Operations &amp; Security/);
+  assert.match(message.html, /Наблюдатель/);
+  assert.match(message.html, /@owner\.name/);
+  assert.match(message.html, /3 января 2030 г\. в 00:00 UTC/);
+  assert.doesNotMatch(message.html, /84f6c860-0d26-4ef5-8652-27cb8b991b70/);
   assert.equal(message.disableFileAccess, true);
   assert.equal(message.disableUrlAccess, true);
 });

--- a/cloud/tests/team-service.test.mjs
+++ b/cloud/tests/team-service.test.mjs
@@ -10,6 +10,7 @@ const session = {
   user_id: "user-1",
   device_id: deviceID,
   email: "owner@example.com",
+  username: "owner.name",
 };
 const config = {
   publicOrigin: "https://cloud.example.invalid",
@@ -335,7 +336,7 @@ test("legacy email invitation API persists only a hash and encrypted durable out
     { email: " MEMBER@Example.com ", role: "editor" },
     "request:team-invite-01",
   );
-  const stored = store.calls[0][1];
+  const stored = store.calls.find(([name]) => name === "createTeamInvitation")[1];
 
   assert.match(stored.tokenHash, /^[0-9a-f]{64}$/);
   assert.equal(JSON.stringify(stored).includes("token\":"), false);
@@ -346,6 +347,8 @@ test("legacy email invitation API persists only a hash and encrypted durable out
   assert.equal(response.invitation.acceptanceURL, null);
   assert.equal(await service.dispatchTeamInvitationOutbox(), true);
   assert.equal(delivered.recipient, "member@example.com");
+  assert.equal(delivered.teamName, "Operations");
+  assert.equal(delivered.invitedBy, "owner.name");
   assert.ok(delivered.token.length >= 40);
   assert.equal(store.calls.at(-1)[0], "completeTeamInvitationOutbox");
 });


### PR DESCRIPTION
## Что изменено
- email-приглашение показывает название команды вместо UUID
- добавлен `@логин` пригласившего пользователя
- роли отображаются понятными русскими названиями
- срок действия форматируется как читаемая UTC-дата
- динамические значения по-прежнему HTML-экранируются
- одноразовый токен остаётся во fragment URL

## Проверка
- `cd cloud && npm test`
- 283 passed, 1 PostgreSQL integration skipped