### PR TITLE
Improve Team Vault management and preserve folder state

### DIFF
--- a/Sources/SelectiveRemote/CloudAPIClient.swift
+++ b/Sources/SelectiveRemote/CloudAPIClient.swift
@@ -718,6 +718,34 @@ actor SelectiveRemoteCloudAPIClient {
         return result.vault
     }
 
+    func renameSharedVault(
+        endpoint: URL,
+        teamID: UUID,
+        vaultID: UUID,
+        name: String
+    ) async throws -> SelectiveRemoteCloudSharedVault {
+        let normalizedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard teamID.isSelectiveRemoteCloudUUID,
+              vaultID.isSelectiveRemoteCloudUUID,
+              !normalizedName.isEmpty,
+              normalizedName.count <= 120
+        else { throw SelectiveRemoteCloudError.invalidRequest }
+        let (data, http) = try await authorizedResponse(
+            endpoint: endpoint,
+            path: "v1/teams/\(teamID.canonicalCloudString)/vaults/\(vaultID.canonicalCloudString)",
+            method: "PATCH",
+            body: try encoder.encode(TeamNameRequest(name: normalizedName)),
+            headers: ["Idempotency-Key": Self.idempotencyKey("vault-rename")]
+        )
+        guard http.statusCode == 200 else { throw serviceError(status: http.statusCode, data: data) }
+        guard Self.validSingleSharedVaultJSON(data),
+              let result = try? decoder.decode(SharedVaultResponse.self, from: data),
+              Self.validSharedVault(result.vault, teamID: teamID),
+              result.vault.id == vaultID
+        else { throw SelectiveRemoteCloudError.invalidResponse }
+        return result.vault
+    }
+
     func teamKeyDevices(
         endpoint: URL,
         teamID: UUID,

--- a/Sources/SelectiveRemote/CloudTeamHosts.swift
+++ b/Sources/SelectiveRemote/CloudTeamHosts.swift
@@ -555,8 +555,16 @@ struct SelectiveRemoteTeamHostsView: View {
     @State private var mutationMessage: SelectiveRemoteTeamHostMutationMessage?
     @State private var searchText = ""
     @State private var selectedFolder = ""
-    @State private var expandedTeamIDs: Set<UUID> = []
-    @State private var expandedFolderKeys: Set<String> = []
+    @State private var expandedTeamIDs = Set(
+        (UserDefaults.standard.stringArray(
+            forKey: "SelectiveRemote.team-host.expanded-teams.v1"
+        ) ?? []).compactMap { UUID(uuidString: $0) }
+    )
+    @State private var expandedFolderKeys = Set(
+        UserDefaults.standard.stringArray(
+            forKey: "SelectiveRemote.team-host.expanded-folders.v1"
+        ) ?? []
+    )
     @AppStorage("SelectiveRemote.cloud.endpoint.v1") private var endpoint = SelectiveRemoteCloudEndpoint.production
     @AppStorage("SelectiveRemote.cloud.device-id.v1") private var storedDeviceID = ""
 
@@ -639,7 +647,11 @@ struct SelectiveRemoteTeamHostsView: View {
                             DisclosureGroup(
                                 isExpanded: expansionBinding(for: teamID)
                             ) {
-                                OutlineGroup(outlineItems(in: teamID), children: \.children) { item in
+                                SelectiveRemotePersistentOutlineRows(
+                                    items: outlineItems(in: teamID),
+                                    children: \.children,
+                                    expandedIDs: $expandedFolderKeys
+                                ) { item in
                                     switch item.kind {
                                     case let .folder(path, name):
                                         Label(name, systemImage: path.isEmpty ? "tray" : "folder")
@@ -757,11 +769,23 @@ struct SelectiveRemoteTeamHostsView: View {
         }
         .onAppear {
             normalizeSelection()
-            expandNewHierarchy()
+            restoreOrInitializeExpansion()
         }
-        .onChange(of: store.hosts.map(\.id)) { _, _ in
+        .onChange(of: store.hosts.map { "\($0.id.uuidString):\($0.profile.group)" }) { _, _ in
             normalizeSelection()
-            expandNewHierarchy()
+            sanitizeExpansion()
+        }
+        .onChange(of: expandedTeamIDs) { _, value in
+            UserDefaults.standard.set(
+                value.map(\.canonicalCloudString).sorted(),
+                forKey: "SelectiveRemote.team-host.expanded-teams.v1"
+            )
+        }
+        .onChange(of: expandedFolderKeys) { _, value in
+            UserDefaults.standard.set(
+                value.sorted(),
+                forKey: "SelectiveRemote.team-host.expanded-folders.v1"
+            )
         }
         .onChange(of: selectedHostID) { _, _ in resetConnectionFields() }
         .sheet(item: $editorRequest) { request in
@@ -1187,23 +1211,34 @@ struct SelectiveRemoteTeamHostsView: View {
         )
     }
 
-    private func folderExpansionBinding(teamID: UUID, folder: String) -> Binding<Bool> {
-        let key = "\(teamID.uuidString.lowercased())/\(folder)"
-        return Binding(
-            get: { expandedFolderKeys.contains(key) },
-            set: { expanded in
-                if expanded { expandedFolderKeys.insert(key) }
-                else { expandedFolderKeys.remove(key) }
-            }
-        )
+    private func restoreOrInitializeExpansion() {
+        let defaults = UserDefaults.standard
+        let teamKey = "SelectiveRemote.team-host.expanded-teams.v1"
+        let folderKey = "SelectiveRemote.team-host.expanded-folders.v1"
+        if defaults.object(forKey: teamKey) == nil {
+            expandedTeamIDs = Set(store.hosts.map(\.teamID))
+        }
+        if defaults.object(forKey: folderKey) == nil {
+            expandedFolderKeys = Set(teamIDs.flatMap { teamID in
+                teamFolderIDs(outlineItems(in: teamID))
+            })
+        }
+        sanitizeExpansion()
     }
 
-    private func expandNewHierarchy() {
-        for host in store.hosts {
-            expandedTeamIDs.insert(host.teamID)
-            expandedFolderKeys.insert(
-                "\(host.teamID.uuidString.lowercased())/\(host.profile.group)"
-            )
+    private func sanitizeExpansion() {
+        let validTeams = Set(store.hosts.map(\.teamID))
+        expandedTeamIDs.formIntersection(validTeams)
+        let validFolders = Set(teamIDs.flatMap { teamID in
+            teamFolderIDs(outlineItems(in: teamID))
+        })
+        expandedFolderKeys.formIntersection(validFolders)
+    }
+
+    private func teamFolderIDs(_ items: [SelectiveRemoteTeamHostOutlineItem]) -> [String] {
+        items.flatMap { item in
+            guard let children = item.children else { return [] }
+            return [item.id] + teamFolderIDs(children)
         }
     }
 

--- a/Sources/SelectiveRemote/CloudTeamHosts.swift
+++ b/Sources/SelectiveRemote/CloudTeamHosts.swift
@@ -1150,7 +1150,7 @@ struct SelectiveRemoteTeamHostsView: View {
         let scopedHosts = store.hosts.filter {
             $0.teamID == host.teamID && $0.vaultID == host.vaultID
         }
-        var grouped = Dictionary(grouping: scopedHosts) { candidate in
+        let grouped = Dictionary(grouping: scopedHosts) { candidate in
             candidate.id == host.id
                 ? folder
                 : SelectiveRemoteHostFolderPath.normalize(candidate.profile.group)
@@ -1236,7 +1236,7 @@ struct SelectiveRemoteTeamHostsView: View {
     }
 
     private func teamFolderIDs(_ items: [SelectiveRemoteTeamHostOutlineItem]) -> [String] {
-        items.flatMap { item in
+        items.flatMap { item -> [String] in
             guard let children = item.children else { return [] }
             return [item.id] + teamFolderIDs(children)
         }

--- a/Sources/SelectiveRemote/CloudTeamManagementView.swift
+++ b/Sources/SelectiveRemote/CloudTeamManagementView.swift
@@ -22,6 +22,10 @@ struct SelectiveRemoteCloudTeamManagementView: View {
     @State private var isBusy = false
     @State private var statusMessage: String?
     @State private var errorMessage: String?
+    @State private var synchronizingVaultID: UUID?
+    @State private var renamingVaultID: UUID?
+    @State private var vaultNameDraft = ""
+    @AppStorage("SelectiveRemote.cloud.device-id.v1") private var storedDeviceID = ""
 
     var body: some View {
         NavigationSplitView {
@@ -90,6 +94,8 @@ struct SelectiveRemoteCloudTeamManagementView: View {
         .task { await loadTeams() }
         .onChange(of: selectedTeamID) { _, _ in
             latestInvitationURL = nil
+            renamingVaultID = nil
+            vaultNameDraft = ""
             if selectedTeam?.role != .owner, invitationRole == .admin {
                 invitationRole = .viewer
             }
@@ -319,11 +325,59 @@ struct SelectiveRemoteCloudTeamManagementView: View {
             Section("Team Vaults") {
                 ForEach(vaults) { vault in
                     HStack {
-                        Label(vault.name, systemImage: "lock.square.stack.fill")
+                        if renamingVaultID == vault.id {
+                            TextField(
+                                UpdateLocalization.text(ru: "Название Vault", en: "Vault Name"),
+                                text: $vaultNameDraft
+                            )
+                            .textFieldStyle(.roundedBorder)
+                        } else {
+                            Label(vault.name, systemImage: "lock.square.stack.fill")
+                        }
                         Spacer()
                         Text("r\(vault.revision) · k\(vault.keyGeneration)")
                             .font(.caption.monospacedDigit())
                             .foregroundStyle(.secondary)
+                        Button(UpdateLocalization.text(ru: "Открыть хосты", en: "Open Hosts")) {
+                            NotificationCenter.default.post(
+                                name: .selectiveRemoteOpenTeamHosts,
+                                object: nil
+                            )
+                            dismiss()
+                        }
+                        .buttonStyle(.bordered)
+                        Button(
+                            UpdateLocalization.text(ru: "Синхронизировать", en: "Synchronize"),
+                            systemImage: "arrow.triangle.2.circlepath"
+                        ) {
+                            synchronizeVault(vault)
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(isBusy || synchronizingVaultID != nil)
+                        if team.role == .owner || team.role == .admin {
+                            if renamingVaultID == vault.id {
+                                Button(UpdateLocalization.text(ru: "Сохранить", en: "Save")) {
+                                    renameVault(vault, team: team)
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .disabled(normalized(vaultNameDraft).isEmpty || isBusy)
+                                Button(UpdateLocalization.text(ru: "Отмена", en: "Cancel")) {
+                                    renamingVaultID = nil
+                                    vaultNameDraft = ""
+                                }
+                                .buttonStyle(.bordered)
+                            } else {
+                                Button(
+                                    UpdateLocalization.text(ru: "Переименовать", en: "Rename"),
+                                    systemImage: "pencil"
+                                ) {
+                                    renamingVaultID = vault.id
+                                    vaultNameDraft = vault.name
+                                }
+                                .buttonStyle(.bordered)
+                                .disabled(isBusy)
+                            }
+                        }
                     }
                 }
             }
@@ -562,6 +616,79 @@ struct SelectiveRemoteCloudTeamManagementView: View {
                 _ = try await client.createSharedVault(endpoint: endpoint, teamID: team.id, name: name)
                 newVaultName = ""
                 statusMessage = UpdateLocalization.text(ru: "Shared Vault создан.", en: "Shared Vault created.")
+                onInventoryChanged()
+                await loadSelectedTeam()
+            } catch {
+                errorMessage = error.localizedDescription
+                isBusy = false
+            }
+        }
+    }
+
+    private func synchronizeVault(_ vault: SelectiveRemoteCloudSharedVault) {
+        guard let deviceID = UUID(uuidString: storedDeviceID),
+              deviceID.isSelectiveRemoteCloudUUID
+        else {
+            errorMessage = UpdateLocalization.text(
+                ru: "Сначала войдите в Cloud на этом Mac и зарегистрируйте устройство.",
+                en: "Sign in to Cloud on this Mac and register the device first."
+            )
+            return
+        }
+        Task { @MainActor in
+            isBusy = true
+            synchronizingVaultID = vault.id
+            errorMessage = nil
+            defer {
+                synchronizingVaultID = nil
+                isBusy = false
+            }
+            do {
+                let report = try await SelectiveRemoteTeamVaultAutoSync.shared.synchronizeOnce(
+                    endpoint: endpoint,
+                    deviceID: deviceID
+                )
+                if report.failures > 0 || report.pendingWrappers > 0 || report.rotations > 0 {
+                    let detail = report.lastFailure.map { " \($0)" } ?? ""
+                    errorMessage = UpdateLocalization.text(
+                        ru: "Синхронизация завершена не полностью: ошибок \(report.failures), ожидают wrapper \(report.pendingWrappers), требуют ротации \(report.rotations).",
+                        en: "Synchronization was incomplete: \(report.failures) failures, \(report.pendingWrappers) pending wrappers, \(report.rotations) rotations required."
+                    ) + detail
+                } else {
+                    statusMessage = UpdateLocalization.text(
+                        ru: "Team Vaults синхронизированы: получено \(report.synchronizedVaults), отправлено \(report.uploadedVaults), выдано wrappers \(report.wrappersGranted).",
+                        en: "Team Vaults synchronized: \(report.synchronizedVaults) received, \(report.uploadedVaults) uploaded, \(report.wrappersGranted) wrappers granted."
+                    )
+                }
+                await loadSelectedTeam()
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func renameVault(
+        _ vault: SelectiveRemoteCloudSharedVault,
+        team: SelectiveRemoteCloudTeam
+    ) {
+        let name = normalized(vaultNameDraft)
+        guard !name.isEmpty else { return }
+        Task { @MainActor in
+            isBusy = true
+            errorMessage = nil
+            do {
+                _ = try await client.renameSharedVault(
+                    endpoint: endpoint,
+                    teamID: team.id,
+                    vaultID: vault.id,
+                    name: name
+                )
+                renamingVaultID = nil
+                vaultNameDraft = ""
+                statusMessage = UpdateLocalization.text(
+                    ru: "Team Vault переименован.",
+                    en: "The Team Vault was renamed."
+                )
                 onInventoryChanged()
                 await loadSelectedTeam()
             } catch {

--- a/Sources/SelectiveRemote/CloudTeamVaultAutoSync.swift
+++ b/Sources/SelectiveRemote/CloudTeamVaultAutoSync.swift
@@ -18,6 +18,7 @@ struct SelectiveRemoteTeamVaultAutoSyncReport: Equatable, Sendable {
     var wrappersGranted = 0
     var rotations = 0
     var failures = 0
+    var lastFailure: String?
 }
 
 typealias SelectiveRemoteTeamVaultSnapshotStoreFactory =
@@ -27,12 +28,18 @@ typealias SelectiveRemoteTeamVaultMaterializedSnapshotConsumer =
     @Sendable ([SelectiveRemoteTeamVaultMaterializedSnapshot]) async -> Void
 
 actor SelectiveRemoteTeamVaultAutoSync {
+    static let shared = SelectiveRemoteTeamVaultAutoSync()
+
     private let remote: any SelectiveRemoteTeamVaultAutoSyncRemote
     private let identityManager: SelectiveRemoteTeamDeviceIdentityManager
     private let snapshotStore: SelectiveRemoteTeamVaultSnapshotStoreFactory
     private let snapshotConsumer: SelectiveRemoteTeamVaultMaterializedSnapshotConsumer
     private let pollInterval: Duration
     private var cycle: Task<Void, Never>?
+    private var activeSynchronization: (
+        token: UUID,
+        task: Task<SelectiveRemoteTeamVaultAutoSyncReport, Error>
+    )?
 
     init(
         remote: any SelectiveRemoteTeamVaultAutoSyncRemote = SelectiveRemoteCloudAPIClient(),
@@ -69,6 +76,28 @@ actor SelectiveRemoteTeamVaultAutoSync {
         endpoint: URL,
         deviceID: UUID
     ) async throws -> SelectiveRemoteTeamVaultAutoSyncReport {
+        if let activeSynchronization {
+            return try await activeSynchronization.task.value
+        }
+        let token = UUID()
+        let task = Task { [self] in
+            try await performSynchronization(endpoint: endpoint, deviceID: deviceID)
+        }
+        activeSynchronization = (token, task)
+        do {
+            let report = try await task.value
+            if activeSynchronization?.token == token { activeSynchronization = nil }
+            return report
+        } catch {
+            if activeSynchronization?.token == token { activeSynchronization = nil }
+            throw error
+        }
+    }
+
+    private func performSynchronization(
+        endpoint: URL,
+        deviceID: UUID
+    ) async throws -> SelectiveRemoteTeamVaultAutoSyncReport {
         let endpoint = try SelectiveRemoteCloudEndpoint.normalized(endpoint.absoluteString)
         guard deviceID.isSelectiveRemoteCloudUUID else {
             throw SelectiveRemoteCloudError.invalidRequest
@@ -91,6 +120,7 @@ actor SelectiveRemoteTeamVaultAutoSync {
                 throw CancellationError()
             } catch {
                 report.failures += 1
+                report.lastFailure = error.localizedDescription
                 continue
             }
 
@@ -190,12 +220,21 @@ actor SelectiveRemoteTeamVaultAutoSync {
                     report.rotations += 1
                 } catch {
                     report.failures += 1
+                    report.lastFailure = error.localizedDescription
                 }
             }
         }
         try Task.checkCancellation()
         await snapshotConsumer(materialized)
         return report
+    }
+
+    func synchronizeConfiguredAccountNow() async throws -> SelectiveRemoteTeamVaultAutoSyncReport {
+        guard let account = configuredAccount() else {
+            await snapshotConsumer([])
+            throw SelectiveRemoteCloudError.invalidRequest
+        }
+        return try await synchronizeOnce(endpoint: account.endpoint, deviceID: account.deviceID)
     }
 
     private static func materializedSnapshot(

--- a/Sources/SelectiveRemote/ContentView.swift
+++ b/Sources/SelectiveRemote/ContentView.swift
@@ -122,6 +122,16 @@ struct ContentView: View {
     @State private var showsPersonalFolderCreator = false
     @State private var newPersonalFolderName = ""
     @State private var newPersonalFolderParent = ""
+    @State private var showsCloudManagement = false
+    @State private var expandedPersonalFolderIDs = Set(
+        UserDefaults.standard.stringArray(
+            forKey: "SelectiveRemote.personal-host.expanded-folders.v1"
+        ) ?? []
+    )
+    @AppStorage("SelectiveRemote.cloud.endpoint.v1")
+    private var cloudEndpoint = SelectiveRemoteCloudEndpoint.production
+
+    private let cloudClient = SelectiveRemoteCloudAPIClient()
 
     private var profile: ConnectionProfile { model.selectedProfile }
     private var profileBinding: Binding<ConnectionProfile> {
@@ -311,6 +321,24 @@ struct ContentView: View {
         .onReceive(NotificationCenter.default.publisher(for: .selectiveRemoteNewLocalTerminal)) { _ in
             openNewLocalTerminalTab()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .selectiveRemoteOpenTeamHosts)) { _ in
+            showsCloudManagement = false
+            setMainArea(.teamHosts)
+        }
+        .sheet(isPresented: $showsCloudManagement) {
+            if let endpoint = try? SelectiveRemoteCloudEndpoint.normalized(cloudEndpoint) {
+                SelectiveRemoteCloudTeamManagementView(
+                    endpoint: endpoint,
+                    client: cloudClient,
+                    onInventoryChanged: {
+                        NotificationCenter.default.post(
+                            name: .selectiveRemoteTeamVaultSyncNow,
+                            object: nil
+                        )
+                    }
+                )
+            }
+        }
     }
 
     private var sidebar: some View {
@@ -473,6 +501,28 @@ struct ContentView: View {
             .padding(.bottom, 10)
 
             VStack(spacing: 5) {
+                Button {
+                    showsCloudManagement = true
+                } label: {
+                    HStack(spacing: 10) {
+                        Image(systemName: "cloud")
+                            .frame(width: 22)
+                        Text(UpdateLocalization.text(
+                            ru: "Управление Cloud",
+                            en: "Cloud Management"
+                        ))
+                        Spacer()
+                    }
+                    .padding(.horizontal, 11)
+                    .frame(height: 34)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help(UpdateLocalization.text(
+                    ru: "Аккаунт, команды и Team Vaults",
+                    en: "Account, Teams, and Team Vaults"
+                ))
+
                 ForEach(MainArea.allCases) { area in
                     Button {
                         setMainArea(area)
@@ -685,7 +735,11 @@ struct ContentView: View {
                 get: { model.selectedProfileID },
                 set: { if let id = $0 { openProfile(id) } }
             )) {
-                OutlineGroup(model.profileOutlineItems, children: \.children) { outline in
+                SelectiveRemotePersistentOutlineRows(
+                    items: model.profileOutlineItems,
+                    children: \.children,
+                    expandedIDs: $expandedPersonalFolderIDs
+                ) { outline in
                     switch outline.kind {
                     case let .folder(path, name):
                         Label(name, systemImage: path.isEmpty ? "tray" : "folder")
@@ -716,6 +770,16 @@ struct ContentView: View {
             }
             .listStyle(.sidebar)
             .scrollContentBackground(.hidden)
+            .onAppear { restoreOrInitializePersonalFolderExpansion() }
+            .onChange(of: expandedPersonalFolderIDs) { _, value in
+                UserDefaults.standard.set(
+                    value.sorted(),
+                    forKey: "SelectiveRemote.personal-host.expanded-folders.v1"
+                )
+            }
+            .onChange(of: model.profiles.map { "\($0.id.uuidString):\($0.group)" }) { _, _ in
+                sanitizePersonalFolderExpansion()
+            }
         } else {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 14) {
@@ -2794,6 +2858,30 @@ struct ContentView: View {
             setTerminalFocusMode(false)
         }
         mainArea = area
+    }
+
+    private func restoreOrInitializePersonalFolderExpansion() {
+        let defaults = UserDefaults.standard
+        let key = "SelectiveRemote.personal-host.expanded-folders.v1"
+        guard defaults.object(forKey: key) == nil else {
+            sanitizePersonalFolderExpansion()
+            return
+        }
+        expandedPersonalFolderIDs = Set(personalFolderIDs(model.profileOutlineItems))
+    }
+
+    private func sanitizePersonalFolderExpansion() {
+        let valid = Set(personalFolderIDs(model.profileOutlineItems))
+        expandedPersonalFolderIDs.formIntersection(valid)
+    }
+
+    private func personalFolderIDs(
+        _ items: [SelectiveRemoteProfileOutlineItem]
+    ) -> [String] {
+        items.flatMap { item in
+            guard let children = item.children else { return [] }
+            return [item.id] + personalFolderIDs(children)
+        }
     }
 
     private func setTerminalFocusMode(_ enabled: Bool) {

--- a/Sources/SelectiveRemote/ContentView.swift
+++ b/Sources/SelectiveRemote/ContentView.swift
@@ -2878,7 +2878,7 @@ struct ContentView: View {
     private func personalFolderIDs(
         _ items: [SelectiveRemoteProfileOutlineItem]
     ) -> [String] {
-        items.flatMap { item in
+        items.flatMap { item -> [String] in
             guard let children = item.children else { return [] }
             return [item.id] + personalFolderIDs(children)
         }

--- a/Sources/SelectiveRemote/PersistentOutlineRows.swift
+++ b/Sources/SelectiveRemote/PersistentOutlineRows.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// A small `OutlineGroup` replacement whose disclosure state is controlled by
+/// the caller. SwiftUI's built-in outline owns that state internally, so it is
+/// lost whenever the application process exits.
+struct SelectiveRemotePersistentOutlineRows<Item, Row>: View
+where Item: Identifiable, Item.ID: Hashable, Row: View {
+    let items: [Item]
+    let children: KeyPath<Item, [Item]?>
+    @Binding var expandedIDs: Set<Item.ID>
+    @ViewBuilder let row: (Item) -> Row
+
+    var body: some View {
+        ForEach(items) { item in
+            if let nested = item[keyPath: children] {
+                DisclosureGroup(isExpanded: expansionBinding(for: item.id)) {
+                    SelectiveRemotePersistentOutlineRows(
+                        items: nested,
+                        children: children,
+                        expandedIDs: $expandedIDs,
+                        row: row
+                    )
+                } label: {
+                    row(item)
+                }
+            } else {
+                row(item)
+            }
+        }
+    }
+
+    private func expansionBinding(for id: Item.ID) -> Binding<Bool> {
+        Binding(
+            get: { expandedIDs.contains(id) },
+            set: { expanded in
+                if expanded { expandedIDs.insert(id) }
+                else { expandedIDs.remove(id) }
+            }
+        )
+    }
+}

--- a/Sources/SelectiveRemote/SelectiveRemoteApp.swift
+++ b/Sources/SelectiveRemote/SelectiveRemoteApp.swift
@@ -11,6 +11,12 @@ extension Notification.Name {
     static let selectiveRemoteCloudTeamMembershipChanged = Notification.Name(
         "SelectiveRemote.cloudTeamMembershipChanged"
     )
+    static let selectiveRemoteOpenTeamHosts = Notification.Name(
+        "SelectiveRemote.openTeamHosts"
+    )
+    static let selectiveRemoteTeamVaultSyncNow = Notification.Name(
+        "SelectiveRemote.teamVaultSyncNow"
+    )
 }
 
 @MainActor
@@ -137,7 +143,7 @@ struct SelectiveRemoteApp: App {
     @StateObject private var appAppearance = AppAppearanceStore.shared
     @StateObject private var appLock = AppLockStore()
     private let personalVaultAutoSync = SelectiveRemotePersonalVaultAutoSync()
-    private let teamVaultAutoSync = SelectiveRemoteTeamVaultAutoSync()
+    private let teamVaultAutoSync = SelectiveRemoteTeamVaultAutoSync.shared
 
     private var menuBarSystemImage: String {
         if appLock.isLocked { return "lock.fill" }
@@ -183,6 +189,11 @@ struct SelectiveRemoteApp: App {
                             try? await Task.sleep(for: .seconds(3))
                             await downloadPersonalVaultChanges()
                         }
+                    }
+                    .onReceive(NotificationCenter.default.publisher(
+                        for: .selectiveRemoteTeamVaultSyncNow
+                    )) { _ in
+                        Task { _ = try? await teamVaultAutoSync.synchronizeConfiguredAccountNow() }
                     }
             }
             .onChange(of: appLock.isLocked) { _, _ in

--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -881,6 +881,22 @@ export function initializeTeamWorkspace({
     grantWrappersButton.disabled = mode !== "wrappers" || !controller || selectedVault?.rotationRequired;
   }
 
+  function teamVaultSynchronizationErrorMessage(code) {
+    const messages = {
+      authentication_required: "Сессия Cloud истекла. Войдите снова.",
+      device_approval_required: "Это устройство ещё не одобрено для Team Vault.",
+      team_vault_key_unavailable: "Для этого браузера пока нет wrapper ключа. Откройте «Управление Cloud» в приложении и запустите синхронизацию Team Vault.",
+      team_vault_rotation_required: "Синхронизация заморожена до безопасной ротации ключа.",
+      remote_revision_regressed: "Cloud вернул более старую ревизию; запись остановлена для защиты данных.",
+      team_vault_generation_changed: "Поколение ключа изменилось. Повторно откройте Team Vault после синхронизации доверенного устройства.",
+      invalid_remote_revision: "Cloud не подтвердил ожидаемую следующую ревизию; локальная копия сохранена.",
+      invalid_local_team_vault: "Локальная зашифрованная копия несовместима или повреждена; серверная версия не перезаписана.",
+      team_vault_storage_failed: "Браузер не смог сохранить локальную зашифрованную копию.",
+    };
+    return messages[code]
+      ?? "Синхронизация не выполнена; локальная зашифрованная копия сохранена.";
+  }
+
   function updateTeamMessage() {
     if (!selectedTeam) return;
     if (activeView === "teams") {
@@ -1485,7 +1501,7 @@ export function initializeTeamWorkspace({
         setText(workspaceStatus, "Ожидаем, пока устройство с текущим Team Vault key автоматически выдаст wrapper этому браузеру.");
       } else {
         setRecoveryControls(teamVaultRecoveryMode({ errorCode: code || "team_vault_sync_failed" }));
-        setText(workspaceStatus, "Автоматическая синхронизация временно остановилась; локальная зашифрованная копия сохранена.");
+        setText(workspaceStatus, teamVaultSynchronizationErrorMessage(code));
       }
     }
   }
@@ -1558,7 +1574,7 @@ export function initializeTeamWorkspace({
         ? "Запись заморожена: после отзыва участника или устройства требуется полная ротация ключа."
         : code === "team_vault_key_unavailable"
           ? "Для этого устройства пока нет wrapper ключа. Ожидаем автоматическую выдачу от любого активного участника с текущим ключом."
-          : "Shared Vault не открыт; локальные данные не изменены. Доступно безопасное повторение.");
+          : teamVaultSynchronizationErrorMessage(code));
     } finally {
       startBackgroundSync();
     }
@@ -1996,7 +2012,7 @@ export function initializeTeamWorkspace({
         ? "Синхронизация заморожена до безопасной ротации ключа."
         : code === "team_vault_key_unavailable"
           ? "Wrapper ещё недоступен. Любой активный участник с текущим ключом выдаст его автоматически."
-          : "Синхронизация не выполнена; локальная зашифрованная копия сохранена.");
+          : teamVaultSynchronizationErrorMessage(code));
     } finally {
       startBackgroundSync();
     }

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Защищённая синхронизация Selective Remote">
   <title>Selective Remote Cloud</title>
-  <link rel="stylesheet" href="/styles.css?v=125">
+  <link rel="stylesheet" href="/styles.css?v=126">
 </head>
 <body>
   <main class="shell">
@@ -631,6 +631,6 @@
       <p>Регистрация доступна только во время контролируемого окна. Вход, подтверждение почты и восстановление пароля остаются доступны для существующего аккаунта.</p>
     </section>
   </main>
-  <script type="module" src="/app.js?v=125"></script>
+  <script type="module" src="/app.js?v=126"></script>
 </body>
 </html>

--- a/cloud/src/postgres-store.mjs
+++ b/cloud/src/postgres-store.mjs
@@ -1220,6 +1220,37 @@ export class PostgresStore {
     });
   }
 
+  async renameSharedVault({ actorUserID, teamID, vaultID, name, idempotencyKey }) {
+    return this.withTeamMutation(actorUserID, "team.vault.rename", idempotencyKey, async (client) => {
+      const actor = await lockTeamActor(client, teamID, actorUserID);
+      if (!actor) throw new Error("team_not_found");
+      requireTeamPermission(actor.role, "rename_vault");
+      let vault;
+      try {
+        const result = await client.query(
+          `UPDATE shared_vaults SET name = $3, updated_at = now()
+           WHERE id = $1 AND team_id = $2 AND archived_at IS NULL
+           RETURNING id, team_id, name, revision, key_generation, rotation_required,
+             created_at, updated_at`,
+          [vaultID, teamID, name],
+        );
+        vault = result.rows[0];
+      } catch (error) {
+        if (error?.code === "23505") throw new Error("shared_vault_exists");
+        throw error;
+      }
+      if (!vault) throw new Error("team_not_found");
+      await writeTeamAudit(client, {
+        teamID,
+        actorUserID,
+        action: "team.vault_renamed",
+        targetVaultID: vaultID,
+        metadata: { name },
+      });
+      return { vault };
+    });
+  }
+
   async listTeamKeyDevices(teamID, vaultID, actorUserID, actorDeviceID) {
     const access = await this.pool.query(
       `SELECT membership.role,

--- a/cloud/src/server.mjs
+++ b/cloud/src/server.mjs
@@ -382,6 +382,18 @@ async function route(request, response) {
           () => service.getSharedVault(session, teamVaultMatch[1], teamVaultMatch[2]),
         );
       }
+      if (method === "PATCH") {
+        return handleOperation(
+          response,
+          async () => service.renameSharedVault(
+            session,
+            teamVaultMatch[1],
+            teamVaultMatch[2],
+            await readJSON(request, maxTeamBodyBytes),
+            idempotencyKey(request),
+          ),
+        );
+      }
       if (method === "PUT") {
         try {
           const result = await service.putSharedVault(

--- a/cloud/src/service.mjs
+++ b/cloud/src/service.mjs
@@ -512,6 +512,17 @@ export class CloudService {
     return { vault: publicSharedVault(result.vault) };
   }
 
+  async renameSharedVault(session, teamID, vaultID, input, idempotencyKey) {
+    const result = await this.store.renameSharedVault({
+      actorUserID: session.user_id,
+      teamID,
+      vaultID,
+      name: validateTeamName(input?.name, "invalid_shared_vault"),
+      idempotencyKey: validateIdempotencyKey(idempotencyKey),
+    });
+    return { vault: publicSharedVault(result.vault) };
+  }
+
   async approveDeviceKey(session, deviceID, input, idempotencyKey) {
     return this.store.approveDeviceKey({
       actorUserID: session.user_id,

--- a/cloud/src/team-policy.mjs
+++ b/cloud/src/team-policy.mjs
@@ -5,6 +5,7 @@ const permissions = Object.freeze({
   read: new Set(teamRoles),
   list_members: new Set(teamRoles),
   create_vault: new Set(["owner", "admin"]),
+  rename_vault: new Set(["owner", "admin"]),
   write_vault: new Set(["owner", "admin", "editor"]),
   manage_vault_keys: new Set(["owner", "admin"]),
   invite_member: new Set(["owner", "admin"]),

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -184,6 +184,9 @@ test("macOS Cloud settings expose device-bound sign-in and native Team managemen
   assert.match(teamManagement, /client\.acceptTeamInvitation/);
   assert.match(teamManagement, /client\.cancelTeamInvitation/);
   assert.match(teamManagement, /client\.createSharedVault/);
+  assert.match(teamManagement, /client\.renameSharedVault/);
+  assert.match(teamManagement, /SelectiveRemoteTeamVaultAutoSync\.shared\.synchronizeOnce/);
+  assert.match(teamManagement, /selectiveRemoteOpenTeamHosts/);
   assert.match(teamManagement, /Team Hosts/);
   assert.match(teamManagement, /@\\\(member\.username\)/);
   assert.doesNotMatch(teamManagement, /Text\(member\.email\)/);
@@ -198,6 +201,21 @@ test("macOS Cloud settings expose device-bound sign-in and native Team managemen
   assert.match(client, /deviceID/);
   assert.match(envelope, /UnifiedCredentialVault\.shared/u);
   assert.doesNotMatch(sessions + envelope, /UserDefaults/);
+});
+
+test("macOS exposes direct Cloud management and persists Personal and Team outline disclosure state", async () => {
+  const [content, hosts, rows] = await Promise.all([
+    readFile(new URL("ContentView.swift", sourceRoot), "utf8"),
+    readFile(new URL("CloudTeamHosts.swift", sourceRoot), "utf8"),
+    readFile(new URL("PersistentOutlineRows.swift", sourceRoot), "utf8"),
+  ]);
+  assert.match(content, /ru: "Управление Cloud"/u);
+  assert.match(content, /showsCloudManagement = true/u);
+  assert.match(content, /SelectiveRemote\.personal-host\.expanded-folders\.v1/u);
+  assert.match(hosts, /SelectiveRemote\.team-host\.expanded-teams\.v1/u);
+  assert.match(hosts, /SelectiveRemote\.team-host\.expanded-folders\.v1/u);
+  assert.match(rows, /DisclosureGroup\(isExpanded:/u);
+  assert.match(rows, /@Binding var expandedIDs/u);
 });
 
 test("connection checks preserve the signed-in account and inventory failures stay isolated", async () => {
@@ -369,7 +387,8 @@ test("macOS Team Hosts expose nested shared folders, tags, filtering, and drag-a
   assert.match(hosts, /safe\.profileDescription = input\.profileDescription/u);
   assert.match(hosts, /\.searchable\(/u);
   assert.match(hosts, /selectedFolder/u);
-  assert.match(hosts, /OutlineGroup\(outlineItems\(in: teamID\)/u);
+  assert.match(hosts, /SelectiveRemotePersistentOutlineRows\([\s\S]*outlineItems\(in: teamID\)/u);
+  assert.match(hosts, /SelectiveRemote\.team-host\.expanded-folders\.v1/u);
   assert.match(hosts, /\.draggable\("team-host:/u);
   assert.match(hosts, /moveTeamHost/u);
   assert.match(tree, /SelectiveRemoteTeamHostOutlineItem/u);
@@ -406,7 +425,7 @@ test("macOS Team Hosts nest teams and folders and expose SSH tools", async () =>
   ]);
   assert.match(hosts, /DisclosureGroup\(/u);
   assert.match(hosts, /Label\(teamName\(teamID\), systemImage: "person\.3\.fill"\)/u);
-  assert.match(hosts, /OutlineGroup\(outlineItems\(in: teamID\)/u);
+  assert.match(hosts, /SelectiveRemotePersistentOutlineRows\([\s\S]*outlineItems\(in: teamID\)/u);
   assert.match(editor, /ru: "Порт", en: "Port"/u);
   assert.match(editor, /profile\.sshPort = port/u);
   assert.match(hosts, /onOpenSFTP/u);

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -254,8 +254,8 @@ test("portal exposes separate public, authentication and workspace states", asyn
   ]);
 
   assert.match(html, /id="cloud-account"[^>]*hidden/u);
-  assert.match(html, /\/styles\.css\?v=125/u);
-  assert.match(html, /\/app\.js\?v=125/u);
+  assert.match(html, /\/styles\.css\?v=126/u);
+  assert.match(html, /\/app\.js\?v=126/u);
   assert.match(html, /id="cloud-workspace"[^>]*hidden/u);
   assert.match(html, /data-open-auth="login"/u);
   assert.match(html, /data-open-auth="registration"/u);
@@ -445,6 +445,8 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(application, /backgroundSyncIntervalMilliseconds = 15_000/u);
   assert.match(application, /documentValue\.visibilityState === "hidden"/u);
   assert.match(application, /runBackgroundTeamVaultSync/u);
+  assert.match(application, /teamVaultSynchronizationErrorMessage/u);
+  assert.match(application, /Управление Cloud/u);
   assert.match(application, /teamVaultRecoveryMode/u);
   assert.match(application, /setRecoveryControls/u);
   assert.doesNotMatch(application, /Owner\/Admin может выдать недостающие wrappers/u);

--- a/cloud/tests/team-api-surface.test.mjs
+++ b/cloud/tests/team-api-surface.test.mjs
@@ -28,6 +28,7 @@ test("Team routes are authenticated, explicitly scoped and idempotent", () => {
   assert.match(serverSource, /service\.listTeamInvitations/);
   assert.match(serverSource, /service\.listPendingTeamInvitations/);
   assert.match(serverSource, /service\.putSharedVault/);
+  assert.match(serverSource, /service\.renameSharedVault/);
   assert.match(serverSource, /service\.approveDeviceKey/);
   assert.match(serverSource, /service\.bootstrapDeviceKey/);
   assert.match(serverSource, /service\.grantSharedVaultWrapper/);

--- a/cloud/tests/team-postgres-store.test.mjs
+++ b/cloud/tests/team-postgres-store.test.mjs
@@ -155,6 +155,44 @@ test("Team rename locks the Team, requires Owner and records both names", async 
   assert.match(audit.parameters.at(-1), /Platform/);
 });
 
+test("Team Vault rename keeps ciphertext and revision untouched and requires a Vault manager", async () => {
+  const vault = {
+    id: vaultID,
+    team_id: teamID,
+    name: "Production",
+    revision: 6,
+    key_generation: 1,
+    rotation_required: false,
+    created_at: new Date(),
+    updated_at: new Date(),
+  };
+  const f = fixture((sql) => {
+    const reservation = mutationReservation(sql);
+    if (reservation) return reservation;
+    if (sql.includes("FOR UPDATE OF membership, team")) {
+      return { rows: [{ id: membershipID, user_id: actorUserID, role: "admin", epoch: 1, team_name: "Operations" }] };
+    }
+    if (sql.includes("UPDATE shared_vaults SET name")) return { rows: [vault], rowCount: 1 };
+    return { rows: [], rowCount: 0 };
+  });
+
+  const result = await f.store.renameSharedVault({
+    actorUserID,
+    teamID,
+    vaultID,
+    name: "Production",
+    idempotencyKey: "request:vault-rename-01",
+  });
+  assert.equal(result.vault.revision, 6);
+  const update = f.queries.find(({ sql }) => sql.includes("UPDATE shared_vaults SET name"));
+  assert.deepEqual(update.parameters, [vaultID, teamID, "Production"]);
+  assert.doesNotMatch(update.sql.split("RETURNING")[0], /ciphertext|key_generation|revision\s*=/u);
+  assert.match(
+    f.queries.find(({ sql }) => sql.includes("INSERT INTO team_audit_events")).parameters.at(-1),
+    /Production/u,
+  );
+});
+
 test("ownership transfer promotes the target and demotes the actor atomically", async () => {
   const targetMembershipID = "87806d7b-d3a9-4701-8262-f247bd5de1e9";
   const targetUserID = "6a812c55-aa74-4be4-bf1a-4cfcd362b459";

--- a/cloud/tests/team-service.test.mjs
+++ b/cloud/tests/team-service.test.mjs
@@ -166,6 +166,18 @@ class TeamStore {
     } };
   }
 
+  async renameSharedVault(input) {
+    this.calls.push(["renameSharedVault", input]);
+    return { vault: {
+      id: input.vaultID,
+      team_id: input.teamID,
+      name: input.name,
+      revision: 6,
+      key_generation: 1,
+      rotation_required: false,
+    } };
+  }
+
   async approveDeviceKey(input) {
     this.calls.push(["approveDeviceKey", input]);
     return { approved: true, deviceID: input.deviceID };
@@ -479,10 +491,25 @@ test("member and shared-Vault operations preserve explicit Team scope", async ()
     { name: " Production " },
     "request:vault-create-01",
   );
+  const renamed = await service.renameSharedVault(
+    session,
+    teamID,
+    created.vault.id,
+    { name: " Production Vault " },
+    "request:vault-rename-01",
+  );
 
   assert.equal(created.vault.teamID, teamID);
   assert.equal(created.vault.revision, 0);
   assert.equal(created.vault.keyGeneration, 1);
+  assert.equal(renamed.vault.name, "Production Vault");
+  assert.deepEqual(store.calls.find(([name]) => name === "renameSharedVault")[1], {
+    actorUserID: "user-1",
+    teamID,
+    vaultID: created.vault.id,
+    name: "Production Vault",
+    idempotencyKey: "request:vault-rename-01",
+  });
   for (const [, value] of store.calls) {
     if (value && typeof value === "object" && "actorUserID" in value) assert.equal(value.actorUserID, "user-1");
   }


### PR DESCRIPTION
## Что изменено

- добавлены явные действия Team Vault: открыть хосты, безопасно синхронизировать и переименовать (Owner/Admin)
- добавлен прямой вход «Управление Cloud» в боковой панели главного окна
- раскрытые личные и командные папки восстанавливаются после перезапуска приложения
- браузер показывает точную причину сбоя Team Vault sync вместо общего сообщения
- добавлен API переименования Vault без изменения ciphertext, ревизии и поколения ключа
- web assets подняты до v126

## Безопасность и совместимость

- состояние папок хранит только UI-идентификаторы и пути, без адресов, логинов и секретов
- Viewer остаётся read-only
- схема БД и миграции не меняются
- одновременные запросы Team Vault sync объединяются в одну операцию

## Проверки

- Cloud suite: 304 passed, 1 PostgreSQL integration skipped without TEST_DATABASE_URL
- focused changed tests: 88 passed
- git diff --check: passed
- нативную Swift 6 сборку и ARM64 DMG проверят GitHub Actions