### PR TITLE
Cloud: fix catalog overflow and expand Personal Host editor

### DIFF
--- a/Sources/SelectiveRemote/CloudPersonalVaultImport.swift
+++ b/Sources/SelectiveRemote/CloudPersonalVaultImport.swift
@@ -174,6 +174,15 @@ enum SelectiveRemotePersonalVaultImporter {
         value.id = record.id
         value.friendlyName = string(data["title"]) ?? address
         value.username = string(data["username"]) ?? ""
+        value.group = SelectiveRemoteHostFolderPath.normalize(string(data["folder"]) ?? "")
+        value.profileDescription = String((string(data["description"]) ?? "").prefix(2_048))
+        if case let .array(tagValues)? = data["tags"] {
+            value.tags = Array(tagValues.compactMap(string).prefix(24))
+        }
+        if (type == .ssh || type == .telnet), let port = integer(data["port"]),
+           (1 ... 65_535).contains(port) {
+            value.sshPort = port
+        }
         if type == .serial { value.serialDevicePath = address } else { value.host = address }
         return value
     }
@@ -269,6 +278,13 @@ enum SelectiveRemotePersonalVaultImporter {
     private static func string(_ value: SelectiveRemoteJSONValue?) -> String? {
         guard case let .string(result)? = value else { return nil }
         return result
+    }
+
+    private static func integer(_ value: SelectiveRemoteJSONValue?) -> Int? {
+        guard case let .number(result)? = value, result.rounded() == result,
+              result >= Double(Int.min), result <= Double(Int.max)
+        else { return nil }
+        return Int(result)
     }
 
     private static func decode<T: Decodable>(_ value: String, recordID: UUID) throws -> T {

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -1532,7 +1532,10 @@ struct PersonalVaultInitialDownloadDecoderTests {
         let snippetID = UUID(uuidString: "55555555-5555-4555-8555-555555555555")!
         let document = try SelectiveRemoteVaultDocument(records: [
             try .init(id: hostID, type: .host, version: version, modifiedAt: "2026-09-10T00:00:00.000Z", data: .object([
-                "title": .string("Web Host"), "address": .string("web.example"), "username": .string("admin")
+                "title": .string("Web Host"), "address": .string("web.example"), "username": .string("admin"),
+                "connectionType": .string("ssh"), "port": .number(2_222),
+                "folder": .string("Work/Production"), "tags": .array([.string("linux"), .string("prod")]),
+                "description": .string("Created in browser")
             ])),
             try .init(id: snippetID, type: .snippet, version: version, modifiedAt: "2026-09-10T00:00:00.000Z", data: .object([
                 "title": .string("Status"), "body": .string("uptime")
@@ -1541,6 +1544,10 @@ struct PersonalVaultInitialDownloadDecoderTests {
         let decoded = try SelectiveRemotePersonalVaultImporter.decode(document)
         #expect(decoded.profiles.first?.id == hostID)
         #expect(decoded.profiles.first?.connectionType == .ssh)
+        #expect(decoded.profiles.first?.sshPort == 2_222)
+        #expect(decoded.profiles.first?.group == "Work/Production")
+        #expect(decoded.profiles.first?.tags == ["linux", "prod"])
+        #expect(decoded.profiles.first?.profileDescription == "Created in browser")
         #expect(decoded.snippets.first?.id == snippetID)
     }
 

--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -113,6 +113,80 @@ export function sortLocalVaultRecords(records, mode = "modified-desc") {
   return values.sort((a, b) => String(b.modifiedAt ?? "").localeCompare(String(a.modifiedAt ?? "")));
 }
 
+function decodePortableRecord(value) {
+  const text = String(value ?? "");
+  if (!text || text.length > 1_048_576) throw new Error("invalid_portable_record");
+  const normalized = text.replace(/-/gu, "+").replace(/_/gu, "/");
+  const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
+  const bytes = Uint8Array.from(atob(padded), (character) => character.charCodeAt(0));
+  const decoded = JSON.parse(new TextDecoder().decode(bytes));
+  if (!decoded || typeof decoded !== "object" || Array.isArray(decoded)) throw new Error("invalid_portable_record");
+  return decoded;
+}
+
+function encodePortableRecord(value) {
+  const bytes = new TextEncoder().encode(JSON.stringify(value));
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/gu, "-").replace(/\//gu, "_").replace(/=+$/u, "");
+}
+
+export function personalHostEditorValues(record) {
+  const data = record?.data ?? {};
+  let profile = null;
+  try { if (data.profile) profile = decodePortableRecord(data.profile); } catch { /* outer fields remain usable */ }
+  const connectionType = String(profile?.connectionType ?? data.connectionType ?? "ssh");
+  const address = connectionType === "serial"
+    ? String(profile?.serialDevicePath ?? data.address ?? "")
+    : String(profile?.host ?? data.address ?? "");
+  return {
+    title: String(profile?.friendlyName ?? data.title ?? ""),
+    address,
+    protocol: ["ssh", "rdp", "telnet", "serial"].includes(connectionType) ? connectionType : "ssh",
+    port: Number(profile?.sshPort ?? data.port ?? (connectionType === "telnet" ? 23 : connectionType === "rdp" ? 3389 : 22)),
+    username: String(profile?.username ?? data.username ?? ""),
+    folder: String(profile?.group ?? data.folder ?? ""),
+    tags: Array.isArray(profile?.tags ?? data.tags) ? (profile?.tags ?? data.tags).join(", ") : "",
+    description: String(profile?.profileDescription ?? data.description ?? ""),
+  };
+}
+
+export function personalHostRecordData({ title, address, protocol, port, username, folder, tags, description, baseData = null }) {
+  const normalizedProtocol = String(protocol ?? "ssh");
+  const normalizedPort = Number(port || (normalizedProtocol === "telnet" ? 23 : normalizedProtocol === "rdp" ? 3389 : 22));
+  const normalizedUsername = String(username ?? "").trim();
+  const normalizedFolder = String(folder ?? "").trim();
+  const normalizedDescription = String(description ?? "").trim();
+  const normalizedTags = [...new Set(String(tags ?? "").split(",").map((value) => value.trim()).filter(Boolean))];
+  if (!["ssh", "rdp", "telnet", "serial"].includes(normalizedProtocol)
+    || !Number.isSafeInteger(normalizedPort) || normalizedPort < 1 || normalizedPort > 65_535
+    || normalizedUsername.length > 256 || normalizedFolder.length > 120 || normalizedDescription.length > 2_048
+    || normalizedTags.length > 24 || normalizedTags.some((value) => value.length > 64)) {
+    throw new Error("invalid_personal_host");
+  }
+  const data = localVaultRecordData("host", { title, target: address, secret: "" }, baseData);
+  data.connectionType = normalizedProtocol;
+  data.port = normalizedPort;
+  data.username = normalizedUsername;
+  if (normalizedFolder) data.folder = normalizedFolder; else delete data.folder;
+  if (normalizedTags.length) data.tags = normalizedTags; else delete data.tags;
+  if (normalizedDescription) data.description = normalizedDescription; else delete data.description;
+  if (baseData?.profile) {
+    const profile = decodePortableRecord(baseData.profile);
+    profile.friendlyName = data.title;
+    profile.connectionType = normalizedProtocol;
+    profile.username = normalizedUsername;
+    profile.group = normalizedFolder;
+    profile.tags = normalizedTags;
+    profile.profileDescription = normalizedDescription;
+    if (normalizedProtocol === "serial") profile.serialDevicePath = data.address;
+    else profile.host = data.address;
+    if (normalizedProtocol === "ssh" || normalizedProtocol === "telnet") profile.sshPort = normalizedPort;
+    data.profile = encodePortableRecord(profile);
+  }
+  return data;
+}
+
 export function teamHostRecordData({ title, target, folder, tags, description, baseData = null }) {
   const data = localVaultRecordData("host", { title, target, secret: "" });
   const normalizedFolder = String(folder ?? "").trim();
@@ -231,6 +305,8 @@ export async function initializeLocalVault({
   const folderFilter = documentValue.querySelector("#personal-vault-folder-filter");
   const saveButton = documentValue.querySelector("#local-record-save");
   const cancelButton = documentValue.querySelector("#local-record-cancel");
+  const editorTitle = documentValue.querySelector("#local-record-editor-title");
+  const editorHint = documentValue.querySelector("#local-record-editor-hint");
   const lockButton = documentValue.querySelector("#local-vault-lock");
   const type = documentValue.querySelector("#local-record-type");
   const title = documentValue.querySelector("#local-record-title");
@@ -238,6 +314,13 @@ export async function initializeLocalVault({
   const secret = documentValue.querySelector("#local-record-secret");
   const targetLabel = documentValue.querySelector("#local-record-target-label");
   const secretLabel = documentValue.querySelector("#local-record-secret-label");
+  const hostFields = documentValue.querySelector("#personal-host-fields");
+  const hostProtocol = documentValue.querySelector("#local-host-protocol");
+  const hostPort = documentValue.querySelector("#local-host-port");
+  const hostUsername = documentValue.querySelector("#local-host-username");
+  const hostFolder = documentValue.querySelector("#local-host-folder");
+  const hostTags = documentValue.querySelector("#local-host-tags");
+  const hostDescription = documentValue.querySelector("#local-host-description");
   const conflictPanel = documentValue.querySelector("#local-vault-conflicts");
   const conflictForm = documentValue.querySelector("#local-vault-conflicts-form");
   const conflictList = documentValue.querySelector("#local-vault-conflicts-list");
@@ -270,6 +353,8 @@ export async function initializeLocalVault({
     type.disabled = false;
     saveButton.textContent = "Зашифровать и сохранить";
     cancelButton.hidden = true;
+    setText(editorTitle, "Новая запись");
+    setText(editorHint, "Выберите тип и заполните поля. Всё шифруется в браузере.");
     updateLabels();
   }
 
@@ -281,8 +366,23 @@ export async function initializeLocalVault({
     title.value = values.title;
     target.value = values.target;
     secret.value = values.secret;
+    if (record.type === "host") {
+      const host = personalHostEditorValues(record);
+      title.value = host.title;
+      target.value = host.address;
+      hostProtocol.value = host.protocol;
+      hostPort.value = String(host.port);
+      hostUsername.value = host.username;
+      hostFolder.value = host.folder;
+      hostTags.value = host.tags;
+      hostDescription.value = host.description;
+    }
     saveButton.textContent = "Сохранить изменения";
     cancelButton.hidden = false;
+    setText(editorTitle, `Редактирование ${String(record.data?.title ?? "записи")}`);
+    setText(editorHint, record.type === "host"
+      ? "Основные поля и организация Host синхронизируются с приложением. Расширенные SSH/RDP-параметры сохраняются без изменений."
+      : "Измените нужные поля и сохраните новую зашифрованную версию записи.");
     updateLabels();
     recordForm.scrollIntoView?.({ behavior: "smooth", block: "center" });
     title.focus?.();
@@ -326,6 +426,13 @@ export async function initializeLocalVault({
     setText(secretLabel, secretText);
     target.required = type.value !== "snippet";
     secret.required = type.value === "credential" || type.value === "snippet";
+    const isHost = type.value === "host";
+    hostFields.hidden = !isHost;
+    secretLabel.hidden = isHost;
+    secret.hidden = isHost;
+    hostPort.disabled = !["ssh", "telnet"].includes(hostProtocol.value);
+    if (hostProtocol.value === "rdp") hostPort.value = "3389";
+    if (hostProtocol.value === "serial") hostPort.value = "1";
   }
 
   function render() {
@@ -429,9 +536,9 @@ export async function initializeLocalVault({
           setText(hostDetailTitle, String(record.data.title ?? "Host"));
           setText(hostDetailAddress, String(record.data.address ?? "—"));
           setText(hostDetailModified, formatVaultTimestamp(record.modifiedAt));
-          const connection = parseTeamHostConnection(record.data);
+          const connection = personalHostEditorValues(record);
           setText(hostDetailProtocol, connection.protocol.toUpperCase());
-          setText(hostDetailPort, String(connection.port));
+          setText(hostDetailPort, connection.protocol === "serial" ? "—" : String(connection.port));
           setText(hostDetailUsername, connection.username || "—");
           setText(hostDetailPasswordState, "Управляется приложением");
           setText(hostDetailFolder, String(record.data?.folder ?? "Личный Vault"));
@@ -467,14 +574,21 @@ export async function initializeLocalVault({
       const existing = editingRecordID
         ? controller.document().records.find((record) => record.id === editingRecordID)
         : null;
-      await controller.upsert({
-        ...(editingRecordID ? { id: editingRecordID } : {}),
-        type: type.value,
-        data: localVaultRecordData(
+      const data = type.value === "host"
+        ? personalHostRecordData({
+          title: title.value, address: target.value, protocol: hostProtocol.value,
+          port: hostPort.value, username: hostUsername.value, folder: hostFolder.value,
+          tags: hostTags.value, description: hostDescription.value, baseData: existing?.data,
+        })
+        : localVaultRecordData(
           type.value,
           { title: title.value, target: target.value, secret: secret.value },
           existing?.data,
-        ),
+        );
+      await controller.upsert({
+        ...(editingRecordID ? { id: editingRecordID } : {}),
+        type: type.value,
+        data,
       });
       const wasEditing = Boolean(editingRecordID);
       resetEditor();
@@ -489,6 +603,11 @@ export async function initializeLocalVault({
   });
 
   type.addEventListener("change", updateLabels);
+  hostProtocol.addEventListener("change", () => {
+    if (hostProtocol.value === "ssh") hostPort.value = "22";
+    if (hostProtocol.value === "telnet") hostPort.value = "23";
+    updateLabels();
+  });
   cancelButton.addEventListener("click", () => {
     resetEditor();
     setText(message, "Изменение отменено.");

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Защищённая синхронизация Selective Remote">
   <title>Selective Remote Cloud</title>
-  <link rel="stylesheet" href="/styles.css?v=121">
+  <link rel="stylesheet" href="/styles.css?v=122">
 </head>
 <body>
   <main class="shell">
@@ -252,18 +252,25 @@
           <button type="button" data-record-filter="forwarding">Forwarding</button>
         </nav>
         <div class="personal-vault-browser" id="personal-vault-browser">
-          <label for="personal-vault-search">Поиск</label>
-          <input id="personal-vault-search" type="search" maxlength="120" placeholder="Название, адрес, логин или папка">
-          <label for="personal-vault-sort">Сортировка</label>
-          <select id="personal-vault-sort">
-            <option value="modified-desc">Сначала изменённые</option>
-            <option value="title-asc">По названию</option>
-            <option value="type-asc">По типу</option>
-          </select>
-          <label for="personal-vault-folder-filter">Папка Hosts</label>
-          <select id="personal-vault-folder-filter"><option value="all">Все папки</option></select>
+          <label class="personal-vault-control" for="personal-vault-search"><span>Поиск</span>
+            <input id="personal-vault-search" type="search" maxlength="120" placeholder="Название, адрес, логин или папка">
+          </label>
+          <label class="personal-vault-control" for="personal-vault-sort"><span>Сортировка</span>
+            <select id="personal-vault-sort">
+              <option value="modified-desc">Сначала изменённые</option>
+              <option value="title-asc">По названию</option>
+              <option value="type-asc">По типу</option>
+            </select>
+          </label>
+          <label class="personal-vault-control" for="personal-vault-folder-filter"><span>Папка Hosts</span>
+            <select id="personal-vault-folder-filter"><option value="all">Все папки</option></select>
+          </label>
         </div>
         <form class="record-form" id="local-vault-record-form">
+          <div class="record-editor-heading">
+            <h3 id="local-record-editor-title">Новая запись</h3>
+            <p id="local-record-editor-hint">Выберите тип и заполните поля. Всё шифруется в браузере.</p>
+          </div>
           <label for="local-record-type">Тип записи</label>
           <select id="local-record-type" name="type">
             <option value="host">Host</option>
@@ -277,6 +284,23 @@
           <input id="local-record-target" name="target" maxlength="2048">
           <label for="local-record-secret" id="local-record-secret-label">Дополнительные данные не требуются</label>
           <textarea id="local-record-secret" name="secret" maxlength="32768" rows="3"></textarea>
+          <div class="personal-host-fields" id="personal-host-fields">
+            <label for="local-host-protocol">Протокол</label>
+            <select id="local-host-protocol" name="protocol">
+              <option value="ssh">SSH</option><option value="rdp">RDP</option>
+              <option value="telnet">Telnet</option><option value="serial">Serial</option>
+            </select>
+            <label for="local-host-port">Порт</label>
+            <input id="local-host-port" name="port" type="number" min="1" max="65535" value="22">
+            <label for="local-host-username">Логин</label>
+            <input id="local-host-username" name="username" maxlength="256" autocomplete="username">
+            <label for="local-host-folder">Папка</label>
+            <input id="local-host-folder" name="folder" maxlength="120" placeholder="Например, Работа/Production">
+            <label for="local-host-tags">Теги</label>
+            <input id="local-host-tags" name="tags" maxlength="512" placeholder="linux, production, eu-west">
+            <label for="local-host-description">Описание</label>
+            <textarea id="local-host-description" name="description" maxlength="2048" rows="3"></textarea>
+          </div>
           <div class="record-form-actions">
             <button type="submit" id="local-record-save">Зашифровать и сохранить</button>
             <button type="button" class="secondary" id="local-record-cancel" hidden>Отменить изменение</button>
@@ -608,6 +632,6 @@
       <p>Регистрация доступна только во время контролируемого окна. Вход, подтверждение почты и восстановление пароля остаются доступны для существующего аккаунта.</p>
     </section>
   </main>
-  <script type="module" src="/app.js?v=121"></script>
+  <script type="module" src="/app.js?v=122"></script>
 </body>
 </html>

--- a/cloud/public/styles.css
+++ b/cloud/public/styles.css
@@ -146,9 +146,12 @@ body { margin:0; min-height:100vh; background:var(--body-bg); color:var(--ink); 
 .team-host-browser { display:grid; grid-template-columns:auto minmax(220px,1fr) auto minmax(180px,.45fr); align-items:center; gap:12px; margin-top:24px; padding:16px; border:1px solid var(--line); border-radius:14px; background:#08110e; }
 .team-host-browser label { color:var(--muted); font-size:13px; }
 .team-host-browser input,.team-host-browser select { width:100%; border:1px solid var(--line); border-radius:10px; padding:12px 14px; background:#07100d; color:var(--ink); font:inherit; }
-.personal-vault-browser { display:grid; grid-template-columns:auto minmax(190px,1fr) auto minmax(170px,.55fr) auto minmax(160px,.5fr); align-items:center; gap:12px; margin-top:22px; padding:16px; border:1px solid var(--line); border-radius:14px; background:#08110e; }
-.personal-vault-browser label { color:var(--muted); font-size:13px; }
+.personal-vault-browser { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); align-items:end; gap:14px; margin-top:22px; padding:16px; border:1px solid var(--line); border-radius:14px; background:#08110e; overflow:hidden; }
+.personal-vault-control { display:grid; gap:7px; min-width:0; color:var(--muted); font-size:13px; }
 .personal-vault-browser input,.personal-vault-browser select { width:100%; box-sizing:border-box; border:1px solid var(--line); border-radius:10px; padding:12px 14px; background:#07100d; color:var(--ink); font:inherit; }
+.record-editor-heading { grid-column:1/-1; padding-bottom:14px; border-bottom:1px solid var(--line); }
+.record-editor-heading h3,.record-editor-heading p { margin:0; }.record-editor-heading p { margin-top:6px; color:var(--muted); }
+.personal-host-fields { display:contents; }
 .record-form-actions { grid-column:2; display:flex; gap:10px; flex-wrap:wrap; align-items:center; }
 .record-form-actions button { grid-column:auto; margin-top:6px; }
 .personal-vault-folder-heading { grid-column:1/-1; margin:12px 0 0; padding-bottom:8px; border-bottom:1px solid var(--line); }

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -10,6 +10,8 @@ import {
   localVaultRecordFormValues,
   localVaultRecordSummary,
   parseTeamHostConnection,
+  personalHostEditorValues,
+  personalHostRecordData,
   sortLocalVaultRecords,
   teamHostConnectionData,
   teamHostRecordData,
@@ -94,6 +96,33 @@ test("Personal Vault editor preserves native fields and maps decrypted form valu
     type: "forwarding",
     data: { title: "DB", destination: "db.invalid:5432", configuration: "local 15432" },
   }), { title: "DB", target: "db.invalid:5432", secret: "local 15432" });
+});
+
+test("Personal Host editor updates organization and the embedded native profile together", () => {
+  const profile = {
+    id: "44444444-4444-4444-8444-444444444444", connectionType: "ssh",
+    friendlyName: "Old", host: "old.invalid", username: "root", sshPort: 22,
+    group: "Old", tags: ["legacy"], profileDescription: "Old description",
+    sshProxyMode: "none",
+  };
+  const encoded = Buffer.from(JSON.stringify(profile)).toString("base64url");
+  const baseData = { title: "Old", address: "old.invalid", connectionType: "ssh", profile: encoded };
+  const data = personalHostRecordData({
+    title: "Production", address: "prod.invalid", protocol: "ssh", port: "2222",
+    username: "deployer", folder: "Work/Production", tags: "linux, prod, linux",
+    description: "Primary endpoint", baseData,
+  });
+  const decoded = JSON.parse(Buffer.from(data.profile, "base64url").toString());
+  assert.deepEqual(personalHostEditorValues({ type: "host", data }), {
+    title: "Production", address: "prod.invalid", protocol: "ssh", port: 2222,
+    username: "deployer", folder: "Work/Production", tags: "linux, prod",
+    description: "Primary endpoint",
+  });
+  assert.equal(decoded.friendlyName, "Production");
+  assert.equal(decoded.host, "prod.invalid");
+  assert.equal(decoded.sshPort, 2222);
+  assert.equal(decoded.group, "Work/Production");
+  assert.equal(decoded.sshProxyMode, "none");
 });
 
 test("Vault timestamps render in the viewer time zone instead of raw UTC", () => {
@@ -217,8 +246,8 @@ test("portal exposes separate public, authentication and workspace states", asyn
   ]);
 
   assert.match(html, /id="cloud-account"[^>]*hidden/u);
-  assert.match(html, /\/styles\.css\?v=121/u);
-  assert.match(html, /\/app\.js\?v=121/u);
+  assert.match(html, /\/styles\.css\?v=122/u);
+  assert.match(html, /\/app\.js\?v=122/u);
   assert.match(html, /id="cloud-workspace"[^>]*hidden/u);
   assert.match(html, /data-open-auth="login"/u);
   assert.match(html, /data-open-auth="registration"/u);
@@ -301,6 +330,9 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(html, /id="personal-vault-sort"/u);
   assert.match(html, /id="personal-vault-folder-filter"/u);
   assert.match(html, /id="local-record-cancel"[^>]*hidden/u);
+  assert.match(html, /id="personal-host-fields"/u);
+  assert.match(html, /id="local-host-protocol"/u);
+  assert.match(html, /id="local-host-folder"/u);
   assert.match(html, /Откройте Vault, чтобы увидеть личные подключения/u);
   assert.doesNotMatch(html, /ещё не выполняет этот импорт автоматически/u);
   assert.match(styles, /\[hidden\]\s*\{\s*display:\s*none\s*!important;\s*\}/u);
@@ -357,7 +389,9 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(application, /formatVaultTimestamp\(record\.modifiedAt\)/u);
   assert.match(application, /localVaultRecordFormValues\(record\)/u);
   assert.match(application, /editingRecordID/u);
+  assert.match(application, /personalHostRecordData/u);
   assert.match(styles, /\.personal-vault-browser/u);
+  assert.match(styles, /grid-template-columns:repeat\(3,minmax\(0,1fr\)\)/u);
   assert.match(server, /\^\\\/app\(\?:\\\/\[\^\/\]\+\)\?\$/u);
   assert.match(application, /createAuthenticatedVaultClient/u);
   assert.match(application, /synchronizeVault/u);


### PR DESCRIPTION
Reflows Personal Vault catalog controls into three bounded responsive groups, adds a complete Personal Host editor (protocol, port, username, nested folder, tags, description), updates embedded native profile data without dropping advanced fields, and teaches macOS to import organization/port fields from browser-created Hosts. Advances web assets to v122.