### PR TITLE
macOS: add inbound Personal Vault autosync

### DIFF
--- a/Sources/SelectiveRemote/CloudPersonalVaultAutoSync.swift
+++ b/Sources/SelectiveRemote/CloudPersonalVaultAutoSync.swift
@@ -184,6 +184,12 @@ actor SelectiveRemotePersonalVaultAutoSync {
     private let keyStore: any SelectiveRemotePersonalVaultKeyStore
     private var pending: Task<Void, Never>?
 
+    struct Download: Sendable {
+        let document: SelectiveRemoteVaultDocument
+        let revision: Int
+        let documentHash: Data
+    }
+
     init(
         client: SelectiveRemoteCloudAPIClient = .init(),
         keyStore: any SelectiveRemotePersonalVaultKeyStore = SelectiveRemotePersonalVaultKeychainStore()
@@ -215,6 +221,36 @@ actor SelectiveRemotePersonalVaultAutoSync {
         }
     }
 
+    func downloadIfNewer(endpoint: URL, deviceID: UUID) async throws -> Download? {
+        guard let material = try keyStore.material(endpoint: endpoint, deviceID: deviceID),
+              material.allowsUpload,
+              await client.hasStoredSession(endpoint: endpoint)
+        else { return nil }
+        let remote = try await client.personalVault(endpoint: endpoint)
+        guard remote.id == material.vaultID, remote.revision > material.revision,
+              let envelope = remote.envelope
+        else { return nil }
+        let document = try SelectiveRemotePersonalVaultCrypto.open(
+            envelope,
+            vaultKey: material.vaultKey
+        )
+        return Download(
+            document: document,
+            revision: remote.revision,
+            documentHash: Data(SHA256.hash(data: try document.encoded()))
+        )
+    }
+
+    func acceptDownload(_ download: Download, endpoint: URL, deviceID: UUID) throws {
+        guard var material = try keyStore.material(endpoint: endpoint, deviceID: deviceID),
+              download.revision > material.revision
+        else { return }
+        material.revision = download.revision
+        material.documentHash = download.documentHash
+        material.requiresInitialDownload = false
+        try keyStore.save(material, endpoint: endpoint, deviceID: deviceID)
+    }
+
     private func synchronize(
         endpoint: URL,
         deviceID: UUID,
@@ -240,15 +276,18 @@ actor SelectiveRemotePersonalVaultAutoSync {
             allowEmpty: true
         )
         let remote = try await client.personalVault(endpoint: endpoint)
-        guard remote.id == material.vaultID, remote.revision == material.revision else {
+        guard remote.id == material.vaultID else {
             throw SelectiveRemotePersonalVaultError.uploadConflict(remote.revision)
         }
-        let document = try mergedDocument(
-            local: exported.document,
-            remote: remote,
-            vaultKey: material.vaultKey,
-            profileIDs: Set(profiles.map(\.id))
-        )
+        let concurrentChange = remote.revision != material.revision
+        let document = concurrentChange
+            ? try mergeConcurrent(local: exported.document, remote: remote, vaultKey: material.vaultKey)
+            : try mergedDocument(
+                local: exported.document,
+                remote: remote,
+                vaultKey: material.vaultKey,
+                profileIDs: Set(profiles.map(\.id))
+            )
         let documentHash = Data(SHA256.hash(data: try document.encoded()))
         guard documentHash != material.documentHash else { return }
         let envelope = try SelectiveRemotePersonalVaultCrypto.reseal(
@@ -261,9 +300,42 @@ actor SelectiveRemotePersonalVaultAutoSync {
         guard !result.conflict, result.revision == remote.revision + 1 else {
             throw SelectiveRemotePersonalVaultError.uploadConflict(result.revision)
         }
+        // Keep the previous revision after a concurrent merge. The inbound loop
+        // then materializes that exact merged revision on this Mac as well.
+        if concurrentChange { return }
         material.revision = result.revision
         material.documentHash = documentHash
         try keyStore.save(material, endpoint: endpoint, deviceID: deviceID)
+    }
+
+    private func mergeConcurrent(
+        local: SelectiveRemoteVaultDocument,
+        remote: SelectiveRemoteCloudPersonalVault,
+        vaultKey: Data
+    ) throws -> SelectiveRemoteVaultDocument {
+        guard let envelope = remote.envelope else {
+            throw SelectiveRemotePersonalVaultError.invalidEnvelope
+        }
+        let current = try SelectiveRemotePersonalVaultCrypto.open(envelope, vaultKey: vaultKey)
+        var records = Dictionary(uniqueKeysWithValues: current.records.map { ($0.id, $0) })
+        for record in local.records {
+            if let existing = records[record.id], existing.modifiedAt > record.modifiedAt { continue }
+            records[record.id] = record
+        }
+        var tombstones = Dictionary(uniqueKeysWithValues: current.tombstones.map { ($0.id, $0) })
+        for tombstone in local.tombstones {
+            if let existing = tombstones[tombstone.id], existing.deletedAt > tombstone.deletedAt { continue }
+            tombstones[tombstone.id] = tombstone
+        }
+        for (id, tombstone) in tombstones {
+            if let record = records[id], tombstone.deletedAt >= record.modifiedAt {
+                records.removeValue(forKey: id)
+            }
+        }
+        return try .init(
+            records: records.values.sorted { $0.id.uuidString < $1.id.uuidString },
+            tombstones: tombstones.values.sorted { $0.id.uuidString < $1.id.uuidString }
+        )
     }
 
     private func mergedDocument(

--- a/Sources/SelectiveRemote/SelectiveRemoteApp.swift
+++ b/Sources/SelectiveRemote/SelectiveRemoteApp.swift
@@ -159,6 +159,9 @@ struct SelectiveRemoteApp: App {
                         schedulePersonalVaultAutoSync()
                         updateTeamVaultAutoSync()
                     }
+                    .task {
+                        await runPersonalVaultInboundSyncLoop()
+                    }
                     .onChange(of: model.profiles) { _, _ in schedulePersonalVaultAutoSync() }
                     .onChange(of: model.independentPortForwards) { _, _ in schedulePersonalVaultAutoSync() }
                     .onChange(of: model.sshKeys) { _, _ in schedulePersonalVaultAutoSync() }
@@ -434,6 +437,55 @@ struct SelectiveRemoteApp: App {
                 forwarding: forwarding,
                 sshKeys: sshKeys
             )
+        }
+    }
+
+    @MainActor
+    private func runPersonalVaultInboundSyncLoop() async {
+        while !Task.isCancelled {
+            if UserDefaults.standard.object(
+                forKey: "SelectiveRemote.cloud.personal-vault-sync-enabled.v1"
+            ) as? Bool ?? true {
+                await downloadPersonalVaultChanges()
+            }
+            do { try await Task.sleep(for: .seconds(15)) }
+            catch { return }
+        }
+    }
+
+    @MainActor
+    private func downloadPersonalVaultChanges() async {
+        guard !appLock.isLocked,
+              let endpointText = UserDefaults.standard.string(
+                  forKey: "SelectiveRemote.cloud.endpoint.v1"
+              ),
+              let endpoint = try? SelectiveRemoteCloudEndpoint.normalized(endpointText),
+              let deviceText = UserDefaults.standard.string(
+                  forKey: "SelectiveRemote.cloud.device-id.v1"
+              ),
+              let deviceID = UUID(uuidString: deviceText), deviceID.isSelectiveRemoteCloudUUID
+        else { return }
+        do {
+            guard let download = try await personalVaultAutoSync.downloadIfNewer(
+                endpoint: endpoint,
+                deviceID: deviceID
+            ) else { return }
+            let snapshot = try SelectiveRemotePersonalVaultImporter.decode(download.document)
+            let restoredKeys = try SelectiveRemotePersonalVaultSSHKeyStore.install(snapshot.sshKeys)
+            try KeychainService.savePasswords(snapshot.credentials)
+            try await personalVaultAutoSync.acceptDownload(
+                download,
+                endpoint: endpoint,
+                deviceID: deviceID
+            )
+            if model.profiles != snapshot.profiles { model.profiles = snapshot.profiles }
+            if model.independentPortForwards != snapshot.forwarding {
+                model.independentPortForwards = snapshot.forwarding
+            }
+            if model.sshKeys != restoredKeys { model.sshKeys = restoredKeys }
+            TerminalCommandHistoryStore.shared.replaceSyncedTemplates(snapshot.snippets)
+        } catch {
+            // Keep local data untouched and retry after the polling interval.
         }
     }
 }

--- a/Sources/SelectiveRemote/TerminalCommandHistory.swift
+++ b/Sources/SelectiveRemote/TerminalCommandHistory.swift
@@ -399,6 +399,14 @@ final class TerminalCommandHistoryStore: ObservableObject {
         persistTemplates()
     }
 
+    func replaceSyncedTemplates(_ values: [TerminalCommandTemplate]) {
+        let internalTemplates = storedTemplates.filter(isInternalTemplate)
+        let replacement = Array(values.prefix(500 - internalTemplates.count))
+        guard templates() != replacement.sorted(by: { $0.updatedAt > $1.updatedAt }) else { return }
+        storedTemplates = internalTemplates + replacement
+        persistTemplates()
+    }
+
     func templates(in groupID: UUID) -> [TerminalCommandTemplate] {
         templates().filter { $0.groupID == groupID }
     }

--- a/Sources/SelectiveRemote/TerminalCommandHistory.swift
+++ b/Sources/SelectiveRemote/TerminalCommandHistory.swift
@@ -400,7 +400,7 @@ final class TerminalCommandHistoryStore: ObservableObject {
     }
 
     func replaceSyncedTemplates(_ values: [TerminalCommandTemplate]) {
-        let internalTemplates = storedTemplates.filter(isInternalTemplate)
+        let internalTemplates = storedTemplates.filter { isInternalTemplate($0) }
         let replacement = Array(values.prefix(500 - internalTemplates.count))
         guard templates() != replacement.sorted(by: { $0.updatedAt > $1.updatedAt }) else { return }
         storedTemplates = internalTemplates + replacement

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -444,10 +444,12 @@ test("macOS Cloud session and Team device key share one Keychain envelope", asyn
 
 
 test("macOS Personal Vault auto-sync preserves encrypted credentials without extra Keychain items", async () => {
-  const [sync, crypto, settings] = await Promise.all([
+  const [sync, crypto, settings, app, snippets] = await Promise.all([
     readFile(new URL("CloudPersonalVaultAutoSync.swift", sourceRoot), "utf8"),
     readFile(new URL("CloudPersonalVaultSync.swift", sourceRoot), "utf8"),
     readFile(new URL("CloudSettingsView.swift", sourceRoot), "utf8"),
+    readFile(new URL("SelectiveRemoteApp.swift", sourceRoot), "utf8"),
+    readFile(new URL("TerminalCommandHistory.swift", sourceRoot), "utf8"),
   ]);
   assert.doesNotMatch(sync, /!material\.includesCredentials/u);
   assert.match(sync, /SelectiveRemotePersonalVaultCrypto\.open/u);
@@ -458,4 +460,15 @@ test("macOS Personal Vault auto-sync preserves encrypted credentials without ext
   assert.match(crypto, /static func open\(/u);
   assert.match(settings, /personalVaultAutoSyncConfigured = true/u);
   assert.doesNotMatch(settings, /Background sync is disabled/u);
+  assert.match(sync, /func downloadIfNewer\(/u);
+  assert.match(sync, /remote\.revision > material\.revision/u);
+  assert.match(sync, /func acceptDownload\(/u);
+  assert.match(sync, /func mergeConcurrent\(/u);
+  assert.match(sync, /tombstone\.deletedAt >= record\.modifiedAt/u);
+  assert.match(sync, /if concurrentChange \{ return \}/u);
+  assert.match(app, /runPersonalVaultInboundSyncLoop/u);
+  assert.match(app, /Task\.sleep\(for: \.seconds\(15\)\)/u);
+  assert.match(app, /KeychainService\.savePasswords\(snapshot\.credentials\)/u);
+  assert.match(app, /SelectiveRemotePersonalVaultSSHKeyStore\.install\(snapshot\.sshKeys\)/u);
+  assert.match(snippets, /func replaceSyncedTemplates\(/u);
 });


### PR DESCRIPTION
## Что изменено
- macOS проверяет Personal Vault каждые 15 секунд, пока приложение разблокировано и синхронизация включена
- новые E2EE-ревизии автоматически применяются к Hosts, Snippets, Forwarding, credentials и SSH keys
- входящая ревизия подтверждается локально только после успешной расшифровки и сохранения
- одновременные изменения сайта и Mac объединяются детерминированно с учётом tombstones
- внутренние startup snippets сохраняются при замене синхронизируемой библиотеки

## Проверка
- `cd cloud && npm test` — green
- полный Swift build и Test DMG проверяются CI