### PR TITLE
macOS: sync Personal Vault credentials automatically

### DIFF
--- a/Sources/SelectiveRemote/CloudPersonalVaultAutoSync.swift
+++ b/Sources/SelectiveRemote/CloudPersonalVaultAutoSync.swift
@@ -122,7 +122,8 @@ struct SelectiveRemotePersonalVaultAccountEnrollment {
         password: String,
         profiles: [ConnectionProfile],
         snippets: [TerminalCommandTemplate],
-        forwarding: [IndependentPortForward]
+        forwarding: [IndependentPortForward],
+        credentials: [SelectiveRemotePersonalVaultCredentialInput] = []
     ) async throws -> Int {
         let passphrase = try SelectiveRemotePersonalVaultCrypto.accountPassphrase(password)
         let remote = try await client.personalVault(endpoint: endpoint)
@@ -130,7 +131,7 @@ struct SelectiveRemotePersonalVaultAccountEnrollment {
         if remote.revision == 0 {
             let exported = try SelectiveRemotePersonalVaultExporter.makeExport(
                 profiles: profiles,
-                credentials: [],
+                credentials: credentials,
                 snippets: snippets,
                 forwarding: forwarding,
                 deviceID: deviceID,
@@ -223,7 +224,10 @@ actor SelectiveRemotePersonalVaultAutoSync {
         else { return }
         let exported = try SelectiveRemotePersonalVaultExporter.makeExport(
             profiles: profiles,
-            credentials: [],
+            credentials: try await SelectiveRemotePersonalVaultCredentialCollector.shared.collect(
+                profiles: profiles,
+                forwarding: forwarding
+            ),
             snippets: snippets,
             forwarding: forwarding,
             deviceID: deviceID,
@@ -266,8 +270,11 @@ actor SelectiveRemotePersonalVaultAutoSync {
             throw SelectiveRemotePersonalVaultError.invalidEnvelope
         }
         let current = try SelectiveRemotePersonalVaultCrypto.open(envelope, vaultKey: vaultKey)
+        let localCredentialIDs = Set(local.records.lazy.filter { $0.type == .credential }.map(\.id))
         let credentials = current.records.filter {
-            $0.type == .credential && credentialSourceID($0).map(profileIDs.contains) == true
+            $0.type == .credential
+                && !localCredentialIDs.contains($0.id)
+                && credentialSourceID($0).map(profileIDs.contains) == true
         }
         return try .init(
             records: local.records + credentials,

--- a/Sources/SelectiveRemote/CloudPersonalVaultCredentials.swift
+++ b/Sources/SelectiveRemote/CloudPersonalVaultCredentials.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+actor SelectiveRemotePersonalVaultCredentialCollector {
+    static let shared = SelectiveRemotePersonalVaultCredentialCollector()
+    private var authorizedForSession = false
+
+    func collect(
+        profiles: [ConnectionProfile],
+        forwarding: [IndependentPortForward]
+    ) async throws -> [SelectiveRemotePersonalVaultCredentialInput] {
+        if !authorizedForSession {
+            try await KeychainService.authenticateDeviceOwner(reason: UpdateLocalization.text(
+                ru: "Разрешить Selective Remote синхронизировать сохранённые пароли через зашифрованный Personal Vault",
+                en: "Allow Selective Remote to sync saved passwords through the encrypted Personal Vault"
+            ))
+            authorizedForSession = true
+        }
+        var result: [SelectiveRemotePersonalVaultCredentialInput] = []
+        for profile in profiles {
+            switch profile.connectionType {
+            case .rdp:
+                try append(&result, sourceID: profile.id, kind: .rdp, title: "\(profile.friendlyName) · RDP", username: profile.username)
+                if !profile.gatewayHost.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    try append(&result, sourceID: profile.id, kind: .gateway, title: "\(profile.friendlyName) · Gateway", username: profile.gatewayUsername)
+                }
+            case .ssh, .telnet:
+                try append(&result, sourceID: profile.id, kind: .ssh, title: "\(profile.friendlyName) · \(profile.connectionType.title)", username: profile.username)
+                if profile.sshProxyMode != .none {
+                    try append(&result, sourceID: profile.id, kind: .proxy, title: "\(profile.friendlyName) · Proxy", username: profile.sshProxyUsername)
+                }
+            case .serial:
+                break
+            }
+        }
+        for item in forwarding {
+            try append(&result, sourceID: item.id, kind: .forwarding, title: "\(item.rule.displayName) · Forwarding", username: item.connection.username)
+        }
+        return result
+    }
+
+    private func append(
+        _ values: inout [SelectiveRemotePersonalVaultCredentialInput],
+        sourceID: UUID,
+        kind: KeychainCredentialKind,
+        title: String,
+        username: String
+    ) throws {
+        guard let secret = try KeychainService.readPassword(profileID: sourceID, kind: kind), !secret.isEmpty else { return }
+        values.append(.init(sourceID: sourceID, kind: kind, title: title, username: username, secret: secret))
+    }
+}

--- a/Sources/SelectiveRemote/CloudSettingsView.swift
+++ b/Sources/SelectiveRemote/CloudSettingsView.swift
@@ -8,6 +8,8 @@ struct CloudSettingsView: View {
     private var endpoint = SelectiveRemoteCloudEndpoint.production
     @AppStorage("SelectiveRemote.cloud.device-id.v1")
     private var storedDeviceID = ""
+    @AppStorage("SelectiveRemote.cloud.personal-vault-sync-enabled.v1")
+    private var personalVaultSyncEnabled = true
 
     @State private var phase = Phase.idle
     @State private var metadata: SelectiveRemoteCloudMetadata?
@@ -201,19 +203,13 @@ struct CloudSettingsView: View {
                             .foregroundStyle(personalVaultAutoSyncConfigured ? Color.green : Color.secondary)
                     }
 
-                    Button(
+                    Toggle(
                         UpdateLocalization.text(
-                            ru: "Настроить защищённую синхронизацию…",
-                            en: "Set Up Secure Sync…"
+                            ru: "Синхронизировать Personal Vault",
+                            en: "Sync Personal Vault"
                         ),
-                        systemImage: "lock.doc.fill"
-                    ) {
-                        personalVaultMessage = nil
-                        personalVaultMessageIsError = false
-                        showsPersonalVaultUpload = true
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(personalVaultUploading || personalVaultRevision != 0)
+                        isOn: $personalVaultSyncEnabled
+                    )
 
                     if let personalVaultMessage {
                         Label(
@@ -235,8 +231,8 @@ struct CloudSettingsView: View {
                     }
 
                     Text(UpdateLocalization.text(
-                        ru: "Настройка выполняется один раз для пустого Cloud Vault. Затем Hosts, Snippets и Forwarding синхронизируются автоматически. Recovery-фраза и открытые данные не сохраняются на сервере; конфликты никогда не перезаписываются молча.",
-                        en: "Setup runs once for an empty Cloud Vault. Hosts, Snippets and Forwarding then sync automatically. The recovery phrase and plaintext are never stored on the server, and conflicts are never overwritten silently."
+                        ru: "После входа Hosts, Snippets, Forwarding и сохранённые пароли синхронизируются автоматически. Keychain подтверждается один раз за сеанс; в Cloud хранится только E2EE-шифротекст.",
+                        en: "After sign-in, Hosts, Snippets, Forwarding, and saved passwords sync automatically. Keychain access is confirmed once per session; Cloud stores only E2EE ciphertext."
                     ))
                     .font(.caption2)
                     .foregroundStyle(.secondary)
@@ -306,9 +302,6 @@ struct CloudSettingsView: View {
         }
         .sheet(isPresented: $showsConflictReview) {
             conflictReviewSheet
-        }
-        .sheet(isPresented: $showsPersonalVaultUpload) {
-            personalVaultUploadSheet
         }
         .sheet(isPresented: $showsTeamManagement) {
             if let url = try? SelectiveRemoteCloudEndpoint.normalized(endpoint) {
@@ -512,13 +505,20 @@ struct CloudSettingsView: View {
                     keyStore: personalVaultKeyStore
                 )
                 do {
+                    let credentials = personalVaultSyncEnabled
+                        ? try await SelectiveRemotePersonalVaultCredentialCollector.shared.collect(
+                            profiles: model.profiles,
+                            forwarding: model.independentPortForwards
+                        )
+                        : []
                     _ = try await enrollment.enrollOrCreate(
                         endpoint: url,
                         deviceID: deviceID,
                         password: password,
                         profiles: model.profiles,
                         snippets: TerminalCommandHistoryStore.shared.templates(),
-                        forwarding: model.independentPortForwards
+                        forwarding: model.independentPortForwards,
+                        credentials: credentials
                     )
                 } catch {
                     enrollmentError = error.localizedDescription

--- a/Sources/SelectiveRemote/SelectiveRemoteApp.swift
+++ b/Sources/SelectiveRemote/SelectiveRemoteApp.swift
@@ -412,6 +412,9 @@ struct SelectiveRemoteApp: App {
     }
 
     private func schedulePersonalVaultAutoSync() {
+        guard UserDefaults.standard.object(
+            forKey: "SelectiveRemote.cloud.personal-vault-sync-enabled.v1"
+        ) as? Bool ?? true else { return }
         guard let endpointText = UserDefaults.standard.string(forKey: "SelectiveRemote.cloud.endpoint.v1"),
               let endpoint = try? SelectiveRemoteCloudEndpoint.normalized(endpointText),
               let deviceText = UserDefaults.standard.string(forKey: "SelectiveRemote.cloud.device-id.v1"),


### PR DESCRIPTION
## Что изменено
- Personal Vault включён по умолчанию после входа в Cloud
- сохранённые RDP, Gateway, SSH, Proxy и Forwarding-пароли входят в первую и последующие E2EE-ревизии
- macOS подтверждает доступ к Keychain один раз за сеанс приложения, а не для каждого хоста
- добавлен глобальный переключатель синхронизации без удаления серверного шифротекста
- ручной Recovery-flow убран из доступного интерфейса
- устранено дублирование credential-записей при безопасном объединении

## Границы этого PR
Приватные файлы SSH-ключей и постоянное входящее применение Cloud-изменений будут добавлены следующим PR. Старый staging Vault до этого не сбрасываем.

## Проверка
Локальная среда не содержит Swift toolchain; обязательная проверка выполняется GitHub CI и Test DMG.