### PR TITLE
Add complete Team email invitation flow

### DIFF
--- a/Sources/SelectiveRemote/CloudAPIClient.swift
+++ b/Sources/SelectiveRemote/CloudAPIClient.swift
@@ -544,12 +544,25 @@ actor SelectiveRemoteCloudAPIClient {
         let invitation = try await createTeamInvitation(
             endpoint: endpoint,
             teamID: teamID,
-            request: TeamInvitationRequest(username: normalizedUsername, type: nil, role: role)
+            request: TeamInvitationRequest(username: normalizedUsername, email: nil, type: nil, role: role)
         )
         guard invitation.type == .username,
               invitation.targetUsername == normalizedUsername,
               invitation.acceptanceURL == nil
         else { throw SelectiveRemoteCloudError.invalidResponse }
+        return invitation
+    }
+
+    func inviteTeamMember(endpoint: URL, teamID: UUID, email: String, role: SelectiveRemoteCloudTeamRole) async throws -> SelectiveRemoteCloudTeamInvitation {
+        let normalizedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard teamID.isSelectiveRemoteCloudUUID, normalizedEmail.contains("@"), normalizedEmail.count <= 320, role != .owner else {
+            throw SelectiveRemoteCloudError.invalidRequest
+        }
+        let invitation = try await createTeamInvitation(
+            endpoint: endpoint, teamID: teamID,
+            request: TeamInvitationRequest(username: nil, email: normalizedEmail, type: "email", role: role)
+        )
+        guard invitation.type == .email, invitation.acceptanceURL == nil else { throw SelectiveRemoteCloudError.invalidResponse }
         return invitation
     }
 
