### PR TITLE
Fix production Cloud login response contract

### DIFF
--- a/cloud/src/postgres-store.mjs
+++ b/cloud/src/postgres-store.mjs
@@ -126,7 +126,7 @@ export class PostgresStore {
 
   async passwordIdentity(email) {
     const result = await this.pool.query(
-      `SELECT u.id, u.email, u.username, u.display_name, u.disabled_at, u.email_verified_at, i.password_hash
+      `SELECT u.id, u.email, u.username, u.display_name, u.created_at, u.disabled_at, u.email_verified_at, i.password_hash
        FROM users u JOIN account_identities i ON i.user_id = u.id
        WHERE i.provider = 'password' AND i.subject = $1`,
       [email],

--- a/cloud/tests/postgres-store.test.mjs
+++ b/cloud/tests/postgres-store.test.mjs
@@ -61,6 +61,25 @@ test("creating an unverified account stores a verification hash but no session",
   assert.equal(fixture.released(), true);
 });
 
+test("password identity includes the account creation time required by the login contract", async () => {
+  const createdAt = new Date("2026-09-11T00:00:00.000Z");
+  const identity = {
+    id: "user-1",
+    email: "user@example.com",
+    username: "user",
+    display_name: "User",
+    created_at: createdAt,
+    disabled_at: null,
+    email_verified_at: createdAt,
+    password_hash: "password-hash",
+  };
+  const fixture = recordingStore(() => ({ rows: [identity] }));
+
+  assert.deepEqual(await fixture.store.passwordIdentity("user@example.com"), identity);
+  assert.deepEqual(fixture.queries[0].parameters, ["user@example.com"]);
+  assert.match(fixture.queries[0].sql, /u\.created_at/u);
+});
+
 test("session lookup rejects accounts without a verified email", async () => {
   const fixture = recordingStore();
   assert.equal(await fixture.store.session("session-hash"), null);


### PR DESCRIPTION
## Summary

- include `users.created_at` in the PostgreSQL password identity used by `CloudService.login`
- preserve the strict macOS login response validator instead of weakening the client contract
- add a regression test proving the production store supplies the timestamp required by `publicUser()`

## User-visible bug

Re-authenticating an already connected Mac to enroll Personal Vault returned HTTP 200, but the production login JSON omitted `user.createdAt`. The macOS client correctly rejected that incomplete response as “Cloud returned an invalid response.”

## Security

No password storage or cryptographic behavior changes. The password remains memory-only during the one-time per-device Vault enrollment; the resulting Vault key material remains in the device-bound Keychain envelope.

## Validation

CI and Test DMG workflows requested for this PR.