### PR TITLE
Cloud: simplify Personal Vault navigation and editor lifecycle

### DIFF
--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -303,6 +303,7 @@ export async function initializeLocalVault({
   const search = documentValue.querySelector("#personal-vault-search");
   const sort = documentValue.querySelector("#personal-vault-sort");
   const folderFilter = documentValue.querySelector("#personal-vault-folder-filter");
+  const createButton = documentValue.querySelector("#local-record-create");
   const saveButton = documentValue.querySelector("#local-record-save");
   const cancelButton = documentValue.querySelector("#local-record-cancel");
   const editorTitle = documentValue.querySelector("#local-record-editor-title");
@@ -347,20 +348,46 @@ export async function initializeLocalVault({
   let activeRecordFilter = "all";
   let editingRecordID = null;
 
-  function resetEditor() {
+  function updateCreateButton() {
+    const labels = {
+      host: "Добавить Host",
+      credential: "Добавить Credential",
+      snippet: "Добавить Snippet",
+      forwarding: "Добавить Forwarding",
+    };
+    setText(createButton, labels[activeRecordFilter] ?? "Добавить запись");
+  }
+
+  function resetEditor({ hide = true } = {}) {
     editingRecordID = null;
     recordForm.reset();
+    recordForm.hidden = hide;
     type.disabled = false;
     saveButton.textContent = "Зашифровать и сохранить";
-    cancelButton.hidden = true;
+    cancelButton.textContent = "Отменить";
+    cancelButton.hidden = hide;
     setText(editorTitle, "Новая запись");
     setText(editorHint, "Выберите тип и заполните поля. Всё шифруется в браузере.");
     updateLabels();
   }
 
+  function beginCreate() {
+    resetEditor({ hide: false });
+    if (["host", "credential", "snippet", "forwarding"].includes(activeRecordFilter)) {
+      type.value = activeRecordFilter;
+      type.disabled = true;
+    }
+    cancelButton.textContent = "Отменить создание";
+    updateLabels();
+    setText(message, "Новая запись. Заполните поля и сохраните зашифрованную версию.");
+    recordForm.scrollIntoView?.({ behavior: "smooth", block: "center" });
+    title.focus?.();
+  }
+
   function beginEdit(record) {
     const values = localVaultRecordFormValues(record);
     editingRecordID = record.id;
+    recordForm.hidden = false;
     type.value = record.type;
     type.disabled = true;
     title.value = values.title;
@@ -378,6 +405,7 @@ export async function initializeLocalVault({
       hostDescription.value = host.description;
     }
     saveButton.textContent = "Сохранить изменения";
+    cancelButton.textContent = "Отменить изменение";
     cancelButton.hidden = false;
     setText(editorTitle, `Редактирование ${String(record.data?.title ?? "записи")}`);
     setText(editorHint, record.type === "host"
@@ -603,6 +631,7 @@ export async function initializeLocalVault({
   });
 
   type.addEventListener("change", updateLabels);
+  createButton?.addEventListener("click", beginCreate);
   hostProtocol.addEventListener("change", () => {
     if (hostProtocol.value === "ssh") hostPort.value = "22";
     if (hostProtocol.value === "telnet") hostPort.value = "23";
@@ -617,7 +646,9 @@ export async function initializeLocalVault({
   folderFilter?.addEventListener("change", render);
   for (const button of filterButtons) {
     button.addEventListener("click", () => {
+      resetEditor();
       activeRecordFilter = button.dataset.recordFilter || "all";
+      updateCreateButton();
       for (const candidate of filterButtons) {
         candidate.classList.toggle("active", candidate === button);
       }
@@ -635,6 +666,7 @@ export async function initializeLocalVault({
   });
 
   updateLabels();
+  updateCreateButton();
   try {
     const status = await controller.status();
     mode(status === "unlocked" ? "unlocked" : "waiting");
@@ -652,8 +684,13 @@ export async function initializeLocalVault({
     render,
     clearConflictUI,
     setConflictMode,
+    closeEditor() {
+      resetEditor();
+    },
     setFilter(value) {
+      resetEditor();
       activeRecordFilter = ["all", "host", "credential", "snippet", "forwarding", "sshKey"].includes(value) ? value : "all";
+      updateCreateButton();
       for (const button of filterButtons) {
         button.classList.toggle("active", button.dataset.recordFilter === activeRecordFilter);
       }
@@ -2667,6 +2704,7 @@ export function initializePortalNavigation({
 
   function selectWorkspacePanel(target, recordFilter = null, teamView = null) {
     const panelID = Object.hasOwn(titles, target) ? target : "workspace-overview";
+    if (panelID !== "local-vault") vaultUI?.closeEditor();
     for (const panel of workspacePanels) panel.hidden = panel.id !== panelID;
     for (const button of sidebarButtons) {
       const matchesPanel = button.dataset.workspaceTarget === panelID;
@@ -2679,7 +2717,7 @@ export function initializePortalNavigation({
     setText(workspaceTitle, panelID === "local-vault"
       ? resourceTitles[recordFilter || "all"]
       : panelID === "team-vault" ? teamTitles[teamView || "teams"] : titles[panelID]);
-    if (recordFilter) vaultUI?.setFilter(recordFilter);
+    if (panelID === "local-vault") vaultUI?.setFilter(recordFilter || "all");
     if (panelID === "team-vault") teamUI?.setView(teamView || "teams");
   }
 
@@ -2702,6 +2740,7 @@ export function initializePortalNavigation({
   });
 
   function showLanding({ replace = false } = {}) {
+    vaultUI?.closeEditor();
     brand.hidden = false;
     publicActions.hidden = false;
     hero.hidden = false;
@@ -2716,6 +2755,7 @@ export function initializePortalNavigation({
   }
 
   function showAuthentication(mode = "login", { replace = false } = {}) {
+    vaultUI?.closeEditor();
     brand.hidden = false;
     publicActions.hidden = true;
     hero.hidden = false;

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Защищённая синхронизация Selective Remote">
   <title>Selective Remote Cloud</title>
-  <link rel="stylesheet" href="/styles.css?v=122">
+  <link rel="stylesheet" href="/styles.css?v=123">
 </head>
 <body>
   <main class="shell">
@@ -148,8 +148,7 @@
           <button type="button" data-workspace-target="local-vault" data-record-filter="snippet">Сниппеты</button>
           <button type="button" data-workspace-target="local-vault" data-record-filter="credential">Учётные данные</button>
           <button type="button" data-workspace-target="local-vault" data-record-filter="forwarding">Forwarding</button>
-          <p class="workspace-nav-label">Хранилища</p>
-          <button type="button" data-workspace-target="local-vault" data-record-filter="all">Personal Vault</button>
+          <p class="workspace-nav-label">Команды</p>
           <button type="button" data-workspace-target="team-vault" data-team-view="teams">Команды</button>
           <button type="button" data-workspace-target="team-vault" data-team-view="members">Участники команд</button>
           <button type="button" data-workspace-target="team-vault" data-team-view="vaults">Папки команд</button>
@@ -240,6 +239,7 @@
         <div class="vault-toolbar">
           <div><h3>Личный Vault</h3><p>Зашифрованная копия, которая разблокируется только на вашем устройстве.</p></div>
           <div class="vault-actions">
+            <button type="button" class="secondary" id="local-record-create">Добавить запись</button>
             <button type="button" id="cloud-vault-sync" disabled>Синхронизировать</button>
             <button type="button" class="secondary" id="local-vault-lock">Заблокировать</button>
           </div>
@@ -266,7 +266,7 @@
             <select id="personal-vault-folder-filter"><option value="all">Все папки</option></select>
           </label>
         </div>
-        <form class="record-form" id="local-vault-record-form">
+        <form class="record-form" id="local-vault-record-form" hidden>
           <div class="record-editor-heading">
             <h3 id="local-record-editor-title">Новая запись</h3>
             <p id="local-record-editor-hint">Выберите тип и заполните поля. Всё шифруется в браузере.</p>
@@ -632,6 +632,6 @@
       <p>Регистрация доступна только во время контролируемого окна. Вход, подтверждение почты и восстановление пароля остаются доступны для существующего аккаунта.</p>
     </section>
   </main>
-  <script type="module" src="/app.js?v=122"></script>
+  <script type="module" src="/app.js?v=123"></script>
 </body>
 </html>

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -246,8 +246,8 @@ test("portal exposes separate public, authentication and workspace states", asyn
   ]);
 
   assert.match(html, /id="cloud-account"[^>]*hidden/u);
-  assert.match(html, /\/styles\.css\?v=122/u);
-  assert.match(html, /\/app\.js\?v=122/u);
+  assert.match(html, /\/styles\.css\?v=123/u);
+  assert.match(html, /\/app\.js\?v=123/u);
   assert.match(html, /id="cloud-workspace"[^>]*hidden/u);
   assert.match(html, /data-open-auth="login"/u);
   assert.match(html, /data-open-auth="registration"/u);
@@ -329,7 +329,11 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(html, /id="personal-vault-search"/u);
   assert.match(html, /id="personal-vault-sort"/u);
   assert.match(html, /id="personal-vault-folder-filter"/u);
+  assert.match(html, /id="local-record-create"/u);
+  assert.match(html, /id="local-vault-record-form"[^>]*hidden/u);
   assert.match(html, /id="local-record-cancel"[^>]*hidden/u);
+  assert.doesNotMatch(html, /data-record-filter="all">Personal Vault/u);
+  assert.match(html, /class="workspace-nav-label">Команды/u);
   assert.match(html, /id="personal-host-fields"/u);
   assert.match(html, /id="local-host-protocol"/u);
   assert.match(html, /id="local-host-folder"/u);
@@ -389,6 +393,11 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(application, /formatVaultTimestamp\(record\.modifiedAt\)/u);
   assert.match(application, /localVaultRecordFormValues\(record\)/u);
   assert.match(application, /editingRecordID/u);
+  assert.match(application, /closeEditor\(\)/u);
+  assert.match(application, /recordForm\.hidden = hide/u);
+  assert.match(application, /createButton\?\.addEventListener\("click", beginCreate\)/u);
+  assert.match(application, /setFilter\(value\) \{\s*resetEditor\(\)/u);
+  assert.match(application, /panelID !== "local-vault"\) vaultUI\?\.closeEditor\(\)/u);
   assert.match(application, /personalHostRecordData/u);
   assert.match(styles, /\.personal-vault-browser/u);
   assert.match(styles, /grid-template-columns:repeat\(3,minmax\(0,1fr\)\)/u);


### PR DESCRIPTION
## Что изменено

- удалён дублирующий пункт `Personal Vault` из бокового меню; разделы ресурсов остаются прямыми маршрутами
- форма создания записи скрыта по умолчанию и открывается контекстной кнопкой для текущего типа ресурса
- редактор полностью очищается и закрывается при смене типа ресурса, переходе в другой раздел, выходе на лендинг или экран входа
- переход без явного фильтра корректно открывает представление «Все»
- web assets подняты до v123

## Проверка

- `node --check cloud/public/app.js`
- 46 целевых Personal Vault/Sync/UI тестов
- полный Cloud suite: 301 passed, 1 skipped (PostgreSQL integration без `TEST_DATABASE_URL`)

Формат Vault, E2EE, серверный API и миграции БД не меняются.