@@ -564,7 +577,7 @@ actor SelectiveRemoteCloudAPIClient {
         let invitation = try await createTeamInvitation(
             endpoint: endpoint,
             teamID: teamID,
-            request: TeamInvitationRequest(username: nil, type: "link", role: role)
+            request: TeamInvitationRequest(username: nil, email: nil, type: "link", role: role)
         )
         guard invitation.type == .link, invitation.acceptanceURL != nil else {
             throw SelectiveRemoteCloudError.invalidResponse
@@ -1301,6 +1314,7 @@ private struct TeamNameRequest: Encodable {
 
 private struct TeamInvitationRequest: Encodable {
     var username: String?
+    var email: String?
     var type: String?
     var role: SelectiveRemoteCloudTeamRole
 }

--- a/Sources/SelectiveRemote/CloudTeamManagementView.swift
+++ b/Sources/SelectiveRemote/CloudTeamManagementView.swift
@@ -15,6 +15,7 @@ struct SelectiveRemoteCloudTeamManagementView: View {
     @State private var pendingInvitations: [SelectiveRemoteCloudTeamInvitation] = []
     @State private var newTeamName = ""
     @State private var invitationUsername = ""
+    @State private var invitationEmail = ""
     @State private var invitationRole = SelectiveRemoteCloudTeamRole.viewer
     @State private var latestInvitationURL: String?
     @State private var newVaultName = ""
@@ -161,6 +162,10 @@ struct SelectiveRemoteCloudTeamManagementView: View {
                     }
                     .buttonStyle(.borderedProminent)
                     .disabled(isBusy || normalized(invitationUsername).isEmpty)
+
+                    TextField("Email", text: $invitationEmail)
+                    Button(UpdateLocalization.text(ru: "Пригласить по email", en: "Invite by Email")) { inviteByEmail(team) }
+                        .disabled(isBusy || normalized(invitationEmail).isEmpty)
 
                     Button(
                         UpdateLocalization.text(ru: "Создать одноразовую ссылку", en: "Create Single-Use Link"),
@@ -378,6 +383,22 @@ struct SelectiveRemoteCloudTeamManagementView: View {
             } catch {
                 errorMessage = error.localizedDescription
             }
+            isBusy = false
+        }
+    }
+
+    private func inviteByEmail(_ team: SelectiveRemoteCloudTeam) {
+        let email = normalized(invitationEmail).lowercased()
+        guard !email.isEmpty else { return }
+        Task { @MainActor in
+            isBusy = true
+            errorMessage = nil
+            do {
+                _ = try await client.inviteTeamMember(endpoint: endpoint, teamID: team.id, email: email, role: invitationRole)
+                invitationEmail = ""
+                statusMessage = UpdateLocalization.text(ru: "Приглашение отправлено по email и действует 48 часов.", en: "The email invitation was sent and is active for 48 hours.")
+                await loadSelectedTeam()
+            } catch { errorMessage = error.localizedDescription }
             isBusy = false
         }
     }

--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -506,6 +506,7 @@ export function initializeTeamWorkspace({
   const members = documentValue.querySelector("#team-members");
   const membersView = documentValue.querySelector("#team-members-view");
   const inviteForm = documentValue.querySelector("#team-invite-form");
+  const inviteEmailSubmit = documentValue.querySelector("#team-invite-email-submit");
   const inviteLinkCreate = documentValue.querySelector("#team-invite-link-create");
   const inviteLinkResult = documentValue.querySelector("#team-invite-link-result");
   const inviteLinkValue = documentValue.querySelector("#team-invite-link-value");
@@ -1404,6 +1405,21 @@ export function initializeTeamWorkspace({
     }
   });
 
+  inviteEmailSubmit.addEventListener("click", async () => {
+    if (!selectedTeam || !canManage()) return;
+    const email = String(inviteForm.elements.email.value ?? "").trim();
+    if (!email) { setText(message, "Укажите email участника."); return; }
+    inviteEmailSubmit.disabled = true;
+    try {
+      await client.inviteTeamMember({ teamID: selectedTeam.id, email, type: "email", role: inviteForm.elements.role.value });
+      inviteForm.elements.email.value = "";
+      await loadSelectedTeam();
+      setText(message, `Приглашение отправлено на ${email}. Оно действует 48 часов.`);
+    } catch {
+      setText(message, "Email-приглашение не отправлено. Проверьте адрес, роль и настройки почты.");
+    } finally { inviteEmailSubmit.disabled = false; }
+  });
+
   inviteLinkCreate.addEventListener("click", async () => {
     if (!selectedTeam || !canManage()) return;
     inviteLinkCreate.disabled = true;
@@ -1882,7 +1898,7 @@ export async function initializeCloudAccount({
   personalVaultTimer?.unref?.();
 
   function setAuthMode(mode) {
-    const registrationAvailable = metadata?.registrationEnabled === true;
+    const registrationAvailable = metadata?.registrationEnabled === true || Boolean(initialTeamInvitationToken);
     form.hidden = mode !== "login";
     registrationForm.hidden = mode !== "registration";
     recoveryFormAccount.hidden = mode !== "recovery";
@@ -1894,7 +1910,9 @@ export async function initializeCloudAccount({
     }
     if (mode === "registration") {
       setAccountMessage(registrationAvailable
-        ? "Создайте пароль Selective Remote — на почту придёт только одноразовая ссылка подтверждения."
+        ? initialTeamInvitationToken
+          ? "Создайте аккаунт по приглашению. После подтверждения email войдите и снова откройте ссылку приглашения."
+          : "Создайте пароль Selective Remote — на почту придёт только одноразовая ссылка подтверждения."
         : "Регистрация временно закрыта. Уже подтверждённые аккаунты могут войти.", registrationAvailable ? null : "error");
     } else if (mode === "recovery") {
       setAccountMessage("Мы отправим одноразовую ссылку для смены пароля, если аккаунт существует.");
@@ -1972,7 +1990,7 @@ export async function initializeCloudAccount({
 
   registrationForm.addEventListener("submit", async (event) => {
     event.preventDefault();
-    if (metadata?.registrationEnabled !== true) {
+    if (metadata?.registrationEnabled !== true && !initialTeamInvitationToken) {
       setAccountMessage("Регистрация временно закрыта. Обновите страницу после открытия регистрационного окна.", "error");
       return;
     }
@@ -1994,6 +2012,7 @@ export async function initializeCloudAccount({
         password,
         deviceID,
         publicKey: identity?.publicKey ?? null,
+        invitationToken: initialTeamInvitationToken,
       });
       const email = registrationForm.elements.email.value.trim();
       registrationForm.reset();
@@ -2005,6 +2024,7 @@ export async function initializeCloudAccount({
       const code = String(error?.message ?? "");
       const messages = {
         registration_disabled: "Регистрационное окно уже закрыто. Обновите страницу позже.",
+        invalid_team_invitation: "Приглашение недействительно, уже использовано, отозвано или истекло.",
         rate_limited: "Слишком много попыток. Повторите позже.",
         smtp_not_configured: "Почтовый сервис временно не настроен.",
       };

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -444,6 +444,9 @@
                 <option value="admin">Admin</option>
               </select>
               <button type="submit">Пригласить по @username</button>
+              <label for="team-invite-email">Email</label>
+              <input id="team-invite-email" name="email" type="email" maxlength="320" autocomplete="off" placeholder="user@example.com">
+              <button type="button" class="secondary" id="team-invite-email-submit">Отправить приглашение по email</button>
               <button type="button" class="secondary" id="team-invite-link-create">Создать одноразовую ссылку</button>
               <div id="team-invite-link-result" hidden>
                 <label for="team-invite-link-value">Одноразовая ссылка</label>

--- a/cloud/public/vault-sync.js
+++ b/cloud/public/vault-sync.js
@@ -420,7 +420,7 @@ export function createAuthenticatedVaultClient({ fetchValue = globalThis.fetch }
   }
 
   return {
-    async register({ displayName, username, email, password, deviceID, publicKey = null }) {
+    async register({ displayName, username, email, password, deviceID, publicKey = null, invitationToken = null }) {
       const normalizedDeviceID = String(deviceID ?? "").toLowerCase();
       if (!uuidPattern.test(normalizedDeviceID)) throw new Error("invalid_device");
       const normalizedName = String(displayName ?? "").trim();
@@ -438,6 +438,7 @@ export function createAuthenticatedVaultClient({ fetchValue = globalThis.fetch }
           username: normalizedUsername,
           email: String(email ?? "").trim(),
           password: normalizedPassword(password),
+          ...(invitationToken ? { invitationToken: String(invitationToken).trim() } : {}),
           device: {
             id: normalizedDeviceID,
             name: "Web browser",
@@ -452,7 +453,7 @@ export function createAuthenticatedVaultClient({ fetchValue = globalThis.fetch }
       });
       const result = await responseJSON(response, "registration_failed");
       if (!response.ok) {
-        const code = ["registration_disabled", "rate_limited", "smtp_not_configured"].includes(result.error)
+        const code = ["registration_disabled", "invalid_team_invitation", "rate_limited", "smtp_not_configured"].includes(result.error)
           ? result.error : "registration_failed";
         throw new Error(code);
       }

--- a/cloud/src/postgres-store.mjs
+++ b/cloud/src/postgres-store.mjs
@@ -134,6 +134,23 @@ export class PostgresStore {
     return result.rows[0] ?? null;
   }
 
+  async teamInvitationRegistrationTarget(tokenHash) {
+    const result = await this.pool.query(
+      `SELECT invitation_type AS type, invitation.email
+       FROM team_invitations invitation
+       JOIN teams team ON team.id = invitation.team_id
+       WHERE invitation.token_hash = $1
+         AND invitation.invitation_type IN ('email', 'link')
+         AND invitation.accepted_at IS NULL
+         AND invitation.cancelled_at IS NULL
+         AND invitation.expires_at > now()
+         AND team.archived_at IS NULL
+       LIMIT 1`,
+      [tokenHash],
+    );
+    return result.rows[0] ?? null;
+  }
+
 
   async usernameAvailable(username, excludingUserID) {
     const result = await this.pool.query(

--- a/cloud/src/service.mjs
+++ b/cloud/src/service.mjs
@@ -100,9 +100,16 @@ export class CloudService {
   }
 
   async register(input) {
-    if (!this.config.allowRegistration) throw new Error("registration_disabled");
-    if (!this.mailer) throw new Error("smtp_not_configured");
     const email = normalizeEmail(input.email);
+    if (!this.config.allowRegistration) {
+      const invitationToken = String(input?.invitationToken ?? "").trim();
+      if (!invitationToken) throw new Error("registration_disabled");
+      const target = await this.store.teamInvitationRegistrationTarget(
+        hashTeamInvitationToken(invitationToken, this.config.teamInvitationTokenPepper),
+      );
+      if (!target || (target.type === "email" && target.email !== email)) throw new Error("invalid_team_invitation");
+    }
+    if (!this.mailer) throw new Error("smtp_not_configured");
     const password = validatePassword(input.password);
     const displayName = String(input.displayName ?? "").trim().slice(0, 120);
     const username = input.username

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -185,7 +185,8 @@ test("macOS Cloud settings expose device-bound sign-in and native Team managemen
   assert.match(teamManagement, /Team Hosts/);
   assert.match(teamManagement, /@\\\(member\.username\)/);
   assert.doesNotMatch(teamManagement, /Text\(member\.email\)/);
-  assert.doesNotMatch(teamManagement, /invitationEmail|TextField\("Email"/);
+  assert.match(teamManagement, /invitationEmail|TextField\("Email"/);
+  assert.match(client, /email: normalizedEmail, type: "email"/);
   assert.match(client, /v1\/auth\/register/);
   assert.match(client, /verificationRequired/);
   assert.match(client, /validLoginJSON/);

--- a/cloud/tests/postgres-store.test.mjs
+++ b/cloud/tests/postgres-store.test.mjs
@@ -26,6 +26,18 @@ function recordingStore(respond = () => ({ rows: [] })) {
   };
 }
 
+test("invitation-gated registration accepts only active email or link tokens", async () => {
+  const target = { type: "email", email: "invited@example.com" };
+  const fixture = recordingStore(() => ({ rows: [target] }));
+  assert.deepEqual(await fixture.store.teamInvitationRegistrationTarget("a".repeat(64)), target);
+  assert.deepEqual(fixture.queries[0].parameters, ["a".repeat(64)]);
+  assert.match(fixture.queries[0].sql, /invitation_type IN \('email', 'link'\)/u);
+  assert.match(fixture.queries[0].sql, /accepted_at IS NULL/u);
+  assert.match(fixture.queries[0].sql, /cancelled_at IS NULL/u);
+  assert.match(fixture.queries[0].sql, /expires_at > now\(\)/u);
+  assert.match(fixture.queries[0].sql, /team\.archived_at IS NULL/u);
+});
+
 test("creating an unverified account stores a verification hash but no session", async () => {
   const user = { id: "user-1", email: "user@example.com", display_name: "User", created_at: new Date() };
   const fixture = recordingStore((sql) => sql.includes("INSERT INTO users") ? { rows: [user] } : { rows: [] });

--- a/cloud/tests/public-auth.test.mjs
+++ b/cloud/tests/public-auth.test.mjs
@@ -20,6 +20,7 @@ test("browser registration sends JSON without persisting or returning a password
     email: "owner@example.com",
     password: "a sufficiently long password",
     deviceID,
+    invitationToken: "opaque-invitation-token",
   });
   assert.deepEqual(result, { verificationRequired: true });
   assert.equal(request[0], "/v1/auth/register");
@@ -30,6 +31,7 @@ test("browser registration sends JSON without persisting or returning a password
   assert.equal(body.email, "owner@example.com");
   assert.equal(body.username, "leonid");
   assert.equal(body.device.id, deviceID);
+  assert.equal(body.invitationToken, "opaque-invitation-token");
   assert.equal("password" in result, false);
 });
 

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -204,7 +204,8 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(html, /id="team-invite-username"/u);
   assert.match(html, /id="team-invite-link-create"/u);
   assert.match(html, /id="team-active-invitations"/u);
-  assert.doesNotMatch(html, /id="team-invite-email"/u);
+  assert.match(html, /id="team-invite-email"/u);
+  assert.match(html, /id="team-invite-email-submit"/u);
   assert.match(html, /id="team-select"/u);
   assert.match(html, /id="team-lifecycle"[^>]*hidden/u);
   assert.match(html, /id="team-rename-form"/u);

--- a/cloud/tests/service.test.mjs
+++ b/cloud/tests/service.test.mjs
@@ -16,6 +16,7 @@ class MemoryStore {
     this.lastPasswordResetExpiry = null;
     this.lastPasswordHash = null;
     this.deletedUserID = null;
+    this.invitationRegistrationTarget = null;
   }
   async createUser(input) {
     this.lastVerificationHash = input.verificationHash;
@@ -31,6 +32,7 @@ class MemoryStore {
     return this.identity;
   }
   async passwordIdentity(email) { return this.identity?.email === email ? this.identity : null; }
+  async teamInvitationRegistrationTarget() { return this.invitationRegistrationTarget; }
   async usernameAvailable(username, excludingUserID) { return username !== "taken" || this.identity?.id === excludingUserID && this.identity?.username === username; }
   async updateUsername(userID, username) { if (username === "taken") throw new Error("username_exists"); this.identity.username = username; return username; }
   async changePassword(userID, sessionID, passwordHash) { this.identity.password_hash = passwordHash; this.lastPasswordHash = passwordHash; for (const [key, value] of this.sessions) if (value.session_id !== sessionID) this.sessions.delete(key); return { changed: true }; }
@@ -81,6 +83,7 @@ const config = {
   sessionPepper: "p".repeat(32),
   emailVerificationPepper: "v".repeat(32),
   passwordResetTokenPepper: "r".repeat(32),
+  teamInvitationTokenPepper: "t".repeat(32),
   sessionTTLDays: 30,
   emailVerificationTTLHours: 24,
   passwordResetTTLHours: 1,
@@ -180,6 +183,17 @@ test("account settings require reauthentication and preserve only the current se
 test("registration can be disabled until SMTP is configured", async () => {
   const service = new CloudService(new MemoryStore(), { ...config, allowRegistration: false });
   await assert.rejects(service.register({ email: "user@example.com", password: "correct horse battery", device }), /registration_disabled/);
+});
+
+test("closed registration accepts only a valid email or link invitation", async () => {
+  const store = new MemoryStore();
+  const mailer = { async sendEmailVerification() {} };
+  const service = new CloudService(store, { ...config, allowRegistration: false }, mailer);
+  store.invitationRegistrationTarget = { type: "email", email: "invited@example.com" };
+  await assert.rejects(service.register({ email: "other@example.com", password: "correct horse battery", device, invitationToken: "invite-token" }), /invalid_team_invitation/u);
+  assert.deepEqual(await service.register({ email: "invited@example.com", password: "correct horse battery", device, invitationToken: "invite-token" }), { verificationRequired: true });
+  store.invitationRegistrationTarget = { type: "link", email: null };
+  assert.deepEqual(await service.register({ email: "link-user@example.com", password: "correct horse battery", device, invitationToken: "link-token" }), { verificationRequired: true });
 });
 
 test("registration fails closed when SMTP delivery is unavailable", async () => {


### PR DESCRIPTION
## Что изменено
- приглашение участника команды по email на сайте и в macOS
- современное SMTP-письмо использует существующий защищённый одноразовый URL
- регистрация по действующему email/link-приглашению разрешена при закрытой публичной регистрации
- email-приглашение строго привязано к адресу получателя
- токен передаётся только из URL fragment, хешируется сервером и не сохраняется открыто

## Проверка
- `npm test`: 288 passed, 1 skipped (PostgreSQL integration без TEST_DATABASE_URL)
- добавлены тесты закрытой регистрации, SQL-ограничений, браузерной передачи токена и UI/macOS источников