### PR TITLE
Automate Vault conflict resolution and improve Team workspace

### DIFF
--- a/Sources/SelectiveRemote/CloudAPIClient.swift
+++ b/Sources/SelectiveRemote/CloudAPIClient.swift
@@ -58,6 +58,36 @@ enum SelectiveRemoteCloudError: LocalizedError, Equatable {
                     ru: "Сервер ещё не настроен для отправки письма подтверждения.",
                     en: "The server is not configured to send verification email yet."
                 )
+            case "account_not_found":
+                UpdateLocalization.text(
+                    ru: "Пользователь с таким username не найден.",
+                    en: "No user with that username was found."
+                )
+            case "team_member_exists":
+                UpdateLocalization.text(
+                    ru: "Этот пользователь уже состоит в команде.",
+                    en: "This user is already a Team member."
+                )
+            case "username_exists":
+                UpdateLocalization.text(
+                    ru: "Этот username уже занят.",
+                    en: "This username is already taken."
+                )
+            case "team_access_denied":
+                UpdateLocalization.text(
+                    ru: "Для этого действия недостаточно прав в команде.",
+                    en: "Your Team role does not allow this action."
+                )
+            case "team_not_found":
+                UpdateLocalization.text(
+                    ru: "Команда больше не существует или недоступна.",
+                    en: "The Team no longer exists or is unavailable."
+                )
+            case "team_last_owner":
+                UpdateLocalization.text(
+                    ru: "В команде должен остаться хотя бы один владелец.",
+                    en: "A Team must keep at least one owner."
+                )
             default:
                 UpdateLocalization.text(
                     ru: "Cloud недоступен (HTTP \(status)\(code.map { ": \($0)" } ?? "")).",

--- a/Sources/SelectiveRemote/CloudPersonalVaultAutoSync.swift
+++ b/Sources/SelectiveRemote/CloudPersonalVaultAutoSync.swift
@@ -338,7 +338,12 @@ actor SelectiveRemotePersonalVaultAutoSync {
         }
         let concurrentChange = remote.revision != material.revision
         let document = concurrentChange
-            ? try mergeConcurrent(local: exported.document, remote: remote, vaultKey: material.vaultKey)
+            ? try mergeConcurrent(
+                local: exported.document,
+                remote: remote,
+                vaultKey: material.vaultKey,
+                deviceID: deviceID
+            )
             : try mergedDocument(
                 local: exported.document,
                 remote: remote,
@@ -369,31 +374,20 @@ actor SelectiveRemotePersonalVaultAutoSync {
     private func mergeConcurrent(
         local: SelectiveRemoteVaultDocument,
         remote: SelectiveRemoteCloudPersonalVault,
-        vaultKey: Data
+        vaultKey: Data,
+        deviceID: UUID
     ) throws -> SelectiveRemoteVaultDocument {
         guard let envelope = remote.envelope else {
             throw SelectiveRemotePersonalVaultError.invalidEnvelope
         }
         let current = try SelectiveRemotePersonalVaultCrypto.open(envelope, vaultKey: vaultKey)
-        var records = Dictionary(uniqueKeysWithValues: current.records.map { ($0.id, $0) })
-        for record in local.records {
-            if let existing = records[record.id], existing.modifiedAt > record.modifiedAt { continue }
-            records[record.id] = record
-        }
-        var tombstones = Dictionary(uniqueKeysWithValues: current.tombstones.map { ($0.id, $0) })
-        for tombstone in local.tombstones {
-            if let existing = tombstones[tombstone.id], existing.deletedAt > tombstone.deletedAt { continue }
-            tombstones[tombstone.id] = tombstone
-        }
-        for (id, tombstone) in tombstones {
-            if let record = records[id], tombstone.deletedAt >= record.modifiedAt {
-                records.removeValue(forKey: id)
-            }
-        }
-        return try .init(
-            records: records.values.sorted { $0.id.uuidString < $1.id.uuidString },
-            tombstones: tombstones.values.sorted { $0.id.uuidString < $1.id.uuidString }
-        )
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return try local.mergedKeepingNewest(
+            with: current,
+            deviceID: deviceID,
+            resolvedAt: formatter.string(from: Date())
+        ).document
     }
 
     private func mergedDocument(

--- a/Sources/SelectiveRemote/CloudTeamManagementView.swift
+++ b/Sources/SelectiveRemote/CloudTeamManagementView.swift
@@ -70,7 +70,12 @@ struct SelectiveRemoteCloudTeamManagementView: View {
                 )
             }
         }
-        .frame(minWidth: 820, minHeight: 600)
+        .frame(
+            minWidth: 1_020,
+            idealWidth: 1_160,
+            minHeight: 700,
+            idealHeight: 800
+        )
         .toolbar {
             ToolbarItem(placement: .automatic) {
                 Button(UpdateLocalization.text(ru: "Обновить", en: "Refresh"), systemImage: "arrow.clockwise") {
@@ -133,54 +138,121 @@ struct SelectiveRemoteCloudTeamManagementView: View {
     }
 
     private func membersView(_ team: SelectiveRemoteCloudTeam) -> some View {
-        Form {
-            Section(UpdateLocalization.text(ru: "Участники", en: "Members")) {
-                ForEach(members) { member in
-                    HStack {
-                        VStack(alignment: .leading) {
+        HSplitView {
+            VStack(alignment: .leading, spacing: 12) {
+                Label(
+                    UpdateLocalization.text(ru: "Участники", en: "Members"),
+                    systemImage: "person.2.fill"
+                )
+                .font(.headline)
+
+                List(members) { member in
+                    HStack(spacing: 12) {
+                        Image(systemName: "person.crop.circle.fill")
+                            .font(.title2)
+                            .foregroundStyle(Color.accentColor)
+                        VStack(alignment: .leading, spacing: 3) {
                             Text(member.displayName).font(.headline)
-                            Text("@\(member.username)").font(.caption).foregroundStyle(.secondary)
+                            Text("@\(member.username)")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
                         }
                         Spacer()
-                        Text(roleTitle(member.role)).foregroundStyle(.secondary)
+                        Text(roleTitle(member.role))
+                            .font(.callout.weight(.medium))
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.vertical, 6)
+                }
+                .listStyle(.inset)
+            }
+            .padding(16)
+            .frame(minWidth: 360, idealWidth: 430, maxWidth: 520)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    if team.role == .owner || team.role == .admin {
+                        usernameInvitationCard(team)
+                        alternativeInvitationCard(team)
+                        activeInvitationsCard
+                    } else {
+                        ContentUnavailableView(
+                            UpdateLocalization.text(
+                                ru: "Управление участниками недоступно",
+                                en: "Member Management Unavailable"
+                            ),
+                            systemImage: "person.badge.shield.checkmark",
+                            description: Text(UpdateLocalization.text(
+                                ru: "Приглашения доступны владельцу и администраторам команды.",
+                                en: "Invitations are available to the Team owner and administrators."
+                            ))
+                        )
                     }
                 }
+                .padding(18)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
             }
+            .frame(minWidth: 480, maxWidth: .infinity)
+        }
+    }
 
-            if team.role == .owner || team.role == .admin {
-                Section(UpdateLocalization.text(ru: "Пригласить на 48 часов", en: "Invite for 48 Hours")) {
-                    TextField("@username", text: $invitationUsername)
-                    Picker(UpdateLocalization.text(ru: "Роль", en: "Role"), selection: $invitationRole) {
-                        Text(roleTitle(.viewer)).tag(SelectiveRemoteCloudTeamRole.viewer)
-                        Text(roleTitle(.editor)).tag(SelectiveRemoteCloudTeamRole.editor)
-                        if team.role == .owner {
-                            Text(roleTitle(.admin)).tag(SelectiveRemoteCloudTeamRole.admin)
-                        }
+    private func usernameInvitationCard(_ team: SelectiveRemoteCloudTeam) -> some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 12) {
+                TextField("@username", text: $invitationUsername)
+                    .textFieldStyle(.roundedBorder)
+                Picker(UpdateLocalization.text(ru: "Роль", en: "Role"), selection: $invitationRole) {
+                    Text(roleTitle(.viewer)).tag(SelectiveRemoteCloudTeamRole.viewer)
+                    Text(roleTitle(.editor)).tag(SelectiveRemoteCloudTeamRole.editor)
+                    if team.role == .owner {
+                        Text(roleTitle(.admin)).tag(SelectiveRemoteCloudTeamRole.admin)
                     }
-                    Button(UpdateLocalization.text(ru: "Отправить приглашение", en: "Send Invitation")) {
-                        invite(team)
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(isBusy || normalized(invitationUsername).isEmpty)
+                }
+                .pickerStyle(.segmented)
+                Button(UpdateLocalization.text(ru: "Отправить приглашение", en: "Send Invitation")) {
+                    invite(team)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .disabled(isBusy || normalized(invitationUsername).isEmpty)
+            }
+            .padding(4)
+        } label: {
+            Label(
+                UpdateLocalization.text(ru: "Пригласить по username", en: "Invite by Username"),
+                systemImage: "at"
+            )
+        }
+    }
 
+    private func alternativeInvitationCard(_ team: SelectiveRemoteCloudTeam) -> some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 10) {
                     TextField("Email", text: $invitationEmail)
-                    Button(UpdateLocalization.text(ru: "Пригласить по email", en: "Invite by Email")) { inviteByEmail(team) }
-                        .disabled(isBusy || normalized(invitationEmail).isEmpty)
+                        .textFieldStyle(.roundedBorder)
+                    Button(UpdateLocalization.text(ru: "Пригласить", en: "Invite")) {
+                        inviteByEmail(team)
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(isBusy || normalized(invitationEmail).isEmpty)
+                }
 
+                Divider()
+
+                HStack {
                     Button(
                         UpdateLocalization.text(ru: "Создать одноразовую ссылку", en: "Create Single-Use Link"),
                         systemImage: "link.badge.plus"
                     ) {
                         createInvitationLink(team)
                     }
+                    .buttonStyle(.bordered)
                     .disabled(isBusy)
-
+                    Spacer()
                     if let latestInvitationURL {
-                        Text(latestInvitationURL)
-                            .font(.caption.monospaced())
-                            .textSelection(.enabled)
                         Button(
-                            UpdateLocalization.text(ru: "Скопировать ссылку", en: "Copy Link"),
+                            UpdateLocalization.text(ru: "Скопировать", en: "Copy"),
                             systemImage: "doc.on.doc"
                         ) {
                             copyInvitationLink(latestInvitationURL)
@@ -188,33 +260,58 @@ struct SelectiveRemoteCloudTeamManagementView: View {
                     }
                 }
 
-                Section(UpdateLocalization.text(ru: "Активные приглашения", en: "Active Invitations")) {
-                    if invitations.isEmpty {
-                        Text(UpdateLocalization.text(ru: "Активных приглашений нет.", en: "There are no active invitations."))
-                            .foregroundStyle(.secondary)
-                    }
-                    ForEach(invitations) { invitation in
-                        HStack {
-                            VStack(alignment: .leading, spacing: 3) {
-                                Text(invitationTitle(invitation))
-                                Text("\(roleTitle(invitation.role)) · \(invitation.expiresAt)")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                            Spacer()
-                            Button(
-                                UpdateLocalization.text(ru: "Отозвать", en: "Revoke"),
-                                role: .destructive
-                            ) {
-                                cancel(invitation)
-                            }
-                            .disabled(isBusy)
+                if let latestInvitationURL {
+                    Text(latestInvitationURL)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
+            }
+            .padding(4)
+        } label: {
+            Label(
+                UpdateLocalization.text(ru: "Другие способы", en: "Other Methods"),
+                systemImage: "paperplane"
+            )
+        }
+    }
+
+    private var activeInvitationsCard: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 10) {
+                if invitations.isEmpty {
+                    Text(UpdateLocalization.text(
+                        ru: "Активных приглашений нет.",
+                        en: "There are no active invitations."
+                    ))
+                    .foregroundStyle(.secondary)
+                }
+                ForEach(invitations) { invitation in
+                    HStack {
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(invitationTitle(invitation))
+                            Text("\(roleTitle(invitation.role)) · \(invitation.expiresAt)")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
                         }
+                        Spacer()
+                        Button(
+                            UpdateLocalization.text(ru: "Отозвать", en: "Revoke"),
+                            role: .destructive
+                        ) {
+                            cancel(invitation)
+                        }
+                        .disabled(isBusy)
                     }
                 }
             }
+            .padding(4)
+        } label: {
+            Label(
+                UpdateLocalization.text(ru: "Активные приглашения", en: "Active Invitations"),
+                systemImage: "clock.badge"
+            )
         }
-        .formStyle(.grouped)
     }
 
     private func vaultsView(_ team: SelectiveRemoteCloudTeam) -> some View {
@@ -250,8 +347,8 @@ struct SelectiveRemoteCloudTeamManagementView: View {
             Label("Team Hosts", systemImage: "server.rack")
         } description: {
             Text(UpdateLocalization.text(
-                ru: "Хосты добавляются из контекстного меню основного списка: «Поделиться с командой…». Просмотр и редактирование Team Hosts появятся здесь следующим этапом.",
-                en: "Add hosts from the main list context menu using Share with Team. Team Host browsing and editing will be added here next."
+                ru: "Просмотр, подключение и редактирование доступны в разделе Team Hosts главного окна. Вложенные папки и drag-and-drop добавляются следующим этапом.",
+                en: "Browse, connect, and edit in Team Hosts in the main window. Nested folders and drag-and-drop are the next milestone."
             ))
         }
     }

--- a/Sources/SelectiveRemote/CloudTeamVaultAutoSync.swift
+++ b/Sources/SelectiveRemote/CloudTeamVaultAutoSync.swift
@@ -142,11 +142,45 @@ actor SelectiveRemoteTeamVaultAutoSync {
                                 vault: vault,
                                 value: value
                             ))
+                        case let .conflict(conflict):
+                            let resolved = try await coordinator.resolveRecordConflictsKeepingNewest(
+                                conflict,
+                                resolvedAt: Self.timestamp(Date()),
+                                teamID: team.id,
+                                vaultID: vault.id,
+                                identity: identity
+                            )
+                            switch resolved {
+                            case let .uploaded(value, _):
+                                report.uploadedVaults += 1
+                                materialized.append(Self.materializedSnapshot(
+                                    team: team,
+                                    vault: vault,
+                                    value: value
+                                ))
+                            case .conflict:
+                                report.conflicts += 1
+                            }
+                        }
+                    case let .conflict(conflict):
+                        let resolved = try await coordinator.resolveRecordConflictsKeepingNewest(
+                            conflict,
+                            resolvedAt: Self.timestamp(Date()),
+                            teamID: team.id,
+                            vaultID: vault.id,
+                            identity: identity
+                        )
+                        switch resolved {
+                        case let .uploaded(value, _):
+                            report.uploadedVaults += 1
+                            materialized.append(Self.materializedSnapshot(
+                                team: team,
+                                vault: vault,
+                                value: value
+                            ))
                         case .conflict:
                             report.conflicts += 1
                         }
-                    case .conflict:
-                        report.conflicts += 1
                     }
                 } catch is CancellationError {
                     throw CancellationError()
@@ -179,6 +213,12 @@ actor SelectiveRemoteTeamVaultAutoSync {
             keyGeneration: value.snapshot.keyGeneration,
             payload: value.payload
         )
+    }
+
+    private static func timestamp(_ value: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: value)
     }
 
     private func runLoop() async {

--- a/Sources/SelectiveRemote/CloudVaultRecordModel.swift
+++ b/Sources/SelectiveRemote/CloudVaultRecordModel.swift
@@ -273,6 +273,11 @@ struct SelectiveRemoteVaultMerge: Equatable, Sendable {
     let conflicts: [SelectiveRemoteVaultConflict]
 }
 
+struct SelectiveRemoteVaultAutomaticMerge: Equatable, Sendable {
+    let document: SelectiveRemoteVaultDocument
+    let resolvedConflictCount: Int
+}
+
 enum SelectiveRemoteVaultConflictChoice: String, Codable, Equatable, Hashable, Sendable {
     case local
     case remote
@@ -397,6 +402,32 @@ struct SelectiveRemoteVaultDocument: Equatable, Sendable, Codable {
         return try .init(document: .init(records: records, tombstones: tombstones), conflicts: conflicts)
     }
 
+    func mergedKeepingNewest(
+        with remote: Self,
+        deviceID: UUID,
+        resolvedAt: String
+    ) throws -> SelectiveRemoteVaultAutomaticMerge {
+        let merge = try merged(with: remote)
+        let resolutions = try merge.conflicts.map { conflict in
+            SelectiveRemoteVaultConflictResolution(
+                id: conflict.id,
+                choice: try conflict.newestChoice()
+            )
+        }
+        let monotonicResolvedAt = merge.conflicts.reduce(resolvedAt) { result, conflict in
+            max(result, max(conflict.local.eventTimestamp, conflict.remote.eventTimestamp))
+        }
+        return try .init(
+            document: merge.document.resolving(
+                merge.conflicts,
+                with: resolutions,
+                deviceID: deviceID,
+                resolvedAt: monotonicResolvedAt
+            ),
+            resolvedConflictCount: merge.conflicts.count
+        )
+    }
+
     func resolving(
         _ conflicts: [SelectiveRemoteVaultConflict],
         with resolutions: [SelectiveRemoteVaultConflictResolution],
@@ -462,6 +493,45 @@ struct SelectiveRemoteVaultDocument: Equatable, Sendable, Codable {
     }
 }
 
+private extension SelectiveRemoteVaultEntity {
+    var eventTimestamp: String {
+        switch self {
+        case let .record(value): value.modifiedAt
+        case let .tombstone(value): value.deletedAt
+        }
+    }
+
+    var isDeletion: Bool {
+        if case .tombstone = self { return true }
+        return false
+    }
+
+    func canonicalData() throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        switch self {
+        case let .record(value):
+            return Data([0]) + (try encoder.encode(value))
+        case let .tombstone(value):
+            return Data([1]) + (try encoder.encode(value))
+        }
+    }
+}
+
+private extension SelectiveRemoteVaultConflict {
+    func newestChoice() throws -> SelectiveRemoteVaultConflictChoice {
+        if local.eventTimestamp != remote.eventTimestamp {
+            return local.eventTimestamp > remote.eventTimestamp ? .local : .remote
+        }
+        if local.isDeletion != remote.isDeletion {
+            return local.isDeletion ? .local : .remote
+        }
+        let localData = try local.canonicalData()
+        let remoteData = try remote.canonicalData()
+        return remoteData.lexicographicallyPrecedes(localData) ? .local : .remote
+    }
+}
+
 struct SelectiveRemoteTeamVaultRecordConflict: Equatable, Sendable {
     let transport: SelectiveRemoteTeamVaultConflict
     let mergedDocument: SelectiveRemoteVaultDocument
@@ -514,6 +584,30 @@ extension SelectiveRemoteTeamVaultSyncCoordinator {
         case let .conflict(updated):
             return .conflict(try prepareRecordConflict(updated))
         }
+    }
+
+    func resolveRecordConflictsKeepingNewest(
+        _ conflict: SelectiveRemoteTeamVaultConflict,
+        resolvedAt: String,
+        teamID: UUID,
+        vaultID: UUID,
+        identity: SelectiveRemoteTeamDeviceIdentity
+    ) async throws -> SelectiveRemoteTeamVaultRecordPushOutcome {
+        let prepared = try prepareRecordConflict(conflict)
+        let resolutions = try prepared.recordConflicts.map { value in
+            SelectiveRemoteVaultConflictResolution(
+                id: value.id,
+                choice: try value.newestChoice()
+            )
+        }
+        return try await resolveRecordConflicts(
+            prepared,
+            resolutions: resolutions,
+            resolvedAt: resolvedAt,
+            teamID: teamID,
+            vaultID: vaultID,
+            identity: identity
+        )
     }
 }
 

--- a/Tests/SelectiveRemoteTests/CloudVaultRecordModelTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudVaultRecordModelTests.swift
@@ -193,6 +193,55 @@ struct CloudVaultRecordModelTests {
         #expect(resolved.tombstones[0].deletedAt == secondTime)
     }
 
+    @Test("Automatic policy keeps the newest concurrent value and joins histories")
+    func automaticNewestResolution() throws {
+        let older = try record(
+            id: recordA,
+            version: [deviceA: 2],
+            value: "older",
+            modifiedAt: firstTime
+        )
+        let newer = try record(
+            id: recordA,
+            version: [deviceB: 1],
+            value: "newer",
+            modifiedAt: secondTime
+        )
+        let result = try SelectiveRemoteVaultDocument(records: [older]).mergedKeepingNewest(
+            with: SelectiveRemoteVaultDocument(records: [newer]),
+            deviceID: deviceC,
+            resolvedAt: secondTime
+        )
+
+        #expect(result.resolvedConflictCount == 1)
+        #expect(result.document.records[0].data == .object(["value": .string("newer")]))
+        #expect(result.document.records[0].version.counters == [deviceA: 2, deviceB: 1, deviceC: 1])
+    }
+
+    @Test("Equal-time concurrent deletion wins automatically")
+    func automaticDeletionResolution() throws {
+        let edited = try record(
+            id: recordA,
+            version: [deviceA: 2],
+            value: "edited",
+            modifiedAt: secondTime
+        )
+        let deleted = try SelectiveRemoteVaultTombstone(
+            id: recordA,
+            version: .init([deviceA: 1, deviceB: 1]),
+            deletedAt: secondTime
+        )
+        let result = try SelectiveRemoteVaultDocument(records: [edited]).mergedKeepingNewest(
+            with: SelectiveRemoteVaultDocument(tombstones: [deleted]),
+            deviceID: deviceC,
+            resolvedAt: secondTime
+        )
+
+        #expect(result.resolvedConflictCount == 1)
+        #expect(result.document.records.isEmpty)
+        #expect(result.document.tombstones.count == 1)
+    }
+
     private func record(
         id: UUID,
         version: [UUID: Int],

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Защищённая синхронизация Selective Remote">
   <title>Selective Remote Cloud</title>
-  <link rel="stylesheet" href="/styles.css?v=117">
+  <link rel="stylesheet" href="/styles.css?v=118">
 </head>
 <body>
   <main class="shell">
@@ -593,6 +593,6 @@
       <p>Регистрация доступна только во время контролируемого окна. Вход, подтверждение почты и восстановление пароля остаются доступны для существующего аккаунта.</p>
     </section>
   </main>
-  <script type="module" src="/app.js?v=117"></script>
+  <script type="module" src="/app.js?v=118"></script>
 </body>
 </html>

--- a/cloud/public/team-vault-sync.js
+++ b/cloud/public/team-vault-sync.js
@@ -3,6 +3,7 @@ import {
   createEmptyVaultDocument,
   deleteVaultRecord,
   mergeVaultDocuments,
+  resolveVaultConflictsByNewest,
   resolveVaultConflict,
   upsertVaultRecord,
   validateVaultDocument,
@@ -443,8 +444,10 @@ export function createTeamVaultController({
       if (localDocument) {
         const merged = mergeVaultDocuments(localDocument, remoteDocument);
         if (merged.conflicts.length > 0) {
-          pendingConflicts = { revision: remote.revision, document: merged.document, conflicts: clone(merged.conflicts) };
-          return { conflicts: clone(merged.conflicts), revision: remote.revision };
+          merged.document = resolveVaultConflictsByNewest(merged.document, merged.conflicts, {
+            deviceID,
+            resolvedAt: now(),
+          });
         }
         nextDocument = merged.document;
       }
@@ -551,10 +554,14 @@ export function createTeamVaultController({
         cryptoValue,
       }));
       const merged = mergeVaultDocuments(document, remoteDocument);
-      if (merged.conflicts.length > 0) {
-        pendingConflicts = { revision: remote.revision, document: merged.document, conflicts: clone(merged.conflicts) };
-        return { conflicts: clone(merged.conflicts) };
+      const automaticallyResolved = merged.conflicts.length;
+      if (automaticallyResolved > 0) {
+        merged.document = resolveVaultConflictsByNewest(merged.document, merged.conflicts, {
+          deviceID,
+          resolvedAt: now(),
+        });
       }
+      pendingConflicts = null;
       const matchesRemote = JSON.stringify(merged.document) === JSON.stringify(remoteDocument);
       const localChanged = JSON.stringify(merged.document) !== JSON.stringify(document);
       if (matchesRemote) {
@@ -572,7 +579,7 @@ export function createTeamVaultController({
         await persist(merged.document);
         await save({ ...snapshot, serverRevision: remote.revision, wrapper: remote.wrapper ?? snapshot.wrapper });
       }
-      return { conflicts: [], matchesRemote, localChanged };
+      return { conflicts: [], automaticallyResolved, matchesRemote, localChanged };
     },
 
     async mergeRemoteGeneration(remote) {
@@ -598,10 +605,12 @@ export function createTeamVaultController({
         cryptoValue,
       }));
       const merged = mergeVaultDocuments(document, remoteDocument);
-      if (merged.conflicts.length > 0) {
-        pendingGeneration = { remote, vaultKey: nextKey, envelope, wrapper: remote.wrapper };
-        pendingConflicts = { revision: remote.revision, document: merged.document, conflicts: clone(merged.conflicts) };
-        return { conflicts: clone(merged.conflicts) };
+      const automaticallyResolved = merged.conflicts.length;
+      if (automaticallyResolved > 0) {
+        merged.document = resolveVaultConflictsByNewest(merged.document, merged.conflicts, {
+          deviceID,
+          resolvedAt: now(),
+        });
       }
       const matchesRemote = JSON.stringify(merged.document) === JSON.stringify(remoteDocument);
       const nextLocalRevision = snapshot.localRevision + 1;
@@ -629,7 +638,7 @@ export function createTeamVaultController({
       document = merged.document;
       pendingConflicts = null;
       pendingGeneration = null;
-      return { conflicts: [], matchesRemote };
+      return { conflicts: [], automaticallyResolved, matchesRemote };
     },
 
     pendingConflicts() {

--- a/cloud/public/vault-local.js
+++ b/cloud/public/vault-local.js
@@ -9,6 +9,7 @@ import {
   createEmptyVaultDocument,
   deleteVaultRecord,
   mergeVaultDocuments,
+  resolveVaultConflictsByNewest,
   resolveVaultConflict,
   upsertVaultRecord,
   validateVaultDocument,
@@ -355,13 +356,12 @@ export function createLocalVaultController({
         throw new Error("remote_wrapped_key_changed");
       }
       const merged = mergeVaultDocuments(document, remoteDocument);
-      if (merged.conflicts.length > 0) {
-        pendingConflicts = {
-          revision,
-          document: merged.document,
-          conflicts: clone(merged.conflicts),
-        };
-        return { conflicts: clone(merged.conflicts) };
+      const automaticallyResolved = merged.conflicts.length;
+      if (automaticallyResolved > 0) {
+        merged.document = resolveVaultConflictsByNewest(merged.document, merged.conflicts, {
+          deviceID: snapshot.deviceID,
+          resolvedAt: now(),
+        });
       }
       pendingConflicts = null;
       const matchesRemote = JSON.stringify(merged.document) === JSON.stringify(remoteDocument);
@@ -369,6 +369,7 @@ export function createLocalVaultController({
       if (localChanged) await persist(merged.document);
       return {
         conflicts: [],
+        automaticallyResolved,
         matchesRemote,
         localChanged,
       };

--- a/cloud/public/vault-model.js
+++ b/cloud/public/vault-model.js
@@ -173,6 +173,46 @@ function normalizedConflictEntity(entity, id) {
   return { kind: entity.kind, value };
 }
 
+function entityTimestamp(entity) {
+  return entity.kind === "tombstone" ? entity.value.deletedAt : entity.value.modifiedAt;
+}
+
+export function newestVaultConflictChoice(conflict) {
+  if (!conflict || typeof conflict !== "object") throw new Error("invalid_vault_conflict");
+  const id = normalizedUUID(conflict.id, "invalid_vault_conflict");
+  const local = normalizedConflictEntity(conflict.local, id);
+  const remote = normalizedConflictEntity(conflict.remote, id);
+  const localTimestamp = entityTimestamp(local);
+  const remoteTimestamp = entityTimestamp(remote);
+  if (localTimestamp !== remoteTimestamp) return localTimestamp > remoteTimestamp ? "local" : "remote";
+
+  // Equal-time edit/delete races must never resurrect a deleted record. Equal-time
+  // edit/edit races use canonical content as a stable, order-independent fallback.
+  if (local.kind !== remote.kind) return local.kind === "tombstone" ? "local" : "remote";
+  return canonicalEntity(local) >= canonicalEntity(remote) ? "local" : "remote";
+}
+
+export function resolveVaultConflictsByNewest(documentValue, conflicts, {
+  deviceID,
+  resolvedAt = new Date().toISOString(),
+} = {}) {
+  if (!Array.isArray(conflicts)) throw new Error("invalid_vault_conflict");
+  let document = validateVaultDocument(documentValue);
+  for (const conflict of conflicts) {
+    const winnerTimestamp = [
+      entityTimestamp(normalizedConflictEntity(conflict.local, conflict.id)),
+      entityTimestamp(normalizedConflictEntity(conflict.remote, conflict.id)),
+      normalizedTimestamp(resolvedAt, "invalid_modified_at"),
+    ].sort().at(-1);
+    document = resolveVaultConflict(document, conflict, {
+      choice: newestVaultConflictChoice(conflict),
+      deviceID,
+      resolvedAt: winnerTimestamp,
+    });
+  }
+  return document;
+}
+
 export function createEmptyVaultDocument() {
   return { schemaVersion: vaultDocumentSchemaVersion, records: [], tombstones: [] };
 }

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -94,7 +94,7 @@ test("macOS automatically provisions and synchronizes Team Vaults while unlocked
   assert.match(coordinator, /actor\.membershipID == remoteVersion\.wrapper\.membershipID/);
   assert.match(autoSync, /pollInterval: Duration = \.seconds\(15\)/);
   assert.match(autoSync, /case \.localChanges:/);
-  assert.match(autoSync, /case \.conflict:/);
+  assert.match(autoSync, /resolveRecordConflictsKeepingNewest/u);
   assert.doesNotMatch(autoSync, /func initialize\(/);
   assert.match(app, /appLock\.isLocked/);
   assert.match(app, /teamVaultAutoSync\.stop\(\)/);
@@ -465,6 +465,23 @@ test("macOS surfaces username Team invitations and uses a roomier settings windo
   assert.match(settings, /\.frame\(minWidth: 760, idealWidth: 820, minHeight: 600, idealHeight: 680\)/u);
 });
 
+test("macOS Team workspace is wide, action-oriented, and maps invitation errors", async () => {
+  const [management, client, records, sync] = await Promise.all([
+    readFile(new URL("CloudTeamManagementView.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudAPIClient.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudVaultRecordModel.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudPersonalVaultAutoSync.swift", sourceRoot), "utf8"),
+  ]);
+  assert.match(management, /minWidth: 1_020/u);
+  assert.match(management, /HSplitView/u);
+  assert.match(management, /Пригласить по username/u);
+  assert.match(management, /Активные приглашения/u);
+  assert.match(client, /case "team_member_exists"/u);
+  assert.match(client, /case "account_not_found"/u);
+  assert.match(records, /mergedKeepingNewest/u);
+  assert.match(sync, /mergedKeepingNewest/u);
+});
+
 
 test("macOS Personal Vault auto-sync preserves encrypted credentials without extra Keychain items", async () => {
   const [sync, crypto, settings, app, snippets] = await Promise.all([
@@ -487,7 +504,7 @@ test("macOS Personal Vault auto-sync preserves encrypted credentials without ext
   assert.match(sync, /remote\.revision > material\.revision/u);
   assert.match(sync, /func acceptDownload\(/u);
   assert.match(sync, /func mergeConcurrent\(/u);
-  assert.match(sync, /tombstone\.deletedAt >= record\.modifiedAt/u);
+  assert.match(sync, /mergedKeepingNewest/u);
   assert.match(sync, /if concurrentChange \{ return \}/u);
   assert.match(app, /runPersonalVaultInboundSyncLoop/u);
   assert.match(app, /Task\.sleep\(for: \.seconds\(15\)\)/u);

--- a/cloud/tests/public-team-vault-sync.test.mjs
+++ b/cloud/tests/public-team-vault-sync.test.mjs
@@ -271,7 +271,7 @@ test("a changed uncommitted initialization is never discarded for a concurrent r
   assert.equal(controllerA.document().records[0].data.title, "Local");
 });
 
-test("two Team devices merge causal updates and require explicit choices for concurrent records", async () => {
+test("two Team devices automatically keep the newer concurrent record", async () => {
   const a = await device(deviceA, membershipA);
   const b = await device(deviceB, membershipB);
   const server = sharedServer([a.keyDevice, b.keyDevice]);
@@ -306,15 +306,6 @@ test("two Team devices merge causal updates and require explicit choices for con
     { status: "uploaded", revision: 2 },
   );
 
-  const conflict = await synchronizeTeamVault({ client: clientB, controller: controllerB, role: "editor" });
-  assert.equal(conflict.status, "conflict");
-  assert.equal(conflict.conflicts.length, 1);
-  assert.equal(conflict.conflicts[0].local.value.data.title, "B");
-  assert.equal(conflict.conflicts[0].remote.value.data.title, "A");
-  await controllerB.resolveConflicts({
-    revision: conflict.revision,
-    resolutions: [{ id: recordID, choice: "local" }],
-  });
   assert.deepEqual(
     await synchronizeTeamVault({ client: clientB, controller: controllerB, role: "editor" }),
     { status: "uploaded", revision: 3 },
@@ -413,7 +404,7 @@ test("competing rotations commit once and never replace the losing local snapsho
   assert.equal(server.inspect().keyGeneration, 2);
 });
 
-test("rotation stops for an explicit causal conflict and resumes only after every choice", async () => {
+test("rotation automatically resolves a causal conflict before replacing the key", async () => {
   const a = await device(deviceA, membershipA);
   const b = await device(deviceB, membershipB);
   const server = sharedServer([a.keyDevice, b.keyDevice]);
@@ -434,14 +425,6 @@ test("rotation stops for an explicit causal conflict and resumes only after ever
   await synchronizeTeamVault({ client: clientA, controller: controllerA, role: "owner" });
   server.requireRotation([a.keyDevice, b.keyDevice]);
 
-  const conflict = await rotateTeamVault({ client: clientB, controller: controllerB, role: "admin" });
-  assert.equal(conflict.status, "conflict");
-  assert.equal(conflict.conflicts.length, 1);
-  assert.equal(server.inspect().rotationRequired, true);
-  await controllerB.resolveConflicts({
-    revision: conflict.revision,
-    resolutions: [{ id: recordID, choice: "local" }],
-  });
   assert.deepEqual(
     await rotateTeamVault({ client: clientB, controller: controllerB, role: "admin" }),
     { status: "rotated", revision: 3, keyGeneration: 2 },

--- a/cloud/tests/public-vault-model.test.mjs
+++ b/cloud/tests/public-vault-model.test.mjs
@@ -4,6 +4,8 @@ import {
   createEmptyVaultDocument,
   deleteVaultRecord,
   mergeVaultDocuments,
+  newestVaultConflictChoice,
+  resolveVaultConflictsByNewest,
   resolveVaultConflict,
   upsertVaultRecord,
   validateVaultDocument,
@@ -94,6 +96,38 @@ test("concurrent edit and deletion require an explicit resolution", () => {
   assert.equal(result.conflicts.length, 1);
   assert.equal(result.conflicts[0].local.kind, "record");
   assert.equal(result.conflicts[0].remote.kind, "tombstone");
+});
+
+test("newest conflict policy picks the later edit and joins both causal histories", () => {
+  const base = host();
+  const local = host(base, "Older local edit", deviceA, secondTime);
+  const remote = host(base, "Newer remote edit", deviceB, thirdTime);
+  const merge = mergeVaultDocuments(local, remote);
+
+  assert.equal(newestVaultConflictChoice(merge.conflicts[0]), "remote");
+  const resolved = resolveVaultConflictsByNewest(merge.document, merge.conflicts, {
+    deviceID: deviceC,
+    resolvedAt: thirdTime,
+  });
+  assert.equal(resolved.records[0].data.title, "Newer remote edit");
+  assert.deepEqual(resolved.records[0].version, { [deviceA]: 2, [deviceB]: 1, [deviceC]: 1 });
+  assert.equal(mergeVaultDocuments(resolved, local).conflicts.length, 0);
+});
+
+test("newest conflict policy keeps a later deletion and never resurrects an equal-time delete", () => {
+  const base = host();
+  const edited = host(base, "Offline edit", deviceA, secondTime);
+  const laterDeletion = deleteVaultRecord(base, { id: recordID, deviceID: deviceB, deletedAt: thirdTime });
+  const laterMerge = mergeVaultDocuments(edited, laterDeletion);
+  assert.equal(newestVaultConflictChoice(laterMerge.conflicts[0]), "remote");
+  assert.equal(resolveVaultConflictsByNewest(laterMerge.document, laterMerge.conflicts, {
+    deviceID: deviceC,
+    resolvedAt: thirdTime,
+  }).tombstones.length, 1);
+
+  const equalDeletion = deleteVaultRecord(base, { id: recordID, deviceID: deviceB, deletedAt: secondTime });
+  const equalMerge = mergeVaultDocuments(edited, equalDeletion);
+  assert.equal(newestVaultConflictChoice(equalMerge.conflicts[0]), "remote");
 });
 
 test("validation rejects duplicate identities, unknown fields and unsafe record data", () => {

--- a/cloud/tests/public-vault-sync.test.mjs
+++ b/cloud/tests/public-vault-sync.test.mjs
@@ -74,13 +74,13 @@ test("an invalid account wrapper cannot replace or back up the locked browser sn
   assert.equal(oldRepository.previous(), null);
 });
 
-function localVault(repository, ids) {
+function localVault(repository, ids, nowValue = "2026-09-04T00:00:00.000Z") {
   let index = 0;
   return createLocalVaultController({
     repository,
     cryptoValue: webcrypto,
     randomUUID: () => ids[index++],
-    now: () => "2026-09-04T00:00:00.000Z",
+    now: () => nowValue,
   });
 }
 
@@ -243,11 +243,11 @@ test("remote and offline local changes merge locally before one conditional uplo
   assert.deepEqual(await vaultA.syncState(), { localRevision: 3, serverRevision: 3, dirty: false });
 });
 
-test("concurrent record conflict blocks upload and preserves the local document", async () => {
+test("concurrent records automatically keep the newer version and upload the joined history", async () => {
   const repoA = memoryRepository();
   const repoB = memoryRepository();
-  const vaultA = localVault(repoA, [deviceA]);
-  const vaultB = localVault(repoB, [deviceB]);
+  const vaultA = localVault(repoA, [deviceA], "2026-09-04T01:00:00.000Z");
+  const vaultB = localVault(repoB, [deviceB], "2026-09-04T02:00:00.000Z");
   await vaultA.create(passphrase);
   const initial = await vaultA.prepareUpload(0);
   await vaultA.markSynced({ serverRevision: 1, localRevision: initial.localRevision });
@@ -260,21 +260,25 @@ test("concurrent record conflict blocks upload and preserves the local document"
   const client = {
     session: () => ({ id: userID }),
     getVault: async () => remoteValue(2, remote.envelope),
-    putVault: async () => { putCalls += 1; throw new Error("must_not_upload"); },
+    putVault: async (_scope, envelope) => {
+      putCalls += 1;
+      assert.equal(envelope.baseRevision, 2);
+      return { conflict: false, revision: 3 };
+    },
   };
 
   const result = await synchronizeVault({ client, vault: vaultA });
-  assert.equal(result.status, "conflict");
-  assert.equal(result.conflicts.length, 1);
-  assert.equal(putCalls, 0);
-  assert.equal(vaultA.document().records[0].data.address, "local.invalid");
+  assert.deepEqual(result, { status: "uploaded", revision: 3 });
+  assert.equal(putCalls, 1);
+  assert.equal(vaultA.document().records[0].data.address, "remote.invalid");
+  assert.deepEqual(vaultA.document().records[0].version, { [deviceA]: 2, [deviceB]: 1 });
 });
 
-test("an explicit complete conflict choice joins histories and uploads from the observed remote revision", async () => {
+test("automatic newest resolution includes unrelated remote records in one conditional upload", async () => {
   const repoA = memoryRepository();
   const repoB = memoryRepository();
-  const vaultA = localVault(repoA, [deviceA]);
-  const vaultB = localVault(repoB, [deviceB]);
+  const vaultA = localVault(repoA, [deviceA], "2026-09-04T01:00:00.000Z");
+  const vaultB = localVault(repoB, [deviceB], "2026-09-04T02:00:00.000Z");
   await vaultA.create(passphrase);
   const initial = await vaultA.prepareUpload(0);
   await vaultA.markSynced({ serverRevision: 1, localRevision: initial.localRevision });
@@ -296,37 +300,19 @@ test("an explicit complete conflict choice joins histories and uploads from the 
     },
   };
 
-  const conflict = await synchronizeVault({ client, vault: vaultA });
-  assert.equal(conflict.status, "conflict");
-  assert.deepEqual(vaultA.pendingConflicts(), { revision: 2, conflicts: conflict.conflicts });
-  assert.equal(vaultA.document().records.some((record) => record.id === recordB), false);
-
-  await assert.rejects(
-    vaultA.resolveConflicts({ revision: 2, resolutions: [] }),
-    /incomplete_conflict_resolution/,
-  );
-  assert.deepEqual(
-    await vaultA.resolveConflicts({
-      revision: 2,
-      resolutions: [{ id: recordA, choice: "local" }],
-    }),
-    { revision: 2, localRevision: 3, conflictsResolved: 1 },
-  );
+  assert.deepEqual(await synchronizeVault({ client, vault: vaultA }), { status: "uploaded", revision: 3 });
   assert.equal(vaultA.pendingConflicts(), null);
   assert.deepEqual(vaultA.document().records.map((record) => record.id), [recordA, recordB]);
-  assert.equal(vaultA.document().records[0].data.address, "local.invalid");
-  assert.deepEqual(await vaultA.syncState(), { localRevision: 3, serverRevision: 2, dirty: true });
-
-  assert.deepEqual(await synchronizeVault({ client, vault: vaultA }), { status: "uploaded", revision: 3 });
+  assert.equal(vaultA.document().records[0].data.address, "remote.invalid");
   assert.equal(uploadedBase, 2);
   assert.deepEqual(await vaultA.syncState(), { localRevision: 3, serverRevision: 3, dirty: false });
 });
 
-test("local edits invalidate a pending conflict set instead of applying a stale choice", async () => {
+test("a local edit after automatic resolution starts a fresh dirty revision", async () => {
   const repoA = memoryRepository();
   const repoB = memoryRepository();
-  const vaultA = localVault(repoA, [deviceA]);
-  const vaultB = localVault(repoB, [deviceB]);
+  const vaultA = localVault(repoA, [deviceA], "2026-09-04T01:00:00.000Z");
+  const vaultB = localVault(repoB, [deviceB], "2026-09-04T02:00:00.000Z");
   await vaultA.create(passphrase);
   const initial = await vaultA.prepareUpload(0);
   await vaultA.markSynced({ serverRevision: 1, localRevision: initial.localRevision });
@@ -337,17 +323,13 @@ test("local edits invalidate a pending conflict set instead of applying a stale 
   const client = {
     session: () => ({ id: userID }),
     getVault: async () => remoteValue(2, remote.envelope),
-    putVault: async () => { throw new Error("must_not_upload"); },
+    putVault: async () => ({ conflict: false, revision: 3 }),
   };
 
-  const conflict = await synchronizeVault({ client, vault: vaultA });
-  assert.equal(conflict.status, "conflict");
+  assert.deepEqual(await synchronizeVault({ client, vault: vaultA }), { status: "uploaded", revision: 3 });
   await vaultA.upsert({ id: recordB, type: "snippet", data: { title: "New local edit", body: "date" } });
   assert.equal(vaultA.pendingConflicts(), null);
-  await assert.rejects(
-    vaultA.resolveConflicts({ revision: 2, resolutions: [{ id: recordA, choice: "remote" }] }),
-    /invalid_pending_conflicts/,
-  );
+  assert.deepEqual(await vaultA.syncState(), { localRevision: 4, serverRevision: 3, dirty: true });
 });
 
 test("a server-side optimistic conflict never marks local data as synchronized", async () => {


### PR DESCRIPTION
## Что изменено

- Personal Vault и Team Vault автоматически разрешают конкурентные изменения по более свежему времени изменения.
- При одинаковом времени удаление побеждает изменение, чтобы удалённые записи не воскресали.
- История vector clock объединяется, а зашифрованная история ревизий на сервере сохраняется.
- Та же политика реализована в браузере и macOS-клиенте.
- Окно управления командой расширено и переработано в двухпанельное рабочее пространство.
- Ошибки приглашений (`team_member_exists`, `account_not_found` и другие) теперь показаны понятным текстом.
- Web assets обновлены до `v118`.

## Проверка

- Cloud test suite: 296 passed, 0 failed, 1 skipped (real PostgreSQL test без `TEST_DATABASE_URL`).
- Все опубликованные blob SHA и итоговый tree SHA сверены с локальным коммитом.
- Swift-компиляцию и Test DMG проверит GitHub Actions, так как Swift toolchain в локальном окружении отсутствует.

## Следующий этап

Drag-and-drop, ручной порядок и вложенные папки для личных и командных хостов будут отдельным PR: для этого требуется совместимое расширение модели хранения, а не только изменение интерфейса.