### PR TITLE
macOS: show Personal Vault sync status

### DIFF
--- a/Sources/SelectiveRemote/CloudPersonalVaultAutoSync.swift
+++ b/Sources/SelectiveRemote/CloudPersonalVaultAutoSync.swift
@@ -2,6 +2,24 @@ import CryptoKit
 import Foundation
 import Security
 
+enum SelectiveRemotePersonalVaultSyncStatus {
+    static let lastSuccessKey = "SelectiveRemote.cloud.personal-vault-sync-last-success.v1"
+    static let revisionKey = "SelectiveRemote.cloud.personal-vault-sync-revision.v1"
+    static let errorKey = "SelectiveRemote.cloud.personal-vault-sync-error.v1"
+    static let isSyncingKey = "SelectiveRemote.cloud.personal-vault-sync-active.v1"
+
+    static func recordSuccess(revision: Int) {
+        let defaults = UserDefaults.standard
+        defaults.set(Date().timeIntervalSince1970, forKey: lastSuccessKey)
+        defaults.set(revision, forKey: revisionKey)
+        defaults.removeObject(forKey: errorKey)
+    }
+
+    static func recordError(_ error: Error) {
+        UserDefaults.standard.set(error.localizedDescription, forKey: errorKey)
+    }
+}
+
 struct SelectiveRemotePersonalVaultKeyMaterial: Codable, Equatable, Sendable {
     let vaultID: UUID
     let vaultKey: Data
@@ -227,9 +245,16 @@ actor SelectiveRemotePersonalVaultAutoSync {
               await client.hasStoredSession(endpoint: endpoint)
         else { return nil }
         let remote = try await client.personalVault(endpoint: endpoint)
-        guard remote.id == material.vaultID, remote.revision > material.revision,
-              let envelope = remote.envelope
-        else { return nil }
+        guard remote.id == material.vaultID else {
+            throw SelectiveRemotePersonalVaultError.uploadConflict(remote.revision)
+        }
+        guard remote.revision > material.revision else {
+            SelectiveRemotePersonalVaultSyncStatus.recordSuccess(revision: remote.revision)
+            return nil
+        }
+        guard let envelope = remote.envelope else {
+            throw SelectiveRemotePersonalVaultError.invalidEnvelope
+        }
         let document = try SelectiveRemotePersonalVaultCrypto.open(
             envelope,
             vaultKey: material.vaultKey
@@ -249,6 +274,7 @@ actor SelectiveRemotePersonalVaultAutoSync {
         material.documentHash = download.documentHash
         material.requiresInitialDownload = false
         try keyStore.save(material, endpoint: endpoint, deviceID: deviceID)
+        SelectiveRemotePersonalVaultSyncStatus.recordSuccess(revision: download.revision)
     }
 
     private func synchronize(
@@ -306,6 +332,7 @@ actor SelectiveRemotePersonalVaultAutoSync {
         material.revision = result.revision
         material.documentHash = documentHash
         try keyStore.save(material, endpoint: endpoint, deviceID: deviceID)
+        SelectiveRemotePersonalVaultSyncStatus.recordSuccess(revision: result.revision)
     }
 
     private func mergeConcurrent(

--- a/Sources/SelectiveRemote/CloudSettingsView.swift
+++ b/Sources/SelectiveRemote/CloudSettingsView.swift
@@ -10,6 +10,14 @@ struct CloudSettingsView: View {
     private var storedDeviceID = ""
     @AppStorage("SelectiveRemote.cloud.personal-vault-sync-enabled.v1")
     private var personalVaultSyncEnabled = true
+    @AppStorage(SelectiveRemotePersonalVaultSyncStatus.lastSuccessKey)
+    private var personalVaultLastSuccess = 0.0
+    @AppStorage(SelectiveRemotePersonalVaultSyncStatus.revisionKey)
+    private var personalVaultSyncedRevision = 0
+    @AppStorage(SelectiveRemotePersonalVaultSyncStatus.errorKey)
+    private var personalVaultSyncError = ""
+    @AppStorage(SelectiveRemotePersonalVaultSyncStatus.isSyncingKey)
+    private var personalVaultIsSyncing = false
 
     @State private var phase = Phase.idle
     @State private var metadata: SelectiveRemoteCloudMetadata?
@@ -210,6 +218,51 @@ struct CloudSettingsView: View {
                         ),
                         isOn: $personalVaultSyncEnabled
                     )
+
+                    LabeledContent(UpdateLocalization.text(
+                        ru: "Последняя синхронизация",
+                        en: "Last synchronization"
+                    )) {
+                        Text(personalVaultLastSuccessText)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if personalVaultSyncedRevision > 0 {
+                        LabeledContent(UpdateLocalization.text(
+                            ru: "Применённая ревизия",
+                            en: "Applied revision"
+                        )) {
+                            Text("r\(personalVaultSyncedRevision)")
+                                .monospacedDigit()
+                        }
+                    }
+
+                    Button(
+                        UpdateLocalization.text(
+                            ru: "Синхронизировать сейчас",
+                            en: "Synchronize Now"
+                        ),
+                        systemImage: "arrow.triangle.2.circlepath"
+                    ) {
+                        NotificationCenter.default.post(
+                            name: .selectiveRemotePersonalVaultSyncNow,
+                            object: nil
+                        )
+                    }
+                    .disabled(!personalVaultSyncEnabled || personalVaultIsSyncing)
+
+                    if personalVaultIsSyncing {
+                        Label(
+                            UpdateLocalization.text(ru: "Синхронизация…", en: "Synchronizing…"),
+                            systemImage: "arrow.triangle.2.circlepath"
+                        )
+                        .foregroundStyle(.secondary)
+                    } else if !personalVaultSyncError.isEmpty {
+                        Label(personalVaultSyncError, systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                            .font(.caption)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
 
                     if let personalVaultMessage {
                         Label(
@@ -739,6 +792,17 @@ struct CloudSettingsView: View {
         return UpdateLocalization.text(
             ru: "Hosts: \(hosts) · Snippets: \(snippets) · Forwarding: \(forwarding)",
             en: "Hosts: \(hosts) · Snippets: \(snippets) · Forwarding: \(forwarding)"
+        )
+    }
+
+    @MainActor
+    private var personalVaultLastSuccessText: String {
+        guard personalVaultLastSuccess > 0 else {
+            return UpdateLocalization.text(ru: "Ещё не выполнялась", en: "Not yet synchronized")
+        }
+        return Date(timeIntervalSince1970: personalVaultLastSuccess).formatted(
+            date: .abbreviated,
+            time: .standard
         )
     }
 

--- a/Sources/SelectiveRemote/SelectiveRemoteApp.swift
+++ b/Sources/SelectiveRemote/SelectiveRemoteApp.swift
@@ -5,6 +5,9 @@ extension Notification.Name {
     static let selectiveRemoteNewLocalTerminal = Notification.Name(
         "SelectiveRemote.newLocalTerminal"
     )
+    static let selectiveRemotePersonalVaultSyncNow = Notification.Name(
+        "SelectiveRemote.personalVaultSyncNow"
+    )
 }
 
 @MainActor
@@ -167,6 +170,15 @@ struct SelectiveRemoteApp: App {
                     .onChange(of: model.sshKeys) { _, _ in schedulePersonalVaultAutoSync() }
                     .onReceive(TerminalCommandHistoryStore.shared.$snippetRevision) { _ in
                         schedulePersonalVaultAutoSync()
+                    }
+                    .onReceive(NotificationCenter.default.publisher(
+                        for: .selectiveRemotePersonalVaultSyncNow
+                    )) { _ in
+                        schedulePersonalVaultAutoSync()
+                        Task { @MainActor in
+                            try? await Task.sleep(for: .seconds(3))
+                            await downloadPersonalVaultChanges()
+                        }
                     }
             }
             .onChange(of: appLock.isLocked) { _, _ in
@@ -465,6 +477,16 @@ struct SelectiveRemoteApp: App {
               ),
               let deviceID = UUID(uuidString: deviceText), deviceID.isSelectiveRemoteCloudUUID
         else { return }
+        UserDefaults.standard.set(
+            true,
+            forKey: SelectiveRemotePersonalVaultSyncStatus.isSyncingKey
+        )
+        defer {
+            UserDefaults.standard.set(
+                false,
+                forKey: SelectiveRemotePersonalVaultSyncStatus.isSyncingKey
+            )
+        }
         do {
             guard let download = try await personalVaultAutoSync.downloadIfNewer(
                 endpoint: endpoint,
@@ -485,7 +507,7 @@ struct SelectiveRemoteApp: App {
             if model.sshKeys != restoredKeys { model.sshKeys = restoredKeys }
             TerminalCommandHistoryStore.shared.replaceSyncedTemplates(snapshot.snippets)
         } catch {
-            // Keep local data untouched and retry after the polling interval.
+            SelectiveRemotePersonalVaultSyncStatus.recordError(error)
         }
     }
 }

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -471,4 +471,11 @@ test("macOS Personal Vault auto-sync preserves encrypted credentials without ext
   assert.match(app, /KeychainService\.savePasswords\(snapshot\.credentials\)/u);
   assert.match(app, /SelectiveRemotePersonalVaultSSHKeyStore\.install\(snapshot\.sshKeys\)/u);
   assert.match(snippets, /func replaceSyncedTemplates\(/u);
+  assert.match(sync, /enum SelectiveRemotePersonalVaultSyncStatus/u);
+  assert.match(sync, /recordSuccess\(revision:/u);
+  assert.match(sync, /recordError\(_ error:/u);
+  assert.match(app, /selectiveRemotePersonalVaultSyncNow/u);
+  assert.match(settings, /Последняя синхронизация/u);
+  assert.match(settings, /Синхронизировать сейчас/u);
+  assert.match(settings, /personalVaultSyncError/u);
 });


### PR DESCRIPTION
## Что изменено
- настройки Cloud показывают время последней успешной синхронизации и применённую ревизию
- добавлена кнопка «Синхронизировать сейчас»
- во время операции отображается активное состояние, при ошибке — понятное сообщение
- успешный pull, отсутствие новых ревизий и успешный upload обновляют единый локальный статус
- ручной запуск использует тот же E2EE-процесс и не создаёт отдельного небезопасного пути

## Проверка
- `cd cloud && npm test` — green
- Swift build и Test DMG проверяются CI