### PR TITLE
Cloud: persist browser sessions securely

### DIFF
--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -2229,8 +2229,23 @@ export async function initializeCloudAccount({
     }
   });
 
-  showSession(null);
   setAuthMode("login");
+  try {
+    const restoredUser = await client.restoreSession();
+    showSession(restoredUser);
+    let identity = null;
+    try {
+      identity = await ensureTeamDeviceIdentity({ repository: teamDeviceRepository, deviceID: client.deviceID() });
+      await teamWorkspace?.activate(identity);
+    } catch {
+      // A valid account session remains usable when this browser has no approved Team key.
+    }
+    setAccountMessage(identity
+      ? "Сессия восстановлена. Team-раздел готов к работе."
+      : "Сессия восстановлена. Для Team Vault может потребоваться одобрение устройства.", "success");
+  } catch {
+    showSession(null);
+  }
   return { client, showAuth: setAuthMode, teamWorkspace };
 }
 
@@ -2543,6 +2558,7 @@ export async function initializePortal({
     teamUI: account?.teamWorkspace,
     showAuthMode: account?.showAuth,
   });
+  navigation?.sessionChanged(account?.client.session());
   if (teamInvitation.present) {
     navigation?.showAuthentication("login", { replace: true });
     const accountMessage = documentValue.querySelector("#cloud-account-message");

--- a/cloud/public/vault-sync.js
+++ b/cloud/public/vault-sync.js
@@ -398,17 +398,16 @@ export function createAuthenticatedVaultClient({ fetchValue = globalThis.fetch }
   let currentDeviceID = null;
 
   async function authorizedRequest(path, options = {}) {
-    if (!token) throw new Error("authentication_required");
     const response = await fetchValue(path, {
       ...options,
       headers: {
         ...(options.headers ?? {}),
         Accept: "application/json",
-        Authorization: `Bearer ${token}`,
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
         ...(options.body ? { "Content-Type": "application/json" } : {}),
       },
       cache: "no-store",
-      credentials: "omit",
+      credentials: "same-origin",
       referrerPolicy: "no-referrer",
     });
     if (response.status === 401) {
@@ -496,7 +495,7 @@ export function createAuthenticatedVaultClient({ fetchValue = globalThis.fetch }
           },
         }),
         cache: "no-store",
-        credentials: "omit",
+        credentials: "same-origin",
         referrerPolicy: "no-referrer",
       });
       const result = await responseJSON(response, "login_failed");
@@ -523,6 +522,23 @@ export function createAuthenticatedVaultClient({ fetchValue = globalThis.fetch }
       return structuredClone(user);
     },
 
+    async restoreSession() {
+      const response = await authorizedRequest("/v1/me");
+      if (!response.ok) throw new Error("authentication_required");
+      const result = await responseJSON(response, "authentication_required");
+      if (!uuidPattern.test(String(result.id ?? "")) || !uuidPattern.test(String(result.deviceID ?? ""))) {
+        throw new Error("authentication_required");
+      }
+      currentDeviceID = String(result.deviceID).toLowerCase();
+      user = {
+        id: String(result.id).toLowerCase(),
+        email: String(result.email ?? ""),
+        username: String(result.username ?? ""),
+        displayName: String(result.displayName ?? ""),
+      };
+      return structuredClone(user);
+    },
+
     session() {
       return user ? structuredClone(user) : null;
     },
