### PR TITLE
Fix Personal Host drag-and-drop and conflict UX

### DIFF
--- a/Sources/SelectiveRemote/CloudTeamHostEditor.swift
+++ b/Sources/SelectiveRemote/CloudTeamHostEditor.swift
@@ -165,6 +165,12 @@ struct SelectiveRemoteTeamHostEditorView: View {
                     UpdateLocalization.text(ru: "Папка", en: "Folder"),
                     text: $folder
                 )
+                Text(UpdateLocalization.text(
+                    ru: "Для вложенности укажите путь через /, например Работа/Серверы/Linux.",
+                    en: "For nesting, use a / path such as Work/Servers/Linux."
+                ))
+                .font(.caption)
+                .foregroundStyle(.secondary)
                 TextField(
                     UpdateLocalization.text(
                         ru: "Теги через запятую",

--- a/Sources/SelectiveRemote/ContentView.swift
+++ b/Sources/SelectiveRemote/ContentView.swift
@@ -119,6 +119,9 @@ struct ContentView: View {
     @State private var showsAppearanceSettings = false
     @State private var showsUpdatePopover = false
     @State private var profileToShare: ConnectionProfile?
+    @State private var showsPersonalFolderCreator = false
+    @State private var newPersonalFolderName = ""
+    @State private var newPersonalFolderParent = ""
 
     private var profile: ConnectionProfile { model.selectedProfile }
     private var profileBinding: Binding<ConnectionProfile> {
@@ -271,6 +274,9 @@ struct ContentView: View {
         }
         .sheet(item: $profileToShare) { profile in
             SelectiveRemoteCloudProfileShareView(profile: profile)
+        }
+        .sheet(isPresented: $showsPersonalFolderCreator) {
+            personalFolderCreator
         }
         .onAppear {
             selectedTab = restoredProfileTab(for: profile.id)
@@ -536,6 +542,20 @@ struct ContentView: View {
                     Button("Новое Serial", systemImage: "cable.connector") {
                         model.addProfile(connectionType: .serial)
                     }
+                    Divider()
+                    Button(
+                        UpdateLocalization.text(
+                            ru: "Новая папка для выбранного Host…",
+                            en: "New Folder for Selected Host…"
+                        ),
+                        systemImage: "folder.badge.plus"
+                    ) {
+                        newPersonalFolderName = ""
+                        newPersonalFolderParent = SelectiveRemoteHostFolderPath.normalize(
+                            model.selectedProfile.group
+                        )
+                        showsPersonalFolderCreator = true
+                    }
                 } label: {
                     Image(systemName: "plus")
                 }
@@ -682,7 +702,6 @@ struct ContentView: View {
                             )
                             .tag(item.id)
                             .contentShape(Rectangle())
-                            .onTapGesture { openProfile(item.id) }
                             .contextMenu { profileContextMenu(item) }
                             .draggable("personal-host:\(item.id.uuidString)")
                             .dropDestination(for: String.self) { values, _ in
@@ -771,6 +790,74 @@ struct ContentView: View {
         else { return false }
         model.moveProfile(profileID: profileID, toFolder: folder, before: targetID)
         return true
+    }
+
+    private var personalFolderPaths: [String] {
+        var paths = Set<String>()
+        for profile in model.profiles {
+            let components = SelectiveRemoteHostFolderPath.components(profile.group)
+            guard !components.isEmpty else { continue }
+            for depth in 1...components.count {
+                paths.insert(components.prefix(depth).joined(separator: "/"))
+            }
+        }
+        return paths.sorted { lhs, rhs in
+            lhs.localizedCaseInsensitiveCompare(rhs) == .orderedAscending
+        }
+    }
+
+    private var personalFolderCreator: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Label(
+                UpdateLocalization.text(ru: "Новая папка", en: "New Folder"),
+                systemImage: "folder.badge.plus"
+            )
+            .font(.title2.bold())
+
+            Text(UpdateLocalization.text(
+                ru: "Выбранный Host будет перемещён в новую папку. Чтобы создать папку внутри папки, выберите родительскую.",
+                en: "The selected Host will move into the new folder. Choose a parent to create a nested folder."
+            ))
+            .foregroundStyle(.secondary)
+
+            Picker(
+                UpdateLocalization.text(ru: "Родительская папка", en: "Parent Folder"),
+                selection: $newPersonalFolderParent
+            ) {
+                Text(UpdateLocalization.text(ru: "Корень", en: "Root")).tag("")
+                ForEach(personalFolderPaths, id: \.self) { path in
+                    Text(path).tag(path)
+                }
+            }
+
+            TextField(
+                UpdateLocalization.text(ru: "Название папки", en: "Folder Name"),
+                text: $newPersonalFolderName
+            )
+            .textFieldStyle(.roundedBorder)
+
+            HStack {
+                Spacer()
+                Button(UpdateLocalization.text(ru: "Отмена", en: "Cancel"), role: .cancel) {
+                    showsPersonalFolderCreator = false
+                }
+                Button(UpdateLocalization.text(ru: "Создать и переместить", en: "Create and Move")) {
+                    let component = SelectiveRemoteHostFolderPath.normalize(newPersonalFolderName)
+                    let path = SelectiveRemoteHostFolderPath.normalize(
+                        [newPersonalFolderParent, component]
+                            .filter { !$0.isEmpty }
+                            .joined(separator: "/")
+                    )
+                    guard !component.isEmpty, !path.isEmpty else { return }
+                    model.moveProfile(profileID: model.selectedProfile.id, toFolder: path)
+                    showsPersonalFolderCreator = false
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(SelectiveRemoteHostFolderPath.normalize(newPersonalFolderName).isEmpty)
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 480)
     }
 
     @ViewBuilder
@@ -2742,12 +2829,24 @@ struct ContentView: View {
                             .textFieldStyle(.roundedBorder)
                     }
                     GridRow {
-                        Text(UpdateLocalization.text(ru: "Группа", en: "Group"))
+                        Text(UpdateLocalization.text(ru: "Папка", en: "Folder"))
                         TextField(
-                            UpdateLocalization.text(ru: "Например: Работа", en: "For example: Work"),
+                            UpdateLocalization.text(
+                                ru: "Например: Работа/Серверы/Linux",
+                                en: "For example: Work/Servers/Linux"
+                            ),
                             text: profileBinding.group
                         )
                             .textFieldStyle(.roundedBorder)
+                    }
+                    GridRow {
+                        Color.clear.frame(width: 1, height: 1)
+                        Text(UpdateLocalization.text(
+                            ru: "Символ / создаёт вложенный уровень папки.",
+                            en: "Use / to create a nested folder level."
+                        ))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                     }
                     GridRow(alignment: .top) {
                         Text(UpdateLocalization.text(ru: "Теги", en: "Tags"))

--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -1,5 +1,6 @@
 import { createIndexedDBVaultRepository, createLocalVaultController } from "./vault-local.js";
 import { createAuthenticatedVaultClient, synchronizeVault } from "./vault-sync.js";
+import { newestVaultConflictChoice } from "./vault-model.js";
 import {
   createIndexedDBTeamDeviceRepository,
   ensureTeamDeviceIdentity,
@@ -1849,23 +1850,38 @@ export async function initializeCloudAccount({
       }
       status = "unlocked";
     }
-    let result = await synchronizeVault({ client, vault, recoveryPassphrase: passphrase });
+    let result = await synchronizePersonalVault({ recoveryPassphrase: passphrase });
     if (status === "empty" && result.status === "empty") {
       await vault.create(passphrase);
-      result = await synchronizeVault({ client, vault });
+      result = await synchronizePersonalVault();
     }
     vaultUI.mode("unlocked");
     vaultUI.render();
     return result;
   }
 
+  async function synchronizePersonalVault({ recoveryPassphrase = null } = {}) {
+    let result = await synchronizeVault({ client, vault, recoveryPassphrase });
+    if (result.status !== "conflict") return result;
+
+    const conflictsResolved = result.conflicts.length;
+    await vault.resolveConflicts({
+      revision: result.revision,
+      resolutions: result.conflicts.map((conflict) => ({
+        id: conflict.id,
+        choice: newestVaultConflictChoice(conflict),
+      })),
+    });
+    result = await synchronizeVault({ client, vault });
+    return { ...result, automaticallyResolved: conflictsResolved };
+  }
+
   async function backgroundPersonalVaultSync() {
     if (backgroundSyncing || !client.session() || await vault.status() !== "unlocked") return;
     backgroundSyncing = true;
     try {
-      const result = await synchronizeVault({ client, vault });
-      if (result.status === "conflict") renderConflicts(result);
-      else if (result.status !== "remote_changed") hideConflicts();
+      const result = await synchronizePersonalVault();
+      if (result.status !== "remote_changed") hideConflicts();
       vaultUI.render();
     } catch {
       // Manual sync keeps the actionable error path; background failures never discard local state.
@@ -2262,7 +2278,7 @@ export async function initializeCloudAccount({
   syncButton.addEventListener("click", async () => {
     syncButton.disabled = true;
     try {
-      const result = await synchronizeVault({ client, vault });
+      const result = await synchronizePersonalVault();
       const messages = {
         empty: "Сначала создайте локальный Vault.",
         uploaded: `Зашифрованная ревизия ${result.revision} загружена.`,
@@ -2270,11 +2286,12 @@ export async function initializeCloudAccount({
         downloaded: `Зашифрованная ревизия ${result.revision} загружена и объединена локально.`,
         up_to_date: `Vault уже синхронизирован на ревизии ${result.revision}.`,
         remote_changed: `Удалённый Vault изменился до ревизии ${result.remoteRevision}. Повторите синхронизацию для безопасного merge.`,
-        conflict: `Обнаружено конфликтов: ${result.conflicts.length}. Upload остановлен; требуется явное разрешение конфликтов.`,
       };
-      if (result.status === "conflict") renderConflicts(result);
-      else hideConflicts();
-      setText(vaultMessage, messages[result.status] ?? "Синхронизация завершена.");
+      hideConflicts();
+      const automaticSuffix = result.automaticallyResolved
+        ? ` Автоматически разрешено конфликтов: ${result.automaticallyResolved}.`
+        : "";
+      setText(vaultMessage, `${messages[result.status] ?? "Синхронизация завершена."}${automaticSuffix}`);
     } catch (error) {
       const code = String(error?.message ?? "");
       if (code === "local_vault_locked") setText(vaultMessage, "Сначала разблокируйте локальный Vault.");

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Защищённая синхронизация Selective Remote">
   <title>Selective Remote Cloud</title>
-  <link rel="stylesheet" href="/styles.css?v=118">
+  <link rel="stylesheet" href="/styles.css?v=120">
 </head>
 <body>
   <main class="shell">
@@ -593,6 +593,6 @@
       <p>Регистрация доступна только во время контролируемого окна. Вход, подтверждение почты и восстановление пароля остаются доступны для существующего аккаунта.</p>
     </section>
   </main>
-  <script type="module" src="/app.js?v=118"></script>
+  <script type="module" src="/app.js?v=120"></script>
 </body>
 </html>

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -487,6 +487,20 @@ test("macOS Team workspace is wide, action-oriented, and maps invitation errors"
   assert.match(sync, /mergedKeepingNewest/u);
 });
 
+test("macOS Personal Hosts use an unambiguous drag gesture and visible nested-folder creator", async () => {
+  const [content, teamEditor] = await Promise.all([
+    readFile(new URL("ContentView.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudTeamHostEditor.swift", sourceRoot), "utf8"),
+  ]);
+  const personalRow = content.match(/\.tag\(item\.id\)[\s\S]*?\.draggable\("personal-host:/u)?.[0] ?? "";
+  assert.doesNotMatch(personalRow, /\.onTapGesture/u);
+  assert.match(content, /Новая папка для выбранного Host/u);
+  assert.match(content, /Родительская папка/u);
+  assert.match(content, /Работа\/Серверы\/Linux/u);
+  assert.match(content, /Символ \/ создаёт вложенный уровень папки/u);
+  assert.match(teamEditor, /Работа\/Серверы\/Linux/u);
+});
+
 
 test("macOS Personal Vault auto-sync preserves encrypted credentials without extra Keychain items", async () => {
   const [sync, crypto, settings, app, snippets] = await Promise.all([

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -320,6 +320,13 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(application, /synchronizeVault/u);
   assert.match(application, /unlockAndSyncPersonalVault\(password\)/u);
   assert.match(application, /backgroundPersonalVaultSync/u);
+  assert.match(application, /newestVaultConflictChoice/u);
+  assert.match(application, /async function synchronizePersonalVault/u);
+  assert.match(application, /automaticallyResolved: conflictsResolved/u);
+  assert.doesNotMatch(
+    application.match(/syncButton\.addEventListener\("click"[\s\S]*?conflictForm\.addEventListener/u)?.[0] ?? "",
+    /renderConflicts\(result\)/u,
+  );
   assert.match(application, /15_000/u);
   assert.match(application, /vault\.lock\(\)/u);
   assert.doesNotMatch(application, /accountVaultMigrationPassphrase|account_password_required/u);


### PR DESCRIPTION
## Исправлено

- Personal Host rows no longer attach a competing tap gesture, so native drag-and-drop can start inside the sidebar List like Team Host drag-and-drop.
- The New menu now exposes “Новая папка для выбранного Host…” with a parent-folder picker and a clear create-and-move action.
- Personal and Team Host editors explain slash-separated nested paths with an example.
- Browser Personal Vault automatically resolves any legacy conflict result using the same deterministic newest-change policy, joins causal histories and retries synchronization without showing the manual conflict wall.
- Web asset URLs advance to v120 so a refreshed tab cannot reuse the pre-fix entry point.

## Verification

- Exact head: `94b5548d75adfe335025b11509506525aad0afab`.
- CI #677 (run `34599039333`) — success: Swift tests, terminal-web, Cloud suite, PostgreSQL 16 and release build.
- Test DMG #307 (run `34599039354`) — success.
- Artifact: `SelectiveRemote-test-120-arm64`, ID `10263314520`, 33,688,335 bytes, digest `sha256:2182d19277933f981f56a9882d45d4df8653791840cf7870222ac8806690f379`.
- Full local Cloud suite: 297 passed, 0 failed, 1 PostgreSQL integration skipped without `TEST_DATABASE_URL`.
- Focused UI/sync suite: 49 passed.
- JavaScript syntax and git diff checks passed.
- All six published Git blob SHAs match the local verified commit byte-for-byte.