### PR TITLE
Migrate legacy Personal Vault automatically after Mac sign-in

### DIFF
--- a/Sources/SelectiveRemote/CloudPersonalVaultAutoSync.swift
+++ b/Sources/SelectiveRemote/CloudPersonalVaultAutoSync.swift
@@ -158,6 +158,7 @@ struct SelectiveRemotePersonalVaultAccountEnrollment {
         let material: SelectiveRemotePersonalVaultKeyMaterial
         if remote.revision == 0 {
             material = try await replaceWithLocalVault(
+                endpoint: endpoint,
                 remote: remote,
                 exported: exported,
                 passphrase: passphrase
@@ -187,6 +188,7 @@ struct SelectiveRemotePersonalVaultAccountEnrollment {
                 // keeps the previous ciphertext in vault_revisions, so migration is reversible by
                 // an administrator without exposing plaintext or asking the user for Recovery.
                 material = try await replaceWithLocalVault(
+                    endpoint: endpoint,
                     remote: remote,
                     exported: exported,
                     passphrase: passphrase
@@ -198,6 +200,7 @@ struct SelectiveRemotePersonalVaultAccountEnrollment {
     }
 
     private func replaceWithLocalVault(
+        endpoint: URL,
         remote: SelectiveRemoteCloudPersonalVault,
         exported: SelectiveRemotePersonalVaultExport,
         passphrase: String
@@ -219,8 +222,6 @@ struct SelectiveRemotePersonalVaultAccountEnrollment {
             documentHash: Data(SHA256.hash(data: try exported.document.encoded())),
             includesCredentials: exported.document.records.contains { $0.type == .credential }
         )
-        try keyStore.save(material, endpoint: endpoint, deviceID: deviceID)
-        return material.revision
     }
 }
 

--- a/Sources/SelectiveRemote/CloudPersonalVaultAutoSync.swift
+++ b/Sources/SelectiveRemote/CloudPersonalVaultAutoSync.swift
@@ -146,52 +146,79 @@ struct SelectiveRemotePersonalVaultAccountEnrollment {
     ) async throws -> Int {
         let passphrase = try SelectiveRemotePersonalVaultCrypto.accountPassphrase(password)
         let remote = try await client.personalVault(endpoint: endpoint)
+        let exported = try SelectiveRemotePersonalVaultExporter.makeExport(
+            profiles: profiles,
+            credentials: credentials,
+            snippets: snippets,
+            forwarding: forwarding,
+            sshKeys: sshKeys,
+            deviceID: deviceID,
+            allowEmpty: true
+        )
         let material: SelectiveRemotePersonalVaultKeyMaterial
         if remote.revision == 0 {
-            let exported = try SelectiveRemotePersonalVaultExporter.makeExport(
-                profiles: profiles,
-                credentials: credentials,
-                snippets: snippets,
-                forwarding: forwarding,
-                sshKeys: sshKeys,
-                deviceID: deviceID,
-                allowEmpty: true
-            )
-            let setup = try SelectiveRemotePersonalVaultCrypto.createSetup(
-                exported.document,
-                recoveryPhrase: passphrase,
-                baseRevision: 0
-            )
-            let result = try await client.putPersonalVault(endpoint: endpoint, envelope: setup.envelope)
-            guard !result.conflict, result.revision == 1 else {
-                throw SelectiveRemotePersonalVaultError.uploadConflict(result.revision)
-            }
-            material = try .init(
-                vaultID: remote.id,
-                vaultKey: setup.vaultKey,
-                wrappedKey: setup.envelope.wrappedKey,
-                revision: result.revision,
-                documentHash: Data(SHA256.hash(data: try exported.document.encoded()))
+            material = try await replaceWithLocalVault(
+                remote: remote,
+                exported: exported,
+                passphrase: passphrase
             )
         } else {
             guard let envelope = remote.envelope else {
                 throw SelectiveRemotePersonalVaultError.invalidEnvelope
             }
-            let vaultKey = try SelectiveRemotePersonalVaultCrypto.unwrapVaultKey(
-                envelope.wrappedKey,
-                passphrase: passphrase
-            )
-            let document = try SelectiveRemotePersonalVaultCrypto.open(envelope, vaultKey: vaultKey)
-            material = try .init(
-                vaultID: remote.id,
-                vaultKey: vaultKey,
-                wrappedKey: envelope.wrappedKey,
-                revision: remote.revision,
-                documentHash: Data(SHA256.hash(data: try document.encoded())),
-                includesCredentials: document.records.contains { $0.type == .credential },
-                requiresInitialDownload: true
-            )
+            do {
+                let vaultKey = try SelectiveRemotePersonalVaultCrypto.unwrapVaultKey(
+                    envelope.wrappedKey,
+                    passphrase: passphrase
+                )
+                let document = try SelectiveRemotePersonalVaultCrypto.open(envelope, vaultKey: vaultKey)
+                material = try .init(
+                    vaultID: remote.id,
+                    vaultKey: vaultKey,
+                    wrappedKey: envelope.wrappedKey,
+                    revision: remote.revision,
+                    documentHash: Data(SHA256.hash(data: try document.encoded())),
+                    includesCredentials: document.records.contains { $0.type == .credential },
+                    requiresInitialDownload: true
+                )
+            } catch SelectiveRemotePersonalVaultError.invalidRecoveryPhrase {
+                // A legacy Recovery-wrapped revision cannot be opened with account credentials.
+                // Make this Mac's complete local snapshot authoritative automatically. The server
+                // keeps the previous ciphertext in vault_revisions, so migration is reversible by
+                // an administrator without exposing plaintext or asking the user for Recovery.
+                material = try await replaceWithLocalVault(
+                    remote: remote,
+                    exported: exported,
+                    passphrase: passphrase
+                )
+            }
         }
+        try keyStore.save(material, endpoint: endpoint, deviceID: deviceID)
+        return material.revision
+    }
+
+    private func replaceWithLocalVault(
+        remote: SelectiveRemoteCloudPersonalVault,
+        exported: SelectiveRemotePersonalVaultExport,
+        passphrase: String
+    ) async throws -> SelectiveRemotePersonalVaultKeyMaterial {
+        let setup = try SelectiveRemotePersonalVaultCrypto.createSetup(
+            exported.document,
+            recoveryPhrase: passphrase,
+            baseRevision: remote.revision
+        )
+        let result = try await client.putPersonalVault(endpoint: endpoint, envelope: setup.envelope)
+        guard !result.conflict, result.revision == remote.revision + 1 else {
+            throw SelectiveRemotePersonalVaultError.uploadConflict(result.revision)
+        }
+        return try .init(
+            vaultID: remote.id,
+            vaultKey: setup.vaultKey,
+            wrappedKey: setup.envelope.wrappedKey,
+            revision: result.revision,
+            documentHash: Data(SHA256.hash(data: try exported.document.encoded())),
+            includesCredentials: exported.document.records.contains { $0.type == .credential }
+        )
         try keyStore.save(material, endpoint: endpoint, deviceID: deviceID)
         return material.revision
     }

--- a/Sources/SelectiveRemote/CloudPersonalVaultAutoSync.swift
+++ b/Sources/SelectiveRemote/CloudPersonalVaultAutoSync.swift
@@ -183,6 +183,9 @@ struct SelectiveRemotePersonalVaultAccountEnrollment {
                     requiresInitialDownload: true
                 )
             } catch SelectiveRemotePersonalVaultError.invalidRecoveryPhrase {
+                guard exported.summary.total > 0 else {
+                    throw SelectiveRemotePersonalVaultError.legacyMigrationRequiresLocalData
+                }
                 // A legacy Recovery-wrapped revision cannot be opened with account credentials.
                 // Make this Mac's complete local snapshot authoritative automatically. The server
                 // keeps the previous ciphertext in vault_revisions, so migration is reversible by

--- a/Sources/SelectiveRemote/CloudPersonalVaultSync.swift
+++ b/Sources/SelectiveRemote/CloudPersonalVaultSync.swift
@@ -9,6 +9,7 @@ enum SelectiveRemotePersonalVaultError: LocalizedError, Equatable {
     case cryptoFailure
     case emptyLocalVault
     case remoteVaultNotEmpty(Int)
+    case legacyMigrationRequiresLocalData
     case uploadConflict(Int)
 
     var errorDescription: String? {
@@ -32,6 +33,11 @@ enum SelectiveRemotePersonalVaultError: LocalizedError, Equatable {
             UpdateLocalization.text(
                 ru: "Cloud Vault уже содержит ревизию \(revision). Автоматическая перезапись остановлена; сначала требуется безопасное объединение.",
                 en: "Cloud Vault already contains revision \(revision). Automatic replacement was stopped; a safe merge is required first."
+            )
+        case .legacyMigrationRequiresLocalData:
+            UpdateLocalization.text(
+                ru: "Legacy Personal Vault ожидает автоматической миграции с Mac, на котором сохранены локальные данные.",
+                en: "The legacy Personal Vault is waiting for automatic migration from a Mac that has local data."
             )
         case let .uploadConflict(revision):
             UpdateLocalization.text(

--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -2106,7 +2106,7 @@ export async function initializeCloudAccount({
         vaultMessage,
         personalVaultReady
           ? "Personal Vault открыт паролем аккаунта и синхронизируется автоматически."
-          : "Для ранее созданного Personal Vault один раз введите Recovery-фразу; новые входы используют пароль аккаунта."
+          : "Legacy Personal Vault будет автоматически переведён после входа в обновлённом приложении на Mac с локальными данными. Recovery-фраза не требуется."
       );
     } catch (error) {
       const code = String(error?.message ?? "");
@@ -2243,8 +2243,7 @@ export async function initializeCloudAccount({
         setText(vaultMessage, "Сессия истекла. Войдите снова.");
       } else if (code === "recovery_passphrase_required") {
         hideConflicts();
-        vaultUI.showRecovery();
-        setText(vaultMessage, "На сервере есть зашифрованный Vault. Введите recovery-фразу для локального импорта.");
+        setText(vaultMessage, "Legacy Personal Vault ожидает автоматической миграции после входа в обновлённом приложении на Mac с локальными данными.");
       } else {
         setText(vaultMessage, "Синхронизация не выполнена; локальные данные не потеряны.");
       }

--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -2077,7 +2077,9 @@ export async function initializeCloudAccount({
         personalVaultReady = true;
         accountVaultMigrationPassphrase = null;
       } catch {
-        // Vaults created before account-password enrollment retain Recovery fallback.
+        // A legacy wrapper is migrated automatically by an updated Mac that has
+        // the authoritative local records. Do not expose Recovery in normal UI.
+        vaultUI.mode("waiting");
       }
       if (identity) {
         try {
@@ -2243,6 +2245,7 @@ export async function initializeCloudAccount({
         setText(vaultMessage, "Сессия истекла. Войдите снова.");
       } else if (code === "recovery_passphrase_required") {
         hideConflicts();
+        vaultUI.mode("waiting");
         setText(vaultMessage, "Legacy Personal Vault ожидает автоматической миграции после входа в обновлённом приложении на Mac с локальными данными.");
       } else {
         setText(vaultMessage, "Синхронизация не выполнена; локальные данные не потеряны.");

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -479,4 +479,9 @@ test("macOS Personal Vault auto-sync preserves encrypted credentials without ext
   assert.match(settings, /Последняя синхронизация/u);
   assert.match(settings, /Синхронизировать сейчас/u);
   assert.match(settings, /personalVaultSyncError/u);
+  assert.match(sync, /catch SelectiveRemotePersonalVaultError\.invalidRecoveryPhrase/u);
+  assert.match(sync, /guard exported\.summary\.total > 0/u);
+  assert.match(sync, /baseRevision: remote\.revision/u);
+  assert.match(sync, /legacyMigrationRequiresLocalData/u);
+  assert.match(sync, /previous ciphertext in vault_revisions/u);
 });

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -320,6 +320,9 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(application, /Recovery-фраза не проверялась/u);
   assert.match(application, /переведена на автоматическую разблокировку паролем аккаунта/u);
   assert.match(application, /Personal Vault открыт паролем аккаунта/u);
+  assert.match(application, /Legacy Personal Vault будет автоматически переведён/u);
+  assert.match(application, /vaultUI\.mode\("waiting"\)/u);
+  assert.doesNotMatch(application, /vaultUI\.showRecovery\(\)/u);
   assert.match(application, /ensureTeamDeviceIdentity/u);
   assert.match(application, /synchronizeTeamVault/u);
   assert.match(application, /provisionTeamVaultWrappers/u);


### PR DESCRIPTION
## Что исправлено

- macOS при обычном входе автоматически переводит legacy Recovery-wrapped Personal Vault на account-password wrapper;
- источником новой активной ревизии служит полный локальный Vault этого Mac;
- миграция запрещена на пустом устройстве, поэтому новый Mac не может затереть Cloud Vault;
- прежний ciphertext остаётся в серверной таблице `vault_revisions`;
- веб-интерфейс больше не показывает Recovery-ввод в обычном account flow и ожидает автоматическую миграцию с Mac;
- добавлены контрактные проверки macOS и веб-пути.

## Ожидаемый live-сценарий

На Mac с локальными данными пользователь только входит в Cloud и один раз подтверждает доступ macOS Keychain. Personal Vault r1 автоматически становится следующей account-wrapped ревизией, после чего приложение и сайт разблокируют его паролем аккаунта без Recovery-фразы.