@@ -532,7 +548,6 @@ export function createAuthenticatedVaultClient({ fetchValue = globalThis.fetch }
     },
 
     async logout() {
-      if (!token) return;
       try {
         await authorizedRequest("/v1/auth/logout", { method: "POST" });
       } finally {

--- a/cloud/src/server.mjs
+++ b/cloud/src/server.mjs
@@ -19,6 +19,7 @@ const authRateLimiter = new AuthRateLimiter(store, config);
 const publicDirectory = fileURLToPath(new URL("../public/", import.meta.url));
 const maxBodyBytes = 34 * 1024 * 1024;
 const maxTeamBodyBytes = 16 * 1024;
+const browserSessionCookie = "sr_session";
 
 const server = createServer(async (request, response) => {
   const requestID = crypto.randomUUID();
@@ -50,7 +51,10 @@ async function route(request, response) {
     return handleAuthOperation(request, response, "register_ip", "register_email", service.register.bind(service), 201);
   }
   if (method === "POST" && url.pathname === "/v1/auth/login") {
-    return handleAuthOperation(request, response, "login_ip", "login_email", service.login.bind(service));
+    return handleAuthOperation(
+      request, response, "login_ip", "login_email", service.login.bind(service), 200,
+      (result) => setBrowserSessionCookie(response, result.token),
+    );
   }
   if (method === "POST" && url.pathname === "/v1/auth/verify-email") {
     return handleAuthOperation(request, response, "verify_email_ip", null, service.verifyEmail.bind(service));
@@ -80,10 +84,19 @@ async function route(request, response) {
   }
 
   if (url.pathname.startsWith("/v1/")) {
-    const session = await service.authenticate(bearerToken(request));
-    if (!session) return sendError(response, 401, "unauthorized");
+    const bearer = bearerToken(request);
+    const cookie = bearer ? null : cookieToken(request);
+    if (cookie && !["GET", "HEAD"].includes(method) && !hasTrustedOrigin(request)) {
+      return sendError(response, 403, "invalid_origin");
+    }
+    const session = await service.authenticate(bearer ?? cookie);
+    if (!session) {
+      if (cookie) clearBrowserSessionCookie(response);
+      return sendError(response, 401, "unauthorized");
+    }
     if (method === "POST" && url.pathname === "/v1/auth/logout") {
       await store.revokeSession(session.session_id);
+      clearBrowserSessionCookie(response);
       return empty(response, 204);
     }
     if (method === "GET" && url.pathname === "/v1/me") {
@@ -98,7 +111,11 @@ async function route(request, response) {
     if (method === "DELETE" && url.pathname === "/v1/me") {
       return handleOperation(
         response,
-        async () => service.deleteAccount(session, await readJSON(request, maxTeamBodyBytes)),
+        async () => {
+          const result = await service.deleteAccount(session, await readJSON(request, maxTeamBodyBytes));
+          clearBrowserSessionCookie(response);
+          return result;
+        },
       );
     }
     if (method === "GET" && url.pathname === "/v1/devices") {
@@ -383,7 +400,7 @@ async function requireTeamSensitiveRateLimits(request, session) {
   await authRateLimiter.require("team_sensitive_ip", clientIPAddress(request, config.proxySharedSecret));
 }
 
-async function handleAuthOperation(request, response, ipScope, emailScope, operation, successStatus = 200) {
+async function handleAuthOperation(request, response, ipScope, emailScope, operation, successStatus = 200, beforeSend = null) {
   return handleOperation(response, async () => {
     await authRateLimiter.require(ipScope, clientIPAddress(request, config.proxySharedSecret));
     const input = await readJSON(request);
@@ -392,7 +409,9 @@ async function handleAuthOperation(request, response, ipScope, emailScope, opera
       try { email = normalizeEmail(input.email); } catch {}
       if (email) await authRateLimiter.require(emailScope, email);
     }
-    return operation(input);
+    const result = await operation(input);
+    beforeSend?.(result);
+    return result;
   }, successStatus);
 }
 
@@ -416,6 +435,35 @@ function handleOperationError(response, error) {
 function bearerToken(request) {
   const value = request.headers.authorization ?? "";
   return value.startsWith("Bearer ") ? value.slice(7) : null;
+}
+
+function cookieToken(request) {
+  const value = request.headers.cookie ?? "";
+  for (const part of value.split(";")) {
+    const separator = part.indexOf("=");
+    if (separator < 0 || part.slice(0, separator).trim() !== browserSessionCookie) continue;
+    const token = part.slice(separator + 1).trim();
+    return token.length >= 32 && token.length <= 256 ? token : null;
+  }
+  return null;
+}
+
+function sessionCookie(value, maximumAge) {
+  const secure = new URL(config.publicOrigin).protocol === "https:" ? "; Secure" : "";
+  return `${browserSessionCookie}=${value}; Path=/; HttpOnly; SameSite=Strict; Max-Age=${maximumAge}${secure}`;
+}
+
+function setBrowserSessionCookie(response, token) {
+  response.setHeader("Set-Cookie", sessionCookie(token, config.sessionTTLDays * 86_400));
+}
+
+function clearBrowserSessionCookie(response) {
+  response.setHeader("Set-Cookie", sessionCookie("", 0));
+}
+
+function hasTrustedOrigin(request) {
+  const origin = Array.isArray(request.headers.origin) ? request.headers.origin[0] : request.headers.origin;
+  return origin === config.publicOrigin;
 }
 
 function idempotencyKey(request) {

--- a/cloud/tests/public-auth.test.mjs
+++ b/cloud/tests/public-auth.test.mjs
@@ -96,4 +96,7 @@ test("portal exposes visible login and registration modes and never promises ema
   assert.match(html, /Пароли по почте не отправляются/u);
   assert.doesNotMatch(html, /отправим[^<]*(?:логин|пароль)/iu);
   assert.match(server, /\["\.html", "\.js", "\.css"\][^\n]*"no-cache"/u);
+  assert.match(server, /HttpOnly; SameSite=Strict/u);
+  assert.match(server, /cookie && !\["GET", "HEAD"\]\.includes\(method\) && !hasTrustedOrigin\(request\)/u);
+  assert.match(server, /origin === config\.publicOrigin/u);
 });

--- a/cloud/tests/public-team-vault-client.test.mjs
+++ b/cloud/tests/public-team-vault-client.test.mjs
@@ -151,7 +151,7 @@ test("account device transport normalizes approval metadata and revokes without 
   const revoke = calls.at(-1);
   assert.equal(revoke.options.method, "DELETE");
   assert.match(revoke.options.headers.Authorization, /^Bearer /u);
-  assert.equal(revoke.options.credentials, "omit");
+  assert.equal(revoke.options.credentials, "same-origin");
 });
 
 test("Team writes carry idempotency and distinguish conflict from committed rotation", async () => {
@@ -232,7 +232,7 @@ test("Team writes carry idempotency and distinguish conflict from committed rota
 
   for (const call of calls.filter((value) => value.options.method && value.path !== "/v1/auth/login")) {
     assert.match(call.options.headers["Idempotency-Key"], /^request:/u);
-    assert.equal(call.options.credentials, "omit");
+    assert.equal(call.options.credentials, "same-origin");
   }
 });
 

--- a/cloud/tests/public-vault-sync.test.mjs
+++ b/cloud/tests/public-vault-sync.test.mjs
@@ -99,9 +99,27 @@ test("authenticated client keeps its bearer token in memory and uses only the pe
 
   await client.putVault(personalVaultScope, envelope);
   assert.equal(calls[1].options.headers.Authorization, `Bearer ${token}`);
-  assert.equal(calls[1].options.credentials, "omit");
+  assert.equal(calls[1].options.credentials, "same-origin");
   await client.logout();
   assert.equal(client.session(), null);
+});
+
+test("browser session restores from an HttpOnly cookie without a JavaScript token", async () => {
+  const calls = [];
+  const client = createAuthenticatedVaultClient({ fetchValue: async (path, options = {}) => {
+    calls.push({ path, options });
+    return jsonResponse(200, {
+      id: userID, email: "user@example.invalid", username: "user", displayName: "User", deviceID: deviceA,
+    });
+  } });
+
+  assert.deepEqual(await client.restoreSession(), {
+    id: userID, email: "user@example.invalid", username: "user", displayName: "User",
+  });
+  assert.equal(client.deviceID(), deviceA);
+  assert.equal(calls[0].path, "/v1/me");
+  assert.equal(calls[0].options.credentials, "same-origin");
+  assert.equal("Authorization" in calls[0].options.headers, false);
 });
 
 test("a 401 response clears the in-memory browser session", async () => {

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -332,7 +332,7 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(application, /recoveryPassphrase/u);
   assert.doesNotMatch(`${application}\n${synchronization}\n${teamSynchronization}`, /localStorage|sessionStorage/u);
   assert.match(synchronization, /unsupported_vault_scope/u);
-  assert.match(synchronization, /credentials: "omit"/u);
+  assert.match(synchronization, /credentials: "same-origin"/u);
   assert.match(teamSynchronization, /team_vault_rotation_required/u);
   assert.match(teamSynchronization, /prepareInitialization/u);
 });


### PR DESCRIPTION
## Что изменено
- login устанавливает ограниченную сессию в `HttpOnly; SameSite=Strict` cookie; в production добавляется `Secure`
- Bearer-токены macOS/API остаются совместимыми
- после F5 web-клиент восстанавливает аккаунт через `GET /v1/me`
- cookie-аутентифицированные изменяющие запросы требуют точного trusted Origin
- logout, удаление аккаунта и просроченная сессия очищают cookie
- добавлены регрессионные проверки восстановления и защитных атрибутов

## Проверка
- `cd cloud && npm test`: 284 passed, 1 skipped
- Node syntax checks и `git diff --check`
