### PR TITLE
Add nested Host folders and drag-and-drop ordering

### DIFF
--- a/Sources/SelectiveRemote/AppModel.swift
+++ b/Sources/SelectiveRemote/AppModel.swift
@@ -1800,10 +1800,65 @@ final class AppModel: NSObject, ObservableObject {
 
     func setProfileGroup(profileID: UUID, group: String) {
         guard let index = profiles.firstIndex(where: { $0.id == profileID }) else { return }
-        profiles[index].group = group.trimmingCharacters(in: .whitespacesAndNewlines)
+        profiles[index].group = SelectiveRemoteHostFolderPath.normalize(group)
         statusMessage = profiles[index].group.isEmpty
-            ? "Профиль перемещён в «Без группы»"
-            : "Профиль перемещён в группу «\(profiles[index].group)»"
+            ? UpdateLocalization.text(
+                ru: "Host перемещён в «Без папки»",
+                en: "Host moved to No Folder"
+            )
+            : UpdateLocalization.text(
+                ru: "Host перемещён в папку «\(profiles[index].group)»",
+                en: "Host moved to “\(profiles[index].group)”"
+            )
+    }
+
+    func moveProfile(
+        profileID: UUID,
+        toFolder rawFolder: String,
+        before targetID: UUID? = nil
+    ) {
+        guard let sourceIndex = profiles.firstIndex(where: { $0.id == profileID }) else { return }
+        let oldFolder = SelectiveRemoteHostFolderPath.normalize(profiles[sourceIndex].group)
+        let folder = SelectiveRemoteHostFolderPath.normalize(rawFolder)
+        profiles[sourceIndex].group = folder
+
+        var destinationIDs = profiles
+            .filter {
+                $0.id != profileID
+                    && SelectiveRemoteHostFolderPath.normalize($0.group) == folder
+            }
+            .sorted { lhs, rhs in
+                if lhs.sortIndex != rhs.sortIndex { return lhs.sortIndex < rhs.sortIndex }
+                return lhs.friendlyName.localizedCaseInsensitiveCompare(rhs.friendlyName)
+                    == .orderedAscending
+            }
+            .map(\.id)
+        let insertionIndex = targetID.flatMap { destinationIDs.firstIndex(of: $0) }
+            ?? destinationIDs.endIndex
+        destinationIDs.insert(profileID, at: insertionIndex)
+        reindexProfiles(destinationIDs)
+
+        if oldFolder != folder {
+            let oldIDs = profiles
+                .filter { SelectiveRemoteHostFolderPath.normalize($0.group) == oldFolder }
+                .sorted { $0.sortIndex < $1.sortIndex }
+                .map(\.id)
+            reindexProfiles(oldIDs)
+        }
+        profileSortMode = .manual
+        statusMessage = folder.isEmpty
+            ? UpdateLocalization.text(ru: "Host перемещён без папки", en: "Host moved to No Folder")
+            : UpdateLocalization.text(
+                ru: "Host перемещён в «\(folder)»",
+                en: "Host moved to “\(folder)”"
+            )
+    }
+
+    private func reindexProfiles(_ ids: [UUID]) {
+        for (sortIndex, id) in ids.enumerated() {
+            guard let index = profiles.firstIndex(where: { $0.id == id }) else { continue }
+            profiles[index].sortIndex = sortIndex
+        }
     }
 
     var profileGroups: [ProfileGroupSection] {
@@ -1853,6 +1908,14 @@ final class AppModel: NSObject, ObservableObject {
         }
     }
 
+    var profileFolderRoots: [SelectiveRemoteProfileFolderNode] {
+        SelectiveRemoteProfileFolderNode.roots(from: profileGroups)
+    }
+
+    var profileOutlineItems: [SelectiveRemoteProfileOutlineItem] {
+        SelectiveRemoteProfileOutlineItem.roots(from: profileFolderRoots)
+    }
+
     func isSessionRunning(profileID: UUID) -> Bool {
         sessions[profileID] != nil
     }
@@ -1883,6 +1946,7 @@ final class AppModel: NSObject, ObservableObject {
 
     func addProfile(connectionType: ConnectionType = .rdp) {
         var profile = ConnectionProfile(connectionType: connectionType)
+        profile.sortIndex = (profiles.map(\.sortIndex).max() ?? -1) + 1
         if connectionType == .rdp {
             configureDefaultDisplays(for: &profile)
         }
@@ -6425,6 +6489,10 @@ final class AppModel: NSObject, ObservableObject {
     private func sortProfiles(_ values: [ConnectionProfile]) -> [ConnectionProfile] {
         values.sorted { lhs, rhs in
             switch profileSortMode {
+            case .manual:
+                if lhs.sortIndex != rhs.sortIndex { return lhs.sortIndex < rhs.sortIndex }
+                return lhs.friendlyName.localizedCaseInsensitiveCompare(rhs.friendlyName)
+                    == .orderedAscending
             case .favoritesAndName:
                 if lhs.isFavorite != rhs.isFavorite { return lhs.isFavorite }
                 return lhs.friendlyName.localizedCaseInsensitiveCompare(rhs.friendlyName)

--- a/Sources/SelectiveRemote/CloudTeamHostMutation.swift
+++ b/Sources/SelectiveRemote/CloudTeamHostMutation.swift
@@ -98,6 +98,43 @@ enum SelectiveRemoteTeamHostDocumentMutation {
         )
     }
 
+    static func organize(
+        in document: SelectiveRemoteVaultDocument,
+        recordID: UUID,
+        profile: ConnectionProfile,
+        role: SelectiveRemoteCloudTeamRole,
+        deviceID: UUID,
+        modifiedAt: String
+    ) throws -> SelectiveRemoteVaultDocument {
+        try requireWritable(role)
+        guard let existing = document.records.first(where: { $0.id == recordID }) else {
+            throw SelectiveRemoteTeamHostMutationError.hostNotFound
+        }
+        guard existing.type == .host else {
+            throw SelectiveRemoteTeamHostMutationError.recordIsNotHost
+        }
+        var exportedProfile = profile
+        exportedProfile.id = recordID
+        let exported = try SelectiveRemotePersonalVaultExporter.makeExport(
+            profiles: [exportedProfile],
+            credentials: [],
+            snippets: [],
+            forwarding: [],
+            deviceID: deviceID
+        ).document.records[0]
+        let replacement = try SelectiveRemoteVaultRecord(
+            id: recordID,
+            type: .host,
+            version: existing.version.incrementing(deviceID),
+            modifiedAt: modifiedAt,
+            data: exported.data
+        )
+        return try .init(
+            records: document.records.map { $0.id == recordID ? replacement : $0 },
+            tombstones: document.tombstones
+        )
+    }
+
     static func delete(
         from document: SelectiveRemoteVaultDocument,
         recordID: UUID,
@@ -267,7 +304,13 @@ struct SelectiveRemoteTeamHostVaultContext: Identifiable, Equatable {
 enum SelectiveRemoteTeamHostMutationChange {
     case create(ConnectionProfile, SelectiveRemoteTeamHostCredentials)
     case update(recordID: UUID, profile: ConnectionProfile, credentials: SelectiveRemoteTeamHostCredentials)
+    case organize([SelectiveRemoteTeamHostOrganizationUpdate])
     case delete(recordID: UUID)
+}
+
+struct SelectiveRemoteTeamHostOrganizationUpdate {
+    let recordID: UUID
+    let profile: ConnectionProfile
 }
 
 @MainActor
@@ -398,6 +441,17 @@ final class SelectiveRemoteTeamHostMutationService {
                 deviceID: deviceID,
                 modifiedAt: timestamp
             )
+        case let .organize(updates):
+            try updates.reduce(document) { partial, update in
+                try SelectiveRemoteTeamHostDocumentMutation.organize(
+                    in: partial,
+                    recordID: update.recordID,
+                    profile: update.profile,
+                    role: role,
+                    deviceID: deviceID,
+                    modifiedAt: timestamp
+                )
+            }
         case let .delete(recordID):
             try SelectiveRemoteTeamHostDocumentMutation.delete(
                 from: document,

--- a/Sources/SelectiveRemote/CloudTeamHosts.swift
+++ b/Sources/SelectiveRemote/CloudTeamHosts.swift
@@ -352,6 +352,7 @@ enum SelectiveRemoteTeamHostMaterializer {
         safe.detectedOperatingSystemLike = ""
         safe.operatingSystemDetectedAt = nil
         safe.group = input.group
+        safe.sortIndex = input.sortIndex
         safe.tags = input.tags
         safe.profileDescription = input.profileDescription
         safe.createdAt = Date(timeIntervalSince1970: 0)
@@ -594,6 +595,13 @@ struct SelectiveRemoteTeamHostsView: View {
             .sorted { folderTitle($0).localizedCaseInsensitiveCompare(folderTitle($1)) == .orderedAscending }
     }
 
+    private func outlineItems(in teamID: UUID) -> [SelectiveRemoteTeamHostOutlineItem] {
+        SelectiveRemoteTeamHostOutlineItem.roots(
+            teamID: teamID,
+            hosts: visibleHosts.filter { $0.teamID == teamID }
+        )
+    }
+
     private var visibleHosts: [SelectiveRemoteTeamHost] {
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
         return store.hosts.filter { host in
@@ -631,21 +639,24 @@ struct SelectiveRemoteTeamHostsView: View {
                             DisclosureGroup(
                                 isExpanded: expansionBinding(for: teamID)
                             ) {
-                                ForEach(folders(in: teamID), id: \.self) { folder in
-                                    DisclosureGroup(
-                                        isExpanded: folderExpansionBinding(
-                                            teamID: teamID,
-                                            folder: folder
-                                        )
-                                    ) {
-                                        ForEach(visibleHosts.filter {
-                                            $0.teamID == teamID && $0.profile.group == folder
-                                        }) { host in
-                                            hostRow(host)
-                                                .tag(host.id)
-                                        }
-                                    } label: {
-                                        Label(folderTitle(folder), systemImage: "folder")
+                                OutlineGroup(outlineItems(in: teamID), children: \.children) { item in
+                                    switch item.kind {
+                                    case let .folder(path, name):
+                                        Label(name, systemImage: path.isEmpty ? "tray" : "folder")
+                                            .dropDestination(for: String.self) { values, _ in
+                                                moveTeamHost(values, toFolder: path)
+                                            }
+                                    case let .host(host):
+                                        hostRow(host)
+                                            .tag(host.id)
+                                            .draggable("team-host:\(host.id.uuidString)")
+                                            .dropDestination(for: String.self) { values, _ in
+                                                moveTeamHost(
+                                                    values,
+                                                    toFolder: host.profile.group,
+                                                    before: host.id
+                                                )
+                                            }
                                     }
                                 }
                             } label: {
@@ -1095,6 +1106,65 @@ struct SelectiveRemoteTeamHostsView: View {
                 mutationMessage = .init(text: error.localizedDescription, isError: true)
             }
         }
+    }
+
+    private func moveTeamHost(
+        _ values: [String],
+        toFolder rawFolder: String,
+        before targetID: UUID? = nil
+    ) -> Bool {
+        guard !isMutating,
+              let value = values.first,
+              value.hasPrefix("team-host:"),
+              let hostID = UUID(uuidString: String(value.dropFirst("team-host:".count))),
+              let host = store.hosts.first(where: { $0.id == hostID }),
+              let context = context(for: host),
+              SelectiveRemoteTeamHostDocumentMutation.isWritable(role: context.role)
+        else { return false }
+
+        let folder = SelectiveRemoteHostFolderPath.normalize(rawFolder)
+        let scopedHosts = store.hosts.filter {
+            $0.teamID == host.teamID && $0.vaultID == host.vaultID
+        }
+        var grouped = Dictionary(grouping: scopedHosts) { candidate in
+            candidate.id == host.id
+                ? folder
+                : SelectiveRemoteHostFolderPath.normalize(candidate.profile.group)
+        }
+        var updates: [SelectiveRemoteTeamHostOrganizationUpdate] = []
+        for path in grouped.keys.sorted() {
+            var ordered = (grouped[path] ?? []).sorted { lhs, rhs in
+                if lhs.profile.sortIndex != rhs.profile.sortIndex {
+                    return lhs.profile.sortIndex < rhs.profile.sortIndex
+                }
+                return lhs.profile.friendlyName.localizedCaseInsensitiveCompare(
+                    rhs.profile.friendlyName
+                ) == .orderedAscending
+            }
+            if path == folder,
+               let source = ordered.firstIndex(where: { $0.id == host.id }) {
+                let moving = ordered.remove(at: source)
+                let destination = targetID.flatMap { id in
+                    ordered.firstIndex(where: { $0.id == id })
+                } ?? ordered.endIndex
+                ordered.insert(moving, at: destination)
+            }
+            for (sortIndex, candidate) in ordered.enumerated() {
+                var profile = candidate.profile
+                profile.group = path
+                profile.sortIndex = sortIndex
+                guard profile.group != candidate.profile.group
+                        || profile.sortIndex != candidate.profile.sortIndex
+                else { continue }
+                updates.append(.init(
+                    recordID: candidate.recordID,
+                    profile: profile
+                ))
+            }
+        }
+        guard !updates.isEmpty else { return false }
+        mutate(.organize(updates), context: context, selectedRecordID: host.recordID)
+        return true
     }
 
     private func resolvedDeviceID() -> UUID {

--- a/Sources/SelectiveRemote/ContentView.swift
+++ b/Sources/SelectiveRemote/ContentView.swift
@@ -665,9 +665,15 @@ struct ContentView: View {
                 get: { model.selectedProfileID },
                 set: { if let id = $0 { openProfile(id) } }
             )) {
-                ForEach(model.profileGroups) { group in
-                    Section(group.name) {
-                        ForEach(group.profiles) { item in
+                OutlineGroup(model.profileOutlineItems, children: \.children) { outline in
+                    switch outline.kind {
+                    case let .folder(path, name):
+                        Label(name, systemImage: path.isEmpty ? "tray" : "folder")
+                            .font(.headline)
+                            .dropDestination(for: String.self) { values, _ in
+                                movePersonalProfile(values, toFolder: path)
+                            }
+                    case let .profile(item):
                             ProfileRow(
                                 profile: item,
                                 session: model.sessions[item.id],
@@ -678,7 +684,14 @@ struct ContentView: View {
                             .contentShape(Rectangle())
                             .onTapGesture { openProfile(item.id) }
                             .contextMenu { profileContextMenu(item) }
-                        }
+                            .draggable("personal-host:\(item.id.uuidString)")
+                            .dropDestination(for: String.self) { values, _ in
+                                movePersonalProfile(
+                                    values,
+                                    toFolder: item.group,
+                                    before: item.id
+                                )
+                            }
                     }
                 }
             }
@@ -693,6 +706,12 @@ struct ContentView: View {
                                 .font(.caption.bold())
                                 .foregroundStyle(.secondary)
                                 .padding(.horizontal, 2)
+                                .dropDestination(for: String.self) { values, _ in
+                                    movePersonalProfile(
+                                        values,
+                                        toFolder: group.profiles.first?.group ?? ""
+                                    )
+                                }
                             LazyVGrid(
                                 columns: [GridItem(.adaptive(minimum: 100), spacing: 8)],
                                 spacing: 9
@@ -713,6 +732,14 @@ struct ContentView: View {
                                     }
                                     .buttonStyle(.plain)
                                     .contextMenu { profileContextMenu(item) }
+                                    .draggable("personal-host:\(item.id.uuidString)")
+                                    .dropDestination(for: String.self) { values, _ in
+                                        movePersonalProfile(
+                                            values,
+                                            toFolder: item.group,
+                                            before: item.id
+                                        )
+                                    }
                                 }
                             }
                         }
@@ -731,6 +758,19 @@ struct ContentView: View {
     private func openProfile(_ profileID: UUID) {
         model.selectProfile(profileID)
         setMainArea(.connections)
+    }
+
+    private func movePersonalProfile(
+        _ values: [String],
+        toFolder folder: String,
+        before targetID: UUID? = nil
+    ) -> Bool {
+        guard let value = values.first,
+              value.hasPrefix("personal-host:"),
+              let profileID = UUID(uuidString: String(value.dropFirst("personal-host:".count)))
+        else { return false }
+        model.moveProfile(profileID: profileID, toFolder: folder, before: targetID)
+        return true
     }
 
     @ViewBuilder
@@ -810,14 +850,17 @@ struct ContentView: View {
                 Text("Создайте тег в настройках профиля")
             }
         }
-        Menu("Переместить в группу", systemImage: "folder") {
-            Button("Без группы") {
-                model.setProfileGroup(profileID: item.id, group: "")
+        Menu(
+            UpdateLocalization.text(ru: "Переместить в папку", en: "Move to Folder"),
+            systemImage: "folder"
+        ) {
+            Button(UpdateLocalization.text(ru: "Без папки", en: "No Folder")) {
+                model.moveProfile(profileID: item.id, toFolder: "")
             }
             if !model.profileGroupNames.isEmpty { Divider() }
             ForEach(model.profileGroupNames, id: \.self) { groupName in
                 Button(groupName) {
-                    model.setProfileGroup(profileID: item.id, group: groupName)
+                    model.moveProfile(profileID: item.id, toFolder: groupName)
                 }
             }
         }

--- a/Sources/SelectiveRemote/HostFolderTree.swift
+++ b/Sources/SelectiveRemote/HostFolderTree.swift
@@ -1,0 +1,200 @@
+import Foundation
+
+enum SelectiveRemoteHostFolderPath {
+    static let maximumDepth = 8
+    static let maximumComponentLength = 64
+    static let maximumPathLength = 120
+
+    static func normalize(_ value: String) -> String {
+        let components = value
+            .split(separator: "/", omittingEmptySubsequences: true)
+            .prefix(maximumDepth)
+            .map {
+                String(
+                    $0.trimmingCharacters(in: .whitespacesAndNewlines)
+                        .prefix(maximumComponentLength)
+                )
+            }
+            .filter { !$0.isEmpty }
+        var result: [String] = []
+        var remaining = maximumPathLength
+        for component in components {
+            let separatorLength = result.isEmpty ? 0 : 1
+            guard remaining > separatorLength else { break }
+            let bounded = String(component.prefix(remaining - separatorLength))
+            guard !bounded.isEmpty else { break }
+            result.append(bounded)
+            remaining -= separatorLength + bounded.count
+        }
+        return result.joined(separator: "/")
+    }
+
+    static func components(_ value: String) -> [String] {
+        let normalized = normalize(value)
+        return normalized.isEmpty ? [] : normalized.split(separator: "/").map(String.init)
+    }
+
+    static func displayName(_ path: String) -> String {
+        components(path).last
+            ?? UpdateLocalization.text(ru: "Без папки", en: "No Folder")
+    }
+}
+
+struct SelectiveRemoteProfileFolderNode: Identifiable, Equatable {
+    let path: String
+    let profiles: [ConnectionProfile]
+    let children: [SelectiveRemoteProfileFolderNode]
+
+    var id: String { path }
+    var name: String { SelectiveRemoteHostFolderPath.displayName(path) }
+
+    static func roots(from sections: [ProfileGroupSection]) -> [Self] {
+        let entries = sections.flatMap { section in
+            section.profiles.map { (SelectiveRemoteHostFolderPath.normalize($0.group), $0) }
+        }
+        return children(parent: "", entries: entries)
+    }
+
+    private static func children(
+        parent: String,
+        entries: [(String, ConnectionProfile)]
+    ) -> [Self] {
+        let directProfiles = entries.filter { $0.0 == parent }.map(\.1)
+        var childNames = Set<String>()
+        let prefix = parent.isEmpty ? "" : "\(parent)/"
+        for (path, _) in entries where path.hasPrefix(prefix) && path != parent {
+            let remainder = path.dropFirst(prefix.count)
+            if let component = remainder.split(separator: "/").first {
+                childNames.insert(String(component))
+            }
+        }
+        var result = childNames.sorted {
+            $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
+        }.map { component in
+            let path = parent.isEmpty ? component : "\(parent)/\(component)"
+            let nested = entries.filter { $0.0 == path || $0.0.hasPrefix("\(path)/") }
+            return Self(
+                path: path,
+                profiles: nested.filter { $0.0 == path }.map(\.1),
+                children: children(parent: path, entries: nested)
+            )
+        }
+        if parent.isEmpty, !directProfiles.isEmpty {
+            result.insert(Self(path: "", profiles: directProfiles, children: []), at: 0)
+        }
+        return result
+    }
+}
+
+struct SelectiveRemoteProfileOutlineItem: Identifiable, Equatable {
+    enum Kind: Equatable {
+        case folder(path: String, name: String)
+        case profile(ConnectionProfile)
+    }
+
+    let id: String
+    let kind: Kind
+    let children: [SelectiveRemoteProfileOutlineItem]?
+
+    static func roots(from folders: [SelectiveRemoteProfileFolderNode]) -> [Self] {
+        folders.map(makeFolder)
+    }
+
+    private static func makeFolder(_ folder: SelectiveRemoteProfileFolderNode) -> Self {
+        let nested = folder.children.map(makeFolder)
+            + folder.profiles.map {
+                Self(id: "profile:\($0.id.uuidString)", kind: .profile($0), children: nil)
+            }
+        return Self(
+            id: "folder:\(folder.path)",
+            kind: .folder(path: folder.path, name: folder.name),
+            children: nested
+        )
+    }
+}
+
+struct SelectiveRemoteTeamHostOutlineItem: Identifiable, Equatable {
+    enum Kind: Equatable {
+        case folder(path: String, name: String)
+        case host(SelectiveRemoteTeamHost)
+    }
+
+    let id: String
+    let kind: Kind
+    let children: [SelectiveRemoteTeamHostOutlineItem]?
+
+    static func roots(teamID: UUID, hosts: [SelectiveRemoteTeamHost]) -> [Self] {
+        let entries = hosts.map {
+            (SelectiveRemoteHostFolderPath.normalize($0.profile.group), $0)
+        }
+        return children(teamID: teamID, parent: "", entries: entries)
+    }
+
+    private static func children(
+        teamID: UUID,
+        parent: String,
+        entries: [(String, SelectiveRemoteTeamHost)]
+    ) -> [Self] {
+        let prefix = parent.isEmpty ? "" : "\(parent)/"
+        var childNames = Set<String>()
+        for (path, _) in entries where path.hasPrefix(prefix) && path != parent {
+            if let component = path.dropFirst(prefix.count).split(separator: "/").first {
+                childNames.insert(String(component))
+            }
+        }
+        var result = childNames.sorted {
+            $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
+        }.map { component in
+            let path = parent.isEmpty ? component : "\(parent)/\(component)"
+            let nested = entries.filter { $0.0 == path || $0.0.hasPrefix("\(path)/") }
+            let descendants = children(teamID: teamID, parent: path, entries: nested)
+                + hostItems(teamID: teamID, path: path, entries: nested)
+            return Self(
+                id: "team-folder:\(teamID.uuidString):\(path)",
+                kind: .folder(path: path, name: SelectiveRemoteHostFolderPath.displayName(path)),
+                children: descendants
+            )
+        }
+        if parent.isEmpty {
+            let ungrouped = hostItems(teamID: teamID, path: "", entries: entries)
+            if !ungrouped.isEmpty {
+                result.insert(
+                    Self(
+                        id: "team-folder:\(teamID.uuidString):",
+                        kind: .folder(
+                            path: "",
+                            name: UpdateLocalization.text(ru: "Без папки", en: "No Folder")
+                        ),
+                        children: ungrouped
+                    ),
+                    at: 0
+                )
+            }
+        }
+        return result
+    }
+
+    private static func hostItems(
+        teamID: UUID,
+        path: String,
+        entries: [(String, SelectiveRemoteTeamHost)]
+    ) -> [Self] {
+        entries.filter { $0.0 == path }
+            .map(\.1)
+            .sorted { lhs, rhs in
+                if lhs.profile.sortIndex != rhs.profile.sortIndex {
+                    return lhs.profile.sortIndex < rhs.profile.sortIndex
+                }
+                return lhs.profile.friendlyName.localizedCaseInsensitiveCompare(
+                    rhs.profile.friendlyName
+                ) == .orderedAscending
+            }
+            .map {
+                Self(
+                    id: "team-host:\(teamID.uuidString):\($0.id.uuidString)",
+                    kind: .host($0),
+                    children: nil
+                )
+            }
+    }
+}

--- a/Sources/SelectiveRemote/Models.swift
+++ b/Sources/SelectiveRemote/Models.swift
@@ -666,6 +666,7 @@ struct SSHKeyRecord: Codable, Equatable, Identifiable, Sendable {
 }
 
 enum ProfileSortMode: String, CaseIterable, Identifiable {
+    case manual
     case favoritesAndName
     case name
     case host
@@ -675,6 +676,7 @@ enum ProfileSortMode: String, CaseIterable, Identifiable {
 
     var title: String {
         switch self {
+        case .manual: UpdateLocalization.text(ru: "Вручную", en: "Manual")
         case .favoritesAndName: "Избранное и название"
         case .name: "Название"
         case .host: "Hostname"
@@ -781,6 +783,7 @@ struct ConnectionProfile: Codable, Equatable, Identifiable {
     var connectionType: ConnectionType
     var friendlyName: String
     var group: String
+    var sortIndex: Int
     var tags: [String]
     var profileDescription: String
     var detectedOperatingSystem: String
@@ -866,6 +869,7 @@ struct ConnectionProfile: Codable, Equatable, Identifiable {
             friendlyName = UpdateLocalization.text(ru: "Новое Serial-подключение", en: "New Serial Connection")
         }
         group = ""
+        sortIndex = 0
         tags = []
         profileDescription = ""
         detectedOperatingSystem = ""
@@ -939,7 +943,7 @@ struct ConnectionProfile: Codable, Equatable, Identifiable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, connectionType, friendlyName, group, tags, profileDescription
+        case id, connectionType, friendlyName, group, sortIndex, tags, profileDescription
         case detectedOperatingSystem, detectedOperatingSystemID
         case detectedOperatingSystemLike, operatingSystemDetectedAt
         case host, username
@@ -973,6 +977,8 @@ struct ConnectionProfile: Codable, Equatable, Identifiable {
         friendlyName = try container.decodeIfPresent(String.self, forKey: .friendlyName)
             ?? defaults.friendlyName
         group = try container.decodeIfPresent(String.self, forKey: .group) ?? defaults.group
+        sortIndex = try container.decodeIfPresent(Int.self, forKey: .sortIndex)
+            ?? defaults.sortIndex
         tags = try container.decodeIfPresent([String].self, forKey: .tags) ?? defaults.tags
         profileDescription = try container.decodeIfPresent(
             String.self,
@@ -1155,6 +1161,7 @@ struct ConnectionProfile: Codable, Equatable, Identifiable {
         try container.encode(connectionType, forKey: .connectionType)
         try container.encode(friendlyName, forKey: .friendlyName)
         try container.encode(group, forKey: .group)
+        try container.encode(sortIndex, forKey: .sortIndex)
         try container.encode(tags, forKey: .tags)
         try container.encode(profileDescription, forKey: .profileDescription)
         try container.encode(detectedOperatingSystem, forKey: .detectedOperatingSystem)

--- a/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudTeamHostsTests.swift
@@ -261,6 +261,40 @@ struct CloudTeamHostsTests {
     }
 
     @MainActor
+    @Test("Team Host organization changes folder/order without rewriting credentials")
+    func organizationMutationPreservesCredentials() throws {
+        let deviceID = try #require(UUID(uuidString: "44444444-4444-4444-8444-444444444444"))
+        let recordID = try #require(UUID(uuidString: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"))
+        var profile = ConnectionProfile(connectionType: .ssh)
+        profile.id = recordID
+        profile.friendlyName = "Bastion"
+        profile.host = "bastion.example.invalid"
+        let created = try SelectiveRemoteTeamHostDocumentMutation.create(
+            profile: profile,
+            credentials: .init(password: "encrypted-secret", gatewayPassword: nil),
+            role: .editor,
+            deviceID: deviceID,
+            modifiedAt: "2026-09-11T11:00:00.000Z"
+        )
+        let credentialBefore = try #require(created.records.first { $0.type == .credential })
+        profile.group = "Infrastructure/Production"
+        profile.sortIndex = 4
+        let organized = try SelectiveRemoteTeamHostDocumentMutation.organize(
+            in: created,
+            recordID: recordID,
+            profile: profile,
+            role: .editor,
+            deviceID: deviceID,
+            modifiedAt: "2026-09-11T11:01:00.000Z"
+        )
+        #expect(organized.records.first { $0.type == .credential } == credentialBefore)
+        let store = SelectiveRemoteTeamHostStore()
+        store.replace(with: [Self.snapshot(payload: try organized.encoded(), role: .editor)])
+        #expect(store.hosts.first?.profile.group == "Infrastructure/Production")
+        #expect(store.hosts.first?.profile.sortIndex == 4)
+    }
+
+    @MainActor
     @Test("Team Host credentials are encrypted records, materialize for connection, and delete causally")
     func sharedCredentialLifecycle() throws {
         let deviceID = try #require(UUID(uuidString: "44444444-4444-4444-8444-444444444444"))

--- a/Tests/SelectiveRemoteTests/ProfileOrganizationAndSecurityTests.swift
+++ b/Tests/SelectiveRemoteTests/ProfileOrganizationAndSecurityTests.swift
@@ -35,6 +35,47 @@ struct ProfileOrganizationAndSecurityTests {
         #expect(migrated.tags.isEmpty)
     }
 
+    @Test("Путь вложенных папок нормализуется, а ручной порядок мигрирует совместимо")
+    func nestedFolderPathAndManualOrderAreBackwardCompatible() throws {
+        #expect(
+            SelectiveRemoteHostFolderPath.normalize("  Infrastructure // Production / Linux  ")
+                == "Infrastructure/Production/Linux"
+        )
+        #expect(SelectiveRemoteHostFolderPath.components("A/B/C") == ["A", "B", "C"])
+
+        var profile = ConnectionProfile(connectionType: .ssh)
+        profile.group = "Infrastructure/Production"
+        profile.sortIndex = 7
+        let encoded = try JSONEncoder().encode(profile)
+        let restored = try JSONDecoder().decode(ConnectionProfile.self, from: encoded)
+        #expect(restored.sortIndex == 7)
+
+        var legacy = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        legacy.removeValue(forKey: "sortIndex")
+        let migrated = try JSONDecoder().decode(
+            ConnectionProfile.self,
+            from: JSONSerialization.data(withJSONObject: legacy)
+        )
+        #expect(migrated.sortIndex == 0)
+    }
+
+    @Test("Дерево Personal Hosts строит папку внутри папки")
+    func personalHostTreeBuildsNestedFolders() throws {
+        var host = ConnectionProfile(connectionType: .ssh)
+        host.group = "Infrastructure/Production/Linux"
+        host.friendlyName = "Bastion"
+        let roots = SelectiveRemoteProfileFolderNode.roots(from: [
+            .init(name: host.group, profiles: [host])
+        ])
+        let infrastructure = try #require(roots.first)
+        #expect(infrastructure.path == "Infrastructure")
+        let production = try #require(infrastructure.children.first)
+        #expect(production.path == "Infrastructure/Production")
+        let linux = try #require(production.children.first)
+        #expect(linux.path == "Infrastructure/Production/Linux")
+        #expect(linux.profiles.map(\.id) == [host.id])
+    }
+
     @Test("Названия пользовательских тегов нормализуются и ограничиваются")
     func customTagNamesAreNormalized() {
         #expect(AppModel.normalizedProfileTagName("  production   servers  ") == "production servers")
@@ -96,5 +137,7 @@ struct ProfileOrganizationAndSecurityTests {
         #expect(content.contains("GridItem(.adaptive(minimum: 100)"))
         #expect(content.contains("Создать свой тег"))
         #expect(content.contains("ConnectionActivityView"))
+        #expect(content.contains(".draggable(\"personal-host:"))
+        #expect(content.contains("movePersonalProfile"))
     }
 }

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -358,17 +358,22 @@ test("macOS Team Host credentials stay inside the encrypted Team Vault lifecycle
 });
 
 
-test("macOS Team Hosts expose shared folders, tags, and local filtering controls", async () => {
-  const [hosts, editor] = await Promise.all([
+test("macOS Team Hosts expose nested shared folders, tags, filtering, and drag-and-drop", async () => {
+  const [hosts, editor, tree] = await Promise.all([
     readFile(new URL("CloudTeamHosts.swift", sourceRoot), "utf8"),
     readFile(new URL("CloudTeamHostEditor.swift", sourceRoot), "utf8"),
+    readFile(new URL("HostFolderTree.swift", sourceRoot), "utf8"),
   ]);
   assert.match(hosts, /safe\.group = input\.group/u);
   assert.match(hosts, /safe\.tags = input\.tags/u);
   assert.match(hosts, /safe\.profileDescription = input\.profileDescription/u);
   assert.match(hosts, /\.searchable\(/u);
   assert.match(hosts, /selectedFolder/u);
-  assert.match(hosts, /Label\(folderTitle\(folder\), systemImage: "folder"\)/u);
+  assert.match(hosts, /OutlineGroup\(outlineItems\(in: teamID\)/u);
+  assert.match(hosts, /\.draggable\("team-host:/u);
+  assert.match(hosts, /moveTeamHost/u);
+  assert.match(tree, /SelectiveRemoteTeamHostOutlineItem/u);
+  assert.match(tree, /"\\\(parent\)\/\\\(component\)"/u);
   assert.match(editor, /Теги через запятую/u);
   assert.match(editor, /Папка/u);
   assert.match(editor, /profile\.group = folder/u);
@@ -401,7 +406,7 @@ test("macOS Team Hosts nest teams and folders and expose SSH tools", async () =>
   ]);
   assert.match(hosts, /DisclosureGroup\(/u);
   assert.match(hosts, /Label\(teamName\(teamID\), systemImage: "person\.3\.fill"\)/u);
-  assert.match(hosts, /Label\(folderTitle\(folder\), systemImage: "folder"\)/u);
+  assert.match(hosts, /OutlineGroup\(outlineItems\(in: teamID\)/u);
   assert.match(editor, /ru: "Порт", en: "Port"/u);
   assert.match(editor, /profile\.sshPort = port/u);
   assert.match(hosts, /onOpenSFTP/u);


### PR DESCRIPTION
## Что изменено

- Personal Hosts отображаются как настоящее дерево папок с глубиной до 8 уровней.
- Team Hosts получают ту же вложенную структуру внутри каждой команды.
- Host можно перетащить на папку или перед другим Host для ручной сортировки.
- Ручной порядок (`sortIndex`) сохраняется в профиле и совместимо декодируется у старых профилей.
- Team-перемещение выполняется одной зашифрованной Vault-мутацией; credential-записи не переписываются и не меняют версии.
- Viewer остаётся строго read-only.
- Старое плоское значение `group` остаётся совместимым; вложенность представлена нормализованным путём `Папка/Подпапка`.

## Проверка после merge #118

- Ветка напрямую основана на `main` `85bc411d655a334d30945cd3465140413789ba81`.
- Exact head: `63a90ad6c59ec094464caef4a65bbf79a313327a`.
- Tree SHA: `802cd7b8e7b80f856666b9a16481bfe23bac7e28`.
- Diff содержит только 1 коммит и 9 файлов слоя вложенных папок, порядка и drag-and-drop.
- CI #675 (run `34595028044`) — success: 411 Swift tests, terminal-web, Cloud suite, PostgreSQL 16 и release build.
- Test DMG #306 (run `34595028052`) — success.
- Artifact: `SelectiveRemote-test-119-arm64`, ID `10262616960`, 33,663,525 bytes, digest `sha256:fa4519b979ea72e624f499f8791f06c97004abd5d2a58104519cc5a276bae52c`.