### PR TITLE
Cloud: fix Personal Vault folders and time labels

### DIFF
--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -105,6 +105,14 @@ export function formatVaultTimestamp(value, { locales, timeZone } = {}) {
   }).format(date);
 }
 
+export function formatVaultSynchronizationSummary(revision, at = new Date().toISOString(), options = {}) {
+  const normalizedRevision = Number(revision);
+  if (!Number.isSafeInteger(normalizedRevision) || normalizedRevision < 0) {
+    return "Последняя синхронизация: —";
+  }
+  return `Последняя синхронизация: ${formatVaultTimestamp(at, options)} · r${normalizedRevision}.`;
+}
+
 export function sortLocalVaultRecords(records, mode = "modified-desc") {
   const values = [...records];
   const title = (record) => String(record?.data?.title ?? "");
@@ -149,6 +157,10 @@ export function personalHostEditorValues(record) {
     tags: Array.isArray(profile?.tags ?? data.tags) ? (profile?.tags ?? data.tags).join(", ") : "",
     description: String(profile?.profileDescription ?? data.description ?? ""),
   };
+}
+
+export function personalHostFolderName(record) {
+  return personalHostEditorValues(record).folder.trim() || "Без папки";
 }
 
 export function personalHostRecordData({ title, address, protocol, port, username, folder, tags, description, baseData = null }) {
@@ -475,7 +487,7 @@ export async function initializeLocalVault({
     for (const [recordType, count] of Object.entries(counts)) {
       setText(documentValue.querySelector(`#workspace-${recordType}-count`), String(count));
     }
-    const hostFolderName = (record) => String(record?.data?.folder ?? "").trim() || "Без папки";
+    const hostFolderName = personalHostFolderName;
     const selectedFolder = String(folderFilter?.value ?? "all");
     const folders = [...new Set(current.records.filter((record) => record.type === "host").map(hostFolderName))]
       .sort((a, b) => a.localeCompare(b));
@@ -497,7 +509,9 @@ export async function initializeLocalVault({
     const visibleRecords = sortLocalVaultRecords(filteredRecords.filter((record) => {
       if (!query) return true;
       const data = record.data ?? {};
+      const host = record.type === "host" ? personalHostEditorValues(record) : null;
       const searchable = [data.title, data.address, data.username, data.destination, data.folder,
+        host?.title, host?.address, host?.username, host?.folder, host?.tags,
         ...(Array.isArray(data.tags) ? data.tags : [])];
       return searchable.some((value) => String(value ?? "").toLocaleLowerCase().includes(query));
     }), sort?.value);
@@ -532,7 +546,7 @@ export async function initializeLocalVault({
       const remove = documentValue.createElement("button");
       heading.textContent = String(record.data.title ?? "Без названия");
       summary.textContent = localVaultRecordSummary(record);
-      metadata.textContent = `${record.type} · ${formatVaultTimestamp(record.modifiedAt)}`;
+      metadata.textContent = `${record.type} · Изменено: ${formatVaultTimestamp(record.modifiedAt)}`;
       actions.className = "record-actions";
       edit.type = "button";
       edit.className = "secondary record-edit";
@@ -572,9 +586,9 @@ export async function initializeLocalVault({
           setText(hostDetailPort, connection.protocol === "serial" ? "—" : String(connection.port));
           setText(hostDetailUsername, connection.username || "—");
           setText(hostDetailPasswordState, "Управляется приложением");
-          setText(hostDetailFolder, String(record.data?.folder ?? "Личный Vault"));
-          setText(hostDetailTags, Array.isArray(record.data?.tags) && record.data.tags.length ? record.data.tags.join(", ") : "—");
-          setText(hostDetailDescription, String(record.data?.description ?? "—"));
+          setText(hostDetailFolder, connection.folder || "Без папки");
+          setText(hostDetailTags, connection.tags || "—");
+          setText(hostDetailDescription, connection.description || "—");
           hostDetailEdit.hidden = false;
           hostDetailEdit.onclick = () => { hostDetail.close?.(); beginEdit(record); };
           hostDetailCopyPassword.hidden = true;
@@ -2178,7 +2192,7 @@ export async function initializeCloudAccount({
       if (result.status !== "remote_changed") hideConflicts();
       vaultUI.render();
       if (Number.isSafeInteger(result.revision)) {
-        setText(vaultMessage, `Personal Vault синхронизирован · r${result.revision}.`);
+        setText(vaultMessage, formatVaultSynchronizationSummary(result.revision));
       }
     } catch {
       setText(vaultMessage, "Автосинхронизация временно недоступна; локальные данные сохранены, повторим автоматически.");
@@ -2596,7 +2610,10 @@ export async function initializeCloudAccount({
       const automaticSuffix = result.automaticallyResolved
         ? ` Автоматически разрешено конфликтов: ${result.automaticallyResolved}.`
         : "";
-      setText(vaultMessage, `${messages[result.status] ?? "Синхронизация завершена."}${automaticSuffix}`);
+      const synchronizedAt = Number.isSafeInteger(result.revision)
+        ? ` ${formatVaultSynchronizationSummary(result.revision)}`
+        : "";
+      setText(vaultMessage, `${messages[result.status] ?? "Синхронизация завершена."}${automaticSuffix}${synchronizedAt}`);
     } catch (error) {
       const code = String(error?.message ?? "");
       if (code === "local_vault_locked") setText(vaultMessage, "Сначала разблокируйте локальный Vault.");

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Защищённая синхронизация Selective Remote">
   <title>Selective Remote Cloud</title>
-  <link rel="stylesheet" href="/styles.css?v=124">
+  <link rel="stylesheet" href="/styles.css?v=125">
 </head>
 <body>
   <main class="shell">
@@ -631,6 +631,6 @@
       <p>Регистрация доступна только во время контролируемого окна. Вход, подтверждение почты и восстановление пароля остаются доступны для существующего аккаунта.</p>
     </section>
   </main>
-  <script type="module" src="/app.js?v=124"></script>
+  <script type="module" src="/app.js?v=125"></script>
 </body>
 </html>

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 import {
   accountVaultPassphrase,
+  formatVaultSynchronizationSummary,
   formatVaultTimestamp,
   initializeAppearance,
   localVaultConflictSideSummary,
@@ -11,6 +12,7 @@ import {
   localVaultRecordSummary,
   parseTeamHostConnection,
   personalHostEditorValues,
+  personalHostFolderName,
   personalHostRecordData,
   sortLocalVaultRecords,
   teamHostConnectionData,
@@ -123,6 +125,8 @@ test("Personal Host editor updates organization and the embedded native profile 
   assert.equal(decoded.sshPort, 2222);
   assert.equal(decoded.group, "Work/Production");
   assert.equal(decoded.sshProxyMode, "none");
+  assert.equal(personalHostFolderName({ type: "host", data: baseData }), "Old");
+  assert.equal(personalHostFolderName({ type: "host", data: { title: "Ungrouped" } }), "Без папки");
 });
 
 test("Vault timestamps render in the viewer time zone instead of raw UTC", () => {
@@ -131,6 +135,10 @@ test("Vault timestamps render in the viewer time zone instead of raw UTC", () =>
   });
   assert.match(rendered, /15:58:29/u);
   assert.equal(formatVaultTimestamp("invalid", { locales: "ru-RU" }), "—");
+  assert.match(formatVaultSynchronizationSummary(23, "2026-09-11T15:17:30.000Z", {
+    locales: "ru-RU", timeZone: "Europe/Moscow",
+  }), /Последняя синхронизация:.*18:17:30.*r23/u);
+  assert.equal(formatVaultSynchronizationSummary(-1), "Последняя синхронизация: —");
 });
 
 test("Personal Vault catalog sorting is deterministic and does not mutate the document", () => {
@@ -246,8 +254,8 @@ test("portal exposes separate public, authentication and workspace states", asyn
   ]);
 
   assert.match(html, /id="cloud-account"[^>]*hidden/u);
-  assert.match(html, /\/styles\.css\?v=124/u);
-  assert.match(html, /\/app\.js\?v=124/u);
+  assert.match(html, /\/styles\.css\?v=125/u);
+  assert.match(html, /\/app\.js\?v=125/u);
   assert.match(html, /id="cloud-workspace"[^>]*hidden/u);
   assert.match(html, /data-open-auth="login"/u);
   assert.match(html, /data-open-auth="registration"/u);
@@ -397,6 +405,9 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(application, /setFilterChangeListener/u);
   assert.match(application, /renderOverviewSummary/u);
   assert.match(application, /formatVaultTimestamp\(record\.modifiedAt\)/u);
+  assert.match(application, /Изменено: \$\{formatVaultTimestamp\(record\.modifiedAt\)\}/u);
+  assert.match(application, /formatVaultSynchronizationSummary\(result\.revision\)/u);
+  assert.match(application, /const hostFolderName = personalHostFolderName/u);
   assert.match(application, /localVaultRecordFormValues\(record\)/u);
   assert.match(application, /editingRecordID/u);
   assert.match(application, /closeEditor\(\)/u);


### PR DESCRIPTION
## Summary

- group and filter Personal Hosts using the decoded native `profile.group` bridge instead of only the optional outer `data.folder`
- include native profile folder, title, address, username, and tags in Personal Vault search
- show decoded folder, tags, and description in Host details
- label record timestamps as `Изменено`
- show the last successful browser synchronization time separately from its Vault revision
- bump web assets to v125

## Compatibility

- no database migration
- no API or encrypted Vault schema change
- existing native profiles remain byte-compatible and are not rewritten by display

## Verification

- full Cloud suite: 302 passed, 1 PostgreSQL integration test skipped without TEST_DATABASE_URL
- focused Vault/UI suite: 36 passed
- node --check and git diff --check passed
- GitHub tree matches local tree `1608ef4333a3c676bef4439c4c9d876e8cec8381`