### PR TITLE
Improve account continuity and invitation UX

### DIFF
--- a/Sources/SelectiveRemote/CloudTeamInvitationPrompt.swift
+++ b/Sources/SelectiveRemote/CloudTeamInvitationPrompt.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+
+struct SelectiveRemoteCloudTeamInvitationPrompt: ViewModifier {
+    @AppStorage("SelectiveRemote.cloud.endpoint.v1")
+    private var endpoint = SelectiveRemoteCloudEndpoint.production
+
+    @State private var invitation: SelectiveRemoteCloudTeamInvitation?
+    @State private var dismissedInvitationIDs: Set<UUID> = []
+    @State private var isAccepting = false
+    @State private var errorMessage: String?
+
+    private let client = SelectiveRemoteCloudAPIClient()
+
+    func body(content: Content) -> some View {
+        content
+            .task { await pollForInvitations() }
+            .sheet(item: $invitation) { value in
+                invitationSheet(value)
+            }
+    }
+
+    @ViewBuilder
+    private func invitationSheet(_ value: SelectiveRemoteCloudTeamInvitation) -> some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Label {
+                Text(UpdateLocalization.text(
+                    ru: "Приглашение в команду",
+                    en: "Team invitation"
+                ))
+                .font(.title2.bold())
+            } icon: {
+                Image(systemName: "person.3.fill")
+                    .font(.title2)
+                    .foregroundStyle(Color.accentColor)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(value.teamName ?? "Team")
+                    .font(.headline)
+                Text(UpdateLocalization.text(
+                    ru: "Вас пригласили с ролью «\(roleTitle(value.role))». После принятия общие хосты и Vaults появятся в приложении автоматически.",
+                    en: "You were invited as \(roleTitle(value.role)). Shared hosts and Vaults will appear automatically after you accept."
+                ))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .font(.caption)
+            }
+
+            HStack {
+                Button(UpdateLocalization.text(ru: "Позже", en: "Later")) {
+                    dismissedInvitationIDs.insert(value.id)
+                    invitation = nil
+                    errorMessage = nil
+                }
+                .disabled(isAccepting)
+                Spacer()
+                Button(UpdateLocalization.text(ru: "Принять", en: "Accept")) {
+                    accept(value)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isAccepting)
+            }
+        }
+        .padding(28)
+        .frame(width: 470)
+        .interactiveDismissDisabled()
+    }
+
+    @MainActor
+    private func pollForInvitations() async {
+        while !Task.isCancelled {
+            await refreshInvitation()
+            try? await Task.sleep(for: .seconds(60))
+        }
+    }
+
+    @MainActor
+    private func refreshInvitation() async {
+        guard invitation == nil,
+              let url = try? SelectiveRemoteCloudEndpoint.normalized(endpoint),
+              client.hasStoredSession(endpoint: url)
+        else { return }
+        do {
+            invitation = try await client.pendingTeamInvitations(endpoint: url)
+                .first { !dismissedInvitationIDs.contains($0.id) }
+        } catch {
+            // A missing or expired Cloud session must not interrupt local-only work.
+        }
+    }
+
+    private func accept(_ value: SelectiveRemoteCloudTeamInvitation) {
+        guard let url = try? SelectiveRemoteCloudEndpoint.normalized(endpoint) else { return }
+        isAccepting = true
+        errorMessage = nil
+        Task { @MainActor in
+            do {
+                _ = try await client.acceptTeamInvitation(endpoint: url, invitationID: value.id)
+                invitation = nil
+                NotificationCenter.default.post(
+                    name: .selectiveRemoteCloudTeamMembershipChanged,
+                    object: nil
+                )
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+            isAccepting = false
+        }
+    }
+
+    private func roleTitle(_ role: SelectiveRemoteCloudTeamRole) -> String {
+        switch role {
+        case .owner: UpdateLocalization.text(ru: "Владелец", en: "Owner")
+        case .admin: UpdateLocalization.text(ru: "Администратор", en: "Admin")
+        case .editor: UpdateLocalization.text(ru: "Редактор", en: "Editor")
+        case .viewer: UpdateLocalization.text(ru: "Наблюдатель", en: "Viewer")
+        }
+    }
+}

--- a/Sources/SelectiveRemote/CloudTeamInvitationPrompt.swift
+++ b/Sources/SelectiveRemote/CloudTeamInvitationPrompt.swift
@@ -83,7 +83,7 @@ struct SelectiveRemoteCloudTeamInvitationPrompt: ViewModifier {
     private func refreshInvitation() async {
         guard invitation == nil,
               let url = try? SelectiveRemoteCloudEndpoint.normalized(endpoint),
-              client.hasStoredSession(endpoint: url)
+              await client.hasStoredSession(endpoint: url)
         else { return }
         do {
             invitation = try await client.pendingTeamInvitations(endpoint: url)

--- a/Sources/SelectiveRemote/SelectiveRemoteApp.swift
+++ b/Sources/SelectiveRemote/SelectiveRemoteApp.swift
@@ -8,6 +8,9 @@ extension Notification.Name {
     static let selectiveRemotePersonalVaultSyncNow = Notification.Name(
         "SelectiveRemote.personalVaultSyncNow"
     )
+    static let selectiveRemoteCloudTeamMembershipChanged = Notification.Name(
+        "SelectiveRemote.cloudTeamMembershipChanged"
+    )
 }
 
 @MainActor
@@ -156,6 +159,7 @@ struct SelectiveRemoteApp: App {
                     .environmentObject(appAppearance)
                     .environment(\.locale, language.locale)
                     .toggleStyle(SelectiveRemoteCheckboxToggleStyle())
+                    .modifier(SelectiveRemoteCloudTeamInvitationPrompt())
                     .frame(minWidth: 1050, minHeight: 700)
                     .onAppear {
                         model.presentWhatsNewAfterUpgradeIfNeeded()

--- a/Sources/SelectiveRemote/UpdateExperienceView.swift
+++ b/Sources/SelectiveRemote/UpdateExperienceView.swift
@@ -34,7 +34,7 @@ struct AppSettingsView: View {
                 .tabItem { Label("Резервная копия", systemImage: "externaldrive.badge.timemachine") }
                 .tag("backup")
         }
-        .frame(width: 610, height: 520)
+        .frame(minWidth: 760, idealWidth: 820, minHeight: 600, idealHeight: 680)
         .background {
             AppWindowBackdrop(appearance: appearance.snapshot)
                 .ignoresSafeArea()

--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -1818,6 +1818,10 @@ export async function initializeCloudAccount({
   const teamDeviceRepository = createIndexedDBTeamDeviceRepository();
   let activeConflicts = null;
   let backgroundSyncing = false;
+  const sessionTabID = globalThis.crypto?.randomUUID?.() ?? null;
+  const sessionChannel = sessionTabID && typeof globalThis.BroadcastChannel === "function"
+    ? new globalThis.BroadcastChannel("selective-remote.personal-vault.session.v1")
+    : null;
   vaultUI.setConflictResetListener(() => {
     activeConflicts = null;
     conflictApply.disabled = true;
@@ -1869,6 +1873,56 @@ export async function initializeCloudAccount({
       backgroundSyncing = false;
     }
   }
+
+  async function requestUnlockedVaultFromOtherTab() {
+    const user = client.session();
+    if (!sessionChannel || !user || await vault.status() === "unlocked") return;
+    try {
+      sessionChannel.postMessage({
+        version: 1,
+        type: "request",
+        requester: sessionTabID,
+        userID: user.id,
+      });
+    } catch {
+      // Browser session remains signed in; manual account sign-in can still unlock the Vault.
+    }
+  }
+
+  sessionChannel?.addEventListener("message", (event) => {
+    const value = event?.data;
+    const user = client.session();
+    if (!value || value.version !== 1 || !user || value.userID !== user.id) return;
+    if (value.type === "request" && value.requester !== sessionTabID) {
+      try {
+        sessionChannel.postMessage({
+          version: 1,
+          type: "key",
+          requester: value.requester,
+          responder: sessionTabID,
+          userID: user.id,
+          key: vault.sessionKey(),
+        });
+      } catch {
+        // This tab is locked or the browser cannot clone CryptoKey values.
+      }
+      return;
+    }
+    if (value.type !== "key" || value.requester !== sessionTabID || value.responder === sessionTabID) return;
+    void (async () => {
+      try {
+        if (await vault.status() !== "locked") return;
+        await vault.unlockWithSessionKey(value.key);
+        vaultUI.mode("unlocked");
+        vaultUI.render();
+        setText(vaultMessage, "Personal Vault разблокирован активной вкладкой и синхронизируется автоматически.");
+        await backgroundPersonalVaultSync();
+      } catch {
+        // Only a key that decrypts this local encrypted snapshot is accepted.
+      }
+    })();
+  });
+  globalThis.addEventListener?.("pagehide", () => sessionChannel?.close(), { once: true });
 
   const personalVaultTimer = globalThis.setInterval(
     () => { void backgroundPersonalVaultSync(); },
@@ -2116,6 +2170,9 @@ export async function initializeCloudAccount({
   usernameForm.addEventListener("input", async () => {
     const username = usernameForm.elements.username.value.trim().toLowerCase();
     if (username.length < 3) return setSettingsMessage(usernameAvailability, "Минимум 3 символа.");
+    if (username === client.session()?.username.toLowerCase()) {
+      return setSettingsMessage(usernameAvailability, `@${username} — ваш текущий username.`);
+    }
     try {
       const result = await client.usernameAvailability(username);
       setSettingsMessage(usernameAvailability, result.available ? `@${result.username} свободен` : `@${result.username} уже занят`, result.available ? "success" : "error");
@@ -2126,6 +2183,12 @@ export async function initializeCloudAccount({
 
   usernameForm.addEventListener("submit", async (event) => {
     event.preventDefault();
+    const requestedUsername = usernameForm.elements.username.value.trim().toLowerCase();
+    if (requestedUsername === client.session()?.username.toLowerCase()) {
+      setSettingsMessage(usernameMessage, "Username уже установлен для этого аккаунта.");
+      usernameForm.elements.password.value = "";
+      return;
+    }
     const button = usernameForm.querySelector('button[type="submit"]');
     button.disabled = true;
     try {
@@ -2258,7 +2321,8 @@ export async function initializeCloudAccount({
     showSession(restoredUser);
     if (await vault.status() !== "unlocked") {
       vaultUI.mode("waiting");
-      setText(vaultMessage, "Personal Vault заблокирован. Войдите в аккаунт, чтобы увидеть данные.");
+      setText(vaultMessage, "Personal Vault заблокирован. Ищем открытую вкладку этого аккаунта…");
+      await requestUnlockedVaultFromOtherTab();
     }
     let identity = null;
     try {

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Защищённая синхронизация Selective Remote">
   <title>Selective Remote Cloud</title>
-  <link rel="stylesheet" href="/styles.css?v=116">
+  <link rel="stylesheet" href="/styles.css?v=117">
 </head>
 <body>
   <main class="shell">
@@ -593,6 +593,6 @@
       <p>Регистрация доступна только во время контролируемого окна. Вход, подтверждение почты и восстановление пароля остаются доступны для существующего аккаунта.</p>
     </section>
   </main>
-  <script type="module" src="/app.js?v=116"></script>
+  <script type="module" src="/app.js?v=117"></script>
 </body>
 </html>

--- a/cloud/public/vault-local.js
+++ b/cloud/public/vault-local.js
@@ -242,6 +242,35 @@ export function createLocalVaultController({
       return clone(document);
     },
 
+    sessionKey() {
+      requireUnlocked();
+      return vaultKey;
+    },
+
+    async unlockWithSessionKey(nextVaultKey) {
+      if (snapshot || vaultKey || document) throw new Error("local_vault_not_locked");
+      const algorithm = nextVaultKey?.algorithm;
+      const usages = Array.from(nextVaultKey?.usages ?? []);
+      if (nextVaultKey?.type !== "secret"
+          || algorithm?.name !== "AES-GCM"
+          || algorithm?.length !== 256
+          || !usages.includes("encrypt")
+          || !usages.includes("decrypt")) {
+        throw new Error("invalid_vault_session_key");
+      }
+      const stored = await repository.load();
+      if (!stored) throw new Error("local_vault_missing");
+      const nextSnapshot = validatedSnapshot(stored);
+      const nextDocument = validateVaultDocument(
+        await decryptVaultEnvelope(nextVaultKey, nextSnapshot.envelope, cryptoValue),
+      );
+      snapshot = nextSnapshot;
+      vaultKey = nextVaultKey;
+      document = nextDocument;
+      pendingConflicts = null;
+      return clone(document);
+    },
+
     lock() {
       snapshot = null;
       vaultKey = null;

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -450,6 +450,21 @@ test("macOS credentials, Cloud session, and device keys share one Keychain item"
   assert.doesNotMatch(envelope, /teamID|vaultID|hostID/u);
 });
 
+test("macOS surfaces username Team invitations and uses a roomier settings window", async () => {
+  const [prompt, app, settings] = await Promise.all([
+    readFile(new URL("CloudTeamInvitationPrompt.swift", sourceRoot), "utf8"),
+    readFile(new URL("SelectiveRemoteApp.swift", sourceRoot), "utf8"),
+    readFile(new URL("UpdateExperienceView.swift", sourceRoot), "utf8"),
+  ]);
+  assert.match(prompt, /pendingTeamInvitations/u);
+  assert.match(prompt, /acceptTeamInvitation/u);
+  assert.match(prompt, /Приглашение в команду/u);
+  assert.match(prompt, /Позже/u);
+  assert.match(prompt, /Task\.sleep\(for: \.seconds\(60\)\)/u);
+  assert.match(app, /SelectiveRemoteCloudTeamInvitationPrompt/u);
+  assert.match(settings, /\.frame\(minWidth: 760, idealWidth: 820, minHeight: 600, idealHeight: 680\)/u);
+});
+
 
 test("macOS Personal Vault auto-sync preserves encrypted credentials without extra Keychain items", async () => {
   const [sync, crypto, settings, app, snippets] = await Promise.all([

--- a/cloud/tests/public-vault-local.test.mjs
+++ b/cloud/tests/public-vault-local.test.mjs
@@ -61,6 +61,27 @@ test("lock drops the in-memory key and wrong recovery passphrases fail closed", 
   assert.throws(() => vault.document(), /local_vault_locked/);
 });
 
+test("an unlocked tab can hand its in-memory key to another tab without persisting it", async () => {
+  const repository = memoryRepository();
+  const firstTab = controller(repository);
+  await firstTab.create(passphrase);
+  await firstTab.upsert({ type: "host", data: { title: "Shared tab", address: "tab.invalid" } });
+
+  const secondTab = controller(repository);
+  assert.equal(await secondTab.status(), "locked");
+  const keyClone = structuredClone(firstTab.sessionKey());
+  assert.equal((await secondTab.unlockWithSessionKey(keyClone)).records[0].data.title, "Shared tab");
+
+  secondTab.lock();
+  const wrongKey = await webcrypto.subtle.generateKey(
+    { name: "AES-GCM", length: 256 },
+    true,
+    ["encrypt", "decrypt"],
+  );
+  await assert.rejects(secondTab.unlockWithSessionKey(wrongKey));
+  assert.equal(await secondTab.status(), "locked");
+});
+
 test("rewrap migrates an unlocked Vault to a new account passphrase", async () => {
   const repository = memoryRepository();
   const vault = controller(repository);

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -272,6 +272,8 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(styles, /prefers-reduced-motion:reduce[^}]*[\s\S]*animation:none!important/u);
   assert.match(styles, /\.team-members article\s*\{[^}]*grid-template-columns:minmax\(180px,1fr\) minmax\(110px,auto\)/u);
   assert.match(application, /initializePortalNavigation/u);
+  assert.match(application, /BroadcastChannel\("selective-remote\.personal-vault\.session\.v1"\)/u);
+  assert.match(application, /ваш текущий username/u);
   assert.match(application, /teamUI\?\.setView\(teamView \|\| "teams"\)/u);
   assert.match(application, /Team «\$\{selectedTeam\.name\}» · участников: \$\{teamMembers\.length\}/u);
   assert.match(application, /Команда «\$\{selectedTeam\.name\}» · папок: \$\{vaults\.length\}/u);


### PR DESCRIPTION
## Что изменено

- новая вкладка браузера безопасно запрашивает уже разблокированный ключ Personal Vault у другой активной вкладки того же аккаунта через `BroadcastChannel`; пароль и ключ не сохраняются в Web Storage
- подменённый ключ принимается только если он действительно расшифровывает локальный E2EE-снимок
- текущий `@username` больше не показывается как свободный и не отправляется как бессмысленное изменение
- macOS-приложение автоматически проверяет адресные приглашения в команды и показывает предложение «Принять / Позже»
- окно настроек стало шире и выше, с возможностью занять больше полезного пространства
- web assets обновлены до v117

## Проверка

- `npm test`: 293 passed, 1 skipped (интеграционный PostgreSQL-тест без `TEST_DATABASE_URL`)
- целевые browser/macOS source tests: 42 passed
- `git diff --check`
- локальная Swift-компиляция недоступна в Linux-окружении; её выполняет GitHub Actions

## Безопасность

- Cloud остаётся необязательным: локальные credentials используют единый Keychain vault независимо от Cloud
- межвкладочный ключ существует только в памяти открытых same-origin вкладок и не переживает закрытие браузера
- принятие приглашения требует действующей сохранённой Cloud-сессии