### PR TITLE
Fix Personal Vault setup after restored sessions

### DIFF
--- a/Sources/SelectiveRemote/CloudSettingsView.swift
+++ b/Sources/SelectiveRemote/CloudSettingsView.swift
@@ -211,6 +211,29 @@ struct CloudSettingsView: View {
                             .foregroundStyle(personalVaultAutoSyncConfigured ? Color.green : Color.secondary)
                     }
 
+                    if !personalVaultAutoSyncConfigured {
+                        Button(
+                            UpdateLocalization.text(
+                                ru: "Подключить автосинхронизацию…",
+                                en: "Connect Automatic Sync…"
+                            ),
+                            systemImage: "key.fill"
+                        ) {
+                            accountErrorMessage = nil
+                            accountSheetMode = .signIn
+                            showsAccountSheet = true
+                        }
+                        .buttonStyle(.borderedProminent)
+
+                        Text(UpdateLocalization.text(
+                            ru: "Повторно войдите в аккаунт: пароль используется только в памяти, чтобы безопасно подключить существующий Personal Vault к Keychain этого Mac.",
+                            en: "Sign in again: the password is used only in memory to securely connect the existing Personal Vault to this Mac's Keychain."
+                        ))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    }
+
                     Toggle(
                         UpdateLocalization.text(
                             ru: "Синхронизировать Personal Vault",
@@ -249,7 +272,11 @@ struct CloudSettingsView: View {
                             object: nil
                         )
                     }
-                    .disabled(!personalVaultSyncEnabled || personalVaultIsSyncing)
+                    .disabled(
+                        !personalVaultSyncEnabled
+                            || !personalVaultAutoSyncConfigured
+                            || personalVaultIsSyncing
+                    )
 
                     if personalVaultIsSyncing {
                         Label(

--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -2257,29 +2257,55 @@ export async function initializeCloudAccount({
     event.preventDefault();
     const button = recoveryForm.querySelector('button[type="submit"]');
     const passphrase = recoveryForm.elements.passphrase.value;
+    const accountPassword = recoveryForm.elements.accountPassword.value;
     button.disabled = true;
     try {
-      const result = await synchronizeVault({ client, vault, recoveryPassphrase: passphrase });
-      if (accountVaultMigrationPassphrase) {
-        await vault.rewrap(accountVaultMigrationPassphrase);
-        await synchronizeVault({ client, vault });
-        accountVaultMigrationPassphrase = null;
+      let migrationPassphrase = accountVaultMigrationPassphrase;
+      if (!migrationPassphrase) {
+        if (!accountPassword) throw new Error("account_password_required");
+        const currentUser = client.session();
+        if (!currentUser) throw new Error("authentication_required");
+        const deviceID = await vault.deviceID();
+        let identity = null;
+        try {
+          identity = await ensureTeamDeviceIdentity({ repository: teamDeviceRepository, deviceID });
+        } catch {
+          // Personal Vault recovery remains available when Team device storage is unavailable.
+        }
+        await client.login({
+          email: currentUser.email,
+          password: accountPassword,
+          deviceID,
+          publicKey: identity?.publicKey ?? null,
+        });
+        migrationPassphrase = accountVaultPassphrase(accountPassword);
       }
+      const result = await synchronizeVault({ client, vault, recoveryPassphrase: passphrase });
+      await vault.rewrap(migrationPassphrase);
+      await synchronizeVault({ client, vault });
+      accountVaultMigrationPassphrase = null;
       recoveryForm.reset();
       await vaultUI.hideRecoveryAndRestoreMode();
       vaultUI.mode("unlocked");
       vaultUI.render();
       setText(vaultMessage, `Зашифрованная ревизия ${result.revision} восстановлена и переведена на автоматическую разблокировку паролем аккаунта.`);
     } catch (error) {
+      const code = String(error?.message ?? "");
       recoveryForm.elements.passphrase.value = "";
-      if (String(error?.message ?? "") === "authentication_required") {
+      if (recoveryForm.elements.accountPassword) recoveryForm.elements.accountPassword.value = "";
+      if (code === "authentication_required") {
         showSession(null);
         await vaultUI.hideRecoveryAndRestoreMode();
         setText(vaultMessage, "Сессия истекла. Войдите снова.");
+      } else if (code === "account_password_required") {
+        setText(vaultMessage, "Введите пароль аккаунта, чтобы подтвердить восстановленную сессию и подключить Vault.");
+      } else if (code === "invalid_credentials") {
+        setText(vaultMessage, "Пароль аккаунта неверен. Recovery-фраза не проверялась.");
       } else {
         setText(vaultMessage, "Не удалось восстановить Vault. Recovery-фраза неверна или зашифрованные данные повреждены.");
       }
     } finally {
+      if (recoveryForm.elements.accountPassword) recoveryForm.elements.accountPassword.value = "";
       button.disabled = false;
     }
   });

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -206,11 +206,14 @@
       </div>
 
       <div class="vault-panel" id="cloud-vault-recovery" hidden>
-        <h3>Восстановить Vault из Cloud</h3>
-        <p>Зашифрованная ревизия уже существует. Введите независимую recovery-фразу: она используется только локально и не отправляется на сервер.</p>
+        <h3>Подключить существующий Vault</h3>
+        <p>Эта ревизия создана до привязки Vault к паролю аккаунта. Введите recovery-фразу один раз: она используется только локально и никогда не отправляется на сервер.</p>
         <form id="cloud-vault-recovery-form">
           <label for="cloud-vault-recovery-passphrase">Recovery-фраза</label>
           <input id="cloud-vault-recovery-passphrase" name="passphrase" type="password" minlength="16" maxlength="1024" autocomplete="off" required>
+          <label for="cloud-vault-recovery-account-password">Пароль аккаунта</label>
+          <input id="cloud-vault-recovery-account-password" name="accountPassword" type="password" minlength="12" maxlength="1024" autocomplete="current-password">
+          <p class="auth-note">Если сессия была восстановлена после перезапуска браузера, пароль нужен для повторной проверки аккаунта и локального rewrap. Он не сохраняется. Сразу после обычного входа поле можно оставить пустым.</p>
           <div class="vault-actions">
             <button type="submit">Расшифровать и импортировать</button>
             <button type="button" class="secondary" id="cloud-vault-recovery-cancel">Отмена</button>
@@ -236,7 +239,7 @@
         <form id="local-vault-unlock-form">
           <label for="local-vault-unlock-passphrase">Recovery-фраза</label>
           <input id="local-vault-unlock-passphrase" name="passphrase" type="password" minlength="16" maxlength="1024" autocomplete="off" required>
-          <button type="submit">Разблокировать</button>
+          <button type="submit">Подключить и разблокировать</button>
         </form>
       </div>
 

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -195,6 +195,9 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(html, /id="cloud-vault-sync"/u);
   assert.match(html, /id="cloud-logout"/u);
   assert.match(html, /id="cloud-vault-recovery-form"/u);
+  assert.match(html, /id="cloud-vault-recovery-account-password"[^>]*name="accountPassword"[^>]*autocomplete="current-password"/u);
+  assert.match(html, /Recovery-фраза[^<]*один раз/u);
+  assert.match(html, /Сразу после обычного входа поле можно оставить пустым/u);
   assert.match(html, /id="local-vault-conflicts-form"/u);
   assert.match(html, /id="local-vault-conflicts-apply"[^>]*disabled/u);
   assert.match(html, /id="team-vault"[^>]*hidden/u);
@@ -310,7 +313,11 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(application, /backgroundPersonalVaultSync/u);
   assert.match(application, /15_000/u);
   assert.match(application, /vault\.lock\(\)/u);
-  assert.match(application, /vault\.rewrap\(accountVaultMigrationPassphrase\)/u);
+  assert.match(application, /let migrationPassphrase = accountVaultMigrationPassphrase/u);
+  assert.match(application, /if \(!accountPassword\) throw new Error\("account_password_required"\)/u);
+  assert.match(application, /email: currentUser\.email,[\s\S]*password: accountPassword/u);
+  assert.match(application, /vault\.rewrap\(migrationPassphrase\)/u);
+  assert.match(application, /Recovery-фраза не проверялась/u);
   assert.match(application, /переведена на автоматическую разблокировку паролем аккаунта/u);
   assert.match(application, /Personal Vault открыт паролем аккаунта/u);
   assert.match(application, /ensureTeamDeviceIdentity/u);

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -196,7 +196,7 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(html, /id="cloud-logout"/u);
   assert.match(html, /id="cloud-vault-recovery-form"/u);
   assert.match(html, /id="cloud-vault-recovery-account-password"[^>]*name="accountPassword"[^>]*autocomplete="current-password"/u);
-  assert.match(html, /Recovery-фраза[^<]*один раз/u);
+  assert.match(html, /recovery-фразу один раз/iu);
   assert.match(html, /Сразу после обычного входа поле можно оставить пустым/u);
   assert.match(html, /id="local-vault-conflicts-form"/u);
   assert.match(html, /id="local-vault-conflicts-apply"[^>]*disabled/u);


### PR DESCRIPTION
## Что исправлено

### macOS

После обновления приложения уже сохранённая Cloud-сессия восстанавливается без пароля аккаунта. Это безопасно, но если на Mac ещё нет Keychain-material Personal Vault, экран показывал «Автосинхронизация: Не настроена» без рабочего пути завершить enrollment.

- показывается кнопка «Подключить автосинхронизацию…»;
- она открывает повторный вход: пароль используется только в памяти, Vault material сохраняется в Keychain;
- «Синхронизировать сейчас» недоступна до завершённого enrollment.

### Web

Cookie-сессия также может восстановиться без пароля. Для legacy Vault, созданного с отдельной Recovery-фразой, прежняя форма могла открыть данные, но не могла надёжно rewrap Vault под пароль аккаунта после перезапуска браузера.

- форма явно объясняет одноразовую миграцию;
- после восстановленной сессии запрашивается пароль аккаунта, повторно проверяется через login и только затем выполняется локальный rewrap;
- сразу после обычного входа повторно вводить пароль не требуется;
- Recovery-фраза остаётся только в браузере и не отправляется на сервер;
- оба поля очищаются после попытки;
- отдельные сообщения различают отсутствующий/неверный пароль и неверную Recovery-фразу.

## Безопасность

Серверный формат, E2EE envelope и API хранения не меняются. Пароль аккаунта используется только для повторной аутентификации и получения доменно-разделённой локальной passphrase; Recovery-фраза не передаётся в запросах.

## Проверка

Первый macOS-only head `5d3d30b946335b0353cc8aa85432fa8cda0c3669` прошёл CI #653 и Test DMG #292. Текущий head добавляет web-flow и контрактные тесты; требуется повторный CI/Test DMG.