### PR TITLE
Scale Team member management for large teams

### DIFF
--- a/Sources/SelectiveRemote/CloudAPIClient.swift
+++ b/Sources/SelectiveRemote/CloudAPIClient.swift
@@ -154,6 +154,12 @@ struct SelectiveRemoteCloudTeamMember: Codable, Equatable, Identifiable, Sendabl
     var joinedAt: String
 }
 
+struct SelectiveRemoteCloudTeamMemberPage: Equatable, Sendable {
+    var members: [SelectiveRemoteCloudTeamMember]
+    var nextCursor: UUID?
+    var total: Int
+}
+
 enum SelectiveRemoteCloudTeamInvitationType: String, Codable, Equatable, Sendable {
     case email
     case username
@@ -533,6 +539,44 @@ actor SelectiveRemoteCloudAPIClient {
         return result.members
     }
 
+    func teamMembersPage(
+        endpoint: URL,
+        teamID: UUID,
+        search: String = "",
+        role: SelectiveRemoteCloudTeamRole? = nil,
+        limit: Int = 50,
+        cursor: UUID? = nil
+    ) async throws -> SelectiveRemoteCloudTeamMemberPage {
+        let normalizedSearch = search.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard teamID.isSelectiveRemoteCloudUUID,
+              normalizedSearch.count <= 120,
+              (1...100).contains(limit),
+              cursor?.isSelectiveRemoteCloudUUID ?? true
+        else { throw SelectiveRemoteCloudError.invalidRequest }
+        var queryItems = [URLQueryItem(name: "limit", value: String(limit))]
+        if !normalizedSearch.isEmpty { queryItems.append(URLQueryItem(name: "search", value: normalizedSearch)) }
+        if let role { queryItems.append(URLQueryItem(name: "role", value: role.rawValue)) }
+        if let cursor { queryItems.append(URLQueryItem(name: "cursor", value: cursor.canonicalCloudString)) }
+        let data = try await authorizedData(
+            endpoint: endpoint,
+            path: "v1/teams/\(teamID.canonicalCloudString)/members",
+            queryItems: queryItems
+        )
+        guard Self.validTeamMemberPageJSON(data),
+              let result = try? decoder.decode(TeamMemberPageResponse.self, from: data),
+              result.members.count <= limit,
+              result.total >= result.members.count,
+              result.members.allSatisfy(Self.validTeamMember),
+              Set(result.members.map(\.id)).count == result.members.count,
+              result.nextCursor?.isSelectiveRemoteCloudUUID ?? true
+        else { throw SelectiveRemoteCloudError.invalidResponse }
+        return SelectiveRemoteCloudTeamMemberPage(
+            members: result.members,
+            nextCursor: result.nextCursor,
+            total: result.total
+        )
+    }
+
     func teamInvitations(
         endpoint: URL,
         teamID: UUID
@@ -902,8 +946,16 @@ actor SelectiveRemoteCloudAPIClient {
         try tokenStore.removeToken(for: endpoint)
     }
 
-    private func authorizedData(endpoint: URL, path: String) async throws -> Data {
-        let (data, http) = try await authorizedResponse(endpoint: endpoint, path: path)
+    private func authorizedData(
+        endpoint: URL,
+        path: String,
+        queryItems: [URLQueryItem] = []
+    ) async throws -> Data {
+        let (data, http) = try await authorizedResponse(
+            endpoint: endpoint,
+            path: path,
+            queryItems: queryItems
+        )
         guard (200..<300).contains(http.statusCode) else {
             throw serviceError(status: http.statusCode, data: data)
         }
@@ -915,13 +967,17 @@ actor SelectiveRemoteCloudAPIClient {
         path: String,
         method: String = "GET",
         body: Data? = nil,
-        headers: [String: String] = [:]
+        headers: [String: String] = [:],
+        queryItems: [URLQueryItem] = []
     ) async throws -> (Data, HTTPURLResponse) {
         guard let token = try storedToken(for: endpoint) else {
             throw SelectiveRemoteCloudError.authenticationRequired
         }
+        var components = URLComponents(url: endpoint.appending(path: path), resolvingAgainstBaseURL: false)
+        components?.queryItems = queryItems.isEmpty ? nil : queryItems
+        guard let requestURL = components?.url else { throw SelectiveRemoteCloudError.invalidRequest }
         var request = JSONRequest(
-            url: endpoint.appending(path: path),
+            url: requestURL,
             method: method,
             body: body
         ).value
@@ -1045,6 +1101,16 @@ actor SelectiveRemoteCloudAPIClient {
     private static func validTeamMembersJSON(_ data: Data) -> Bool {
         guard let object = try? JSONSerialization.jsonObject(with: data),
               exactKeys(object, expected: ["members"]),
+              let members = (object as? [String: Any])?["members"] as? [Any]
+        else { return false }
+        return members.allSatisfy { exactKeys($0, expected: [
+            "id", "userID", "username", "displayName", "role", "epoch", "joinedAt"
+        ]) }
+    }
+
+    private static func validTeamMemberPageJSON(_ data: Data) -> Bool {
+        guard let object = try? JSONSerialization.jsonObject(with: data),
+              exactKeys(object, expected: ["members", "nextCursor", "total"]),
               let members = (object as? [String: Any])?["members"] as? [Any]
         else { return false }
         return members.allSatisfy { exactKeys($0, expected: [
@@ -1344,6 +1410,12 @@ private struct TeamResponse: Decodable {
 
 private struct TeamMembersResponse: Decodable {
     var members: [SelectiveRemoteCloudTeamMember]
+}
+
+private struct TeamMemberPageResponse: Decodable {
+    var members: [SelectiveRemoteCloudTeamMember]
+    var nextCursor: UUID?
+    var total: Int
 }
 
 private struct TeamInvitationResponse: Decodable {

--- a/Sources/SelectiveRemote/CloudAPIClient.swift
+++ b/Sources/SelectiveRemote/CloudAPIClient.swift
@@ -562,6 +562,34 @@ actor SelectiveRemoteCloudAPIClient {
             path: "v1/teams/\(teamID.canonicalCloudString)/members",
             queryItems: queryItems
         )
+        if Self.validTeamMembersJSON(data),
+           let legacy = try? decoder.decode(TeamMembersResponse.self, from: data),
+           legacy.members.count <= 10_000,
+           legacy.members.allSatisfy(Self.validTeamMember),
+           Set(legacy.members.map(\.id)).count == legacy.members.count {
+            let searchValue = normalizedSearch.lowercased()
+            let filtered = legacy.members.filter { member in
+                (searchValue.isEmpty
+                    || member.username.lowercased().contains(searchValue)
+                    || member.displayName.lowercased().contains(searchValue))
+                    && (role == nil || member.role == role)
+            }
+            let start: Int
+            if let cursor {
+                guard let cursorIndex = filtered.firstIndex(where: { $0.id == cursor })
+                else { throw SelectiveRemoteCloudError.invalidResponse }
+                start = filtered.index(after: cursorIndex)
+            } else {
+                start = filtered.startIndex
+            }
+            let end = min(start + limit, filtered.endIndex)
+            let members = Array(filtered[start..<end])
+            return SelectiveRemoteCloudTeamMemberPage(
+                members: members,
+                nextCursor: end < filtered.endIndex ? members.last?.id : nil,
+                total: filtered.count
+            )
+        }
         guard Self.validTeamMemberPageJSON(data),
               let result = try? decoder.decode(TeamMemberPageResponse.self, from: data),
               result.members.count <= limit,

--- a/Sources/SelectiveRemote/CloudTeamManagementView.swift
+++ b/Sources/SelectiveRemote/CloudTeamManagementView.swift
@@ -10,6 +10,12 @@ struct SelectiveRemoteCloudTeamManagementView: View {
     @State private var teams: [SelectiveRemoteCloudTeam] = []
     @State private var selectedTeamID: UUID?
     @State private var members: [SelectiveRemoteCloudTeamMember] = []
+    @State private var memberSearch = ""
+    @State private var memberRoleFilter = ""
+    @State private var memberNextCursor: UUID?
+    @State private var memberTotal = 0
+    @State private var isLoadingMembers = false
+    @State private var memberRequestID = UUID()
     @State private var vaults: [SelectiveRemoteCloudSharedVault] = []
     @State private var invitations: [SelectiveRemoteCloudTeamInvitation] = []
     @State private var pendingInvitations: [SelectiveRemoteCloudTeamInvitation] = []
@@ -154,6 +160,21 @@ struct SelectiveRemoteCloudTeamManagementView: View {
                 )
                 .font(.headline)
 
+                HStack(spacing: 10) {
+                    Picker(UpdateLocalization.text(ru: "Роль", en: "Role"), selection: $memberRoleFilter) {
+                        Text(UpdateLocalization.text(ru: "Все роли", en: "All Roles")).tag("")
+                        Text(roleTitle(.owner)).tag(SelectiveRemoteCloudTeamRole.owner.rawValue)
+                        Text(roleTitle(.admin)).tag(SelectiveRemoteCloudTeamRole.admin.rawValue)
+                        Text(roleTitle(.editor)).tag(SelectiveRemoteCloudTeamRole.editor.rawValue)
+                        Text(roleTitle(.viewer)).tag(SelectiveRemoteCloudTeamRole.viewer.rawValue)
+                    }
+                    .pickerStyle(.menu)
+                    Spacer()
+                    Text("\(members.count) / \(memberTotal)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
                 List(members) { member in
                     HStack(spacing: 12) {
                         Image(systemName: "person.crop.circle.fill")
@@ -173,6 +194,25 @@ struct SelectiveRemoteCloudTeamManagementView: View {
                     .padding(.vertical, 6)
                 }
                 .listStyle(.inset)
+                .searchable(
+                    text: $memberSearch,
+                    prompt: UpdateLocalization.text(ru: "Имя или @username", en: "Name or @username")
+                )
+                .task(id: memberSearch) {
+                    try? await Task.sleep(for: .milliseconds(250))
+                    guard !Task.isCancelled else { return }
+                    await loadMembers(team, reset: true)
+                }
+                .onChange(of: memberRoleFilter) { _, _ in
+                    Task { await loadMembers(team, reset: true) }
+                }
+
+                if memberNextCursor != nil {
+                    Button(UpdateLocalization.text(ru: "Показать ещё", en: "Load More")) {
+                        Task { await loadMembers(team, reset: false) }
+                    }
+                    .disabled(isLoadingMembers)
+                }
             }
             .padding(16)
             .frame(minWidth: 360, idealWidth: 430, maxWidth: 520)
@@ -439,24 +479,41 @@ struct SelectiveRemoteCloudTeamManagementView: View {
     private func loadSelectedTeam() async {
         guard let team = selectedTeam else {
             members = []
+            memberNextCursor = nil
+            memberTotal = 0
             vaults = []
             invitations = []
             return
         }
         isBusy = true
         errorMessage = nil
+        let requestedMemberSearch = memberSearch
+        let requestedMemberRole = memberRoleFilter
+        let memberLoadID = UUID()
+        memberRequestID = memberLoadID
         do {
-            async let loadedMembers = client.teamMembers(endpoint: endpoint, teamID: team.id)
+            async let loadedMemberPage = client.teamMembersPage(
+                endpoint: endpoint,
+                teamID: team.id,
+                search: requestedMemberSearch,
+                role: SelectiveRemoteCloudTeamRole(rawValue: requestedMemberRole),
+                limit: 50
+            )
             async let loadedVaults = client.sharedVaults(endpoint: endpoint, teamID: team.id)
-            let (memberResult, vaultResult) = try await (loadedMembers, loadedVaults)
+            let (memberPage, vaultResult) = try await (loadedMemberPage, loadedVaults)
             let invitationResult: [SelectiveRemoteCloudTeamInvitation]
             if team.role == .owner || team.role == .admin {
                 invitationResult = try await client.teamInvitations(endpoint: endpoint, teamID: team.id)
             } else {
                 invitationResult = []
             }
-            members = memberResult.sorted {
-                $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+            if selectedTeamID == team.id,
+               memberRequestID == memberLoadID,
+               memberSearch == requestedMemberSearch,
+               memberRoleFilter == requestedMemberRole {
+                members = memberPage.members
+                memberNextCursor = memberPage.nextCursor
+                memberTotal = memberPage.total
             }
             vaults = vaultResult.sorted {
                 $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
@@ -466,6 +523,38 @@ struct SelectiveRemoteCloudTeamManagementView: View {
             errorMessage = error.localizedDescription
         }
         isBusy = false
+    }
+
+    @MainActor
+    private func loadMembers(_ team: SelectiveRemoteCloudTeam, reset: Bool) async {
+        guard selectedTeamID == team.id else { return }
+        let requestedSearch = memberSearch
+        let requestedRole = memberRoleFilter
+        let requestedCursor = reset ? nil : memberNextCursor
+        let requestID = UUID()
+        memberRequestID = requestID
+        isLoadingMembers = true
+        errorMessage = nil
+        do {
+            let page = try await client.teamMembersPage(
+                endpoint: endpoint,
+                teamID: team.id,
+                search: requestedSearch,
+                role: SelectiveRemoteCloudTeamRole(rawValue: requestedRole),
+                limit: 50,
+                cursor: requestedCursor
+            )
+            if selectedTeamID == team.id,
+               memberSearch == requestedSearch,
+               memberRoleFilter == requestedRole {
+                members = reset ? page.members : members + page.members
+                memberNextCursor = page.nextCursor
+                memberTotal = page.total
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        if memberRequestID == requestID { isLoadingMembers = false }
     }
 
     private func createTeam() {

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -110,6 +110,13 @@ struct CloudMacOSFoundationTests {
             case ("GET", "/v1/teams/\(teamID.canonicalCloudString)/members"):
                 if let components = URLComponents(url: try #require(request.url), resolvingAgainstBaseURL: false),
                    components.queryItems != nil {
+                    if components.queryItems?.first(where: { $0.name == "search" })?.value == "legacy" {
+                        return Self.response(request, status: 200, json: ["members": [[
+                            "id": membershipID.canonicalCloudString, "userID": userID.canonicalCloudString,
+                            "username": "owner", "displayName": "Owner", "role": "owner",
+                            "epoch": 1, "joinedAt": "2026-09-09T00:00:00.000Z"
+                        ]]])
+                    }
                     #expect(components.queryItems?.first(where: { $0.name == "search" })?.value == "owner")
                     #expect(components.queryItems?.first(where: { $0.name == "role" })?.value == "owner")
                     #expect(components.queryItems?.first(where: { $0.name == "limit" })?.value == "50")
@@ -197,6 +204,13 @@ struct CloudMacOSFoundationTests {
         #expect(memberPage.members.first?.role == .owner)
         #expect(memberPage.total == 1)
         #expect(memberPage.nextCursor == nil)
+        let legacyPage = try await client.teamMembersPage(
+            endpoint: endpoint,
+            teamID: teamID,
+            search: "legacy"
+        )
+        #expect(legacyPage.members.isEmpty)
+        #expect(legacyPage.total == 0)
         #expect(try await client.inviteTeamMember(
             endpoint: endpoint, teamID: teamID, username: " @Viewer ", role: .viewer
         ).targetUsername == "viewer")

--- a/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
+++ b/Tests/SelectiveRemoteTests/CloudMacOSFoundationTests.swift
@@ -108,6 +108,21 @@ struct CloudMacOSFoundationTests {
                     "createdAt": "2026-09-09T00:00:00.000Z", "updatedAt": "2026-09-09T00:00:00.000Z"
                 ]])
             case ("GET", "/v1/teams/\(teamID.canonicalCloudString)/members"):
+                if let components = URLComponents(url: try #require(request.url), resolvingAgainstBaseURL: false),
+                   components.queryItems != nil {
+                    #expect(components.queryItems?.first(where: { $0.name == "search" })?.value == "owner")
+                    #expect(components.queryItems?.first(where: { $0.name == "role" })?.value == "owner")
+                    #expect(components.queryItems?.first(where: { $0.name == "limit" })?.value == "50")
+                    return Self.response(request, status: 200, json: [
+                        "members": [[
+                            "id": membershipID.canonicalCloudString, "userID": userID.canonicalCloudString,
+                            "username": "owner", "displayName": "Owner", "role": "owner",
+                            "epoch": 1, "joinedAt": "2026-09-09T00:00:00.000Z"
+                        ]],
+                        "nextCursor": NSNull(),
+                        "total": 1,
+                    ])
+                }
                 return Self.response(request, status: 200, json: ["members": [[
                     "id": membershipID.canonicalCloudString, "userID": userID.canonicalCloudString,
                     "username": "owner", "displayName": "Owner", "role": "owner",
@@ -173,6 +188,15 @@ struct CloudMacOSFoundationTests {
 
         #expect(try await client.createTeam(endpoint: endpoint, name: " Platform ").name == "Platform")
         #expect(try await client.teamMembers(endpoint: endpoint, teamID: teamID).first?.role == .owner)
+        let memberPage = try await client.teamMembersPage(
+            endpoint: endpoint,
+            teamID: teamID,
+            search: "owner",
+            role: .owner
+        )
+        #expect(memberPage.members.first?.role == .owner)
+        #expect(memberPage.total == 1)
+        #expect(memberPage.nextCursor == nil)
         #expect(try await client.inviteTeamMember(
             endpoint: endpoint, teamID: teamID, username: " @Viewer ", role: .viewer
         ).targetUsername == "viewer")

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -90,7 +90,9 @@ the database stores and replays the committed response atomically.
   compatibility. Supplying any of `search`, `role`, `limit` or `cursor` enables
   the bounded directory response `{ members, nextCursor, total }`; `limit`
   defaults to 50 and is capped at 100. The opaque cursor is the last returned
-  membership UUID and must be reused with the same filters.
+  membership UUID and must be reused with the same filters. New browser/macOS
+  clients also recognize the legacy `{ members }` response and apply the same
+  bounded directory behavior locally during a staged server rollout.
 - `GET|POST /v1/teams/{teamID}/invitations` lists manageable active
   invitations or creates a rate-limited invitation by public `@username` or a
   revocable 48-hour single-use link. Admins cannot invite Admins and

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -86,7 +86,11 @@ the database stores and replays the committed response atomically.
 - `DELETE /v1/teams/{teamID}` requires rate-limited password re-authentication
   and exact current-name confirmation, then transactionally soft-archives the
   Team and Vaults while retiring pending invitations, delivery and rotations.
-- `GET /v1/teams/{teamID}/members` lists active members.
+- `GET /v1/teams/{teamID}/members` lists all active members for released-client
+  compatibility. Supplying any of `search`, `role`, `limit` or `cursor` enables
+  the bounded directory response `{ members, nextCursor, total }`; `limit`
+  defaults to 50 and is capped at 100. The opaque cursor is the last returned
+  membership UUID and must be reused with the same filters.
 - `GET|POST /v1/teams/{teamID}/invitations` lists manageable active
   invitations or creates a rate-limited invitation by public `@username` or a
   revocable 48-hour single-use link. Admins cannot invite Admins and

--- a/cloud/public/app.js
+++ b/cloud/public/app.js
@@ -763,6 +763,10 @@ export function initializeTeamWorkspace({
   const teamRole = documentValue.querySelector("#team-role");
   const members = documentValue.querySelector("#team-members");
   const membersView = documentValue.querySelector("#team-members-view");
+  const memberSearch = documentValue.querySelector("#team-member-search");
+  const memberRoleFilter = documentValue.querySelector("#team-member-role-filter");
+  const memberCount = documentValue.querySelector("#team-member-count");
+  const memberMore = documentValue.querySelector("#team-member-more");
   const inviteForm = documentValue.querySelector("#team-invite-form");
   const inviteEmailSubmit = documentValue.querySelector("#team-invite-email-submit");
   const inviteLinkCreate = documentValue.querySelector("#team-invite-link-create");
@@ -836,6 +840,11 @@ export function initializeTeamWorkspace({
   let teams = [];
   let vaults = [];
   let teamMembers = [];
+  let ownershipMembers = [];
+  let memberNextCursor = null;
+  let memberTotal = 0;
+  let memberSearchTimer = null;
+  let memberRequestGeneration = 0;
   let teamInvitations = [];
   let accountInvitations = [];
   let selectedTeam = null;
@@ -900,7 +909,7 @@ export function initializeTeamWorkspace({
   function updateTeamMessage() {
     if (!selectedTeam) return;
     if (activeView === "teams") {
-      setText(message, `Team «${selectedTeam.name}» · участников: ${teamMembers.length}.`);
+      setText(message, `Team «${selectedTeam.name}» · участников: ${memberTotal}.`);
     } else if (activeView === "members") {
       setText(message, `Команда «${selectedTeam.name}» · участники и приглашения.`);
     } else if (activeView === "management") {
@@ -1201,15 +1210,37 @@ export function initializeTeamWorkspace({
 
   function renderMembers(values) {
     members.replaceChildren();
+    memberCount.textContent = `${values.length} из ${memberTotal}`;
+    memberMore.hidden = !memberNextCursor;
+    memberMore.disabled = false;
+    if (values.length === 0) {
+      const empty = documentValue.createElement("p");
+      empty.className = "vault-empty";
+      empty.textContent = "Участники не найдены.";
+      members.append(empty);
+      return;
+    }
     for (const member of values) {
       const card = documentValue.createElement("article");
+      const avatar = documentValue.createElement("span");
+      const identityBlock = documentValue.createElement("div");
       const name = documentValue.createElement("strong");
       const detail = documentValue.createElement("small");
+      const roleBadge = documentValue.createElement("span");
+      const actions = documentValue.createElement("details");
+      const actionsLabel = documentValue.createElement("summary");
+      const actionMenu = documentValue.createElement("div");
       const role = documentValue.createElement("select");
       const save = documentValue.createElement("button");
       const revoke = documentValue.createElement("button");
+      avatar.className = "team-member-avatar";
+      avatar.textContent = (member.displayName || member.username).trim().slice(0, 1).toUpperCase();
+      identityBlock.className = "team-member-identity";
       name.textContent = member.displayName || `@${member.username}`;
       detail.textContent = `@${member.username} · epoch ${member.epoch}`;
+      identityBlock.append(name, detail);
+      roleBadge.className = "team-member-role";
+      roleBadge.textContent = member.role;
       const editableByActor = selectedTeam.role === "owner"
         || (selectedTeam.role === "admin" && ["editor", "viewer"].includes(member.role));
       const self = member.id === selectedTeam.membershipID;
@@ -1223,13 +1254,14 @@ export function initializeTeamWorkspace({
       }
       role.disabled = !editableByActor || self;
       save.type = "button";
-      save.textContent = "Изменить роль";
+      save.textContent = "Сохранить роль";
       save.disabled = !editableByActor || self;
       save.addEventListener("click", async () => {
         save.disabled = true;
         try {
           await client.updateTeamMemberRole({ teamID: selectedTeam.id, membershipID: member.id, role: role.value });
-          await loadSelectedTeam();
+          ownershipMembers = [];
+          await loadMemberPage({ reset: true });
           setText(message, "Роль участника обновлена.");
         } catch {
           setText(message, "Роль не изменена: проверьте полномочия и правило последнего Owner.");
@@ -1245,6 +1277,7 @@ export function initializeTeamWorkspace({
         revoke.disabled = true;
         try {
           const result = await client.revokeTeamMember({ teamID: selectedTeam.id, membershipID: member.id });
+          ownershipMembers = [];
           await loadSelectedTeam();
           lockCurrentVault();
           setText(message, `Доступ отозван. Vaults для обязательной ротации: ${result.rotationRequiredVaults}.`);
@@ -1253,9 +1286,19 @@ export function initializeTeamWorkspace({
           revoke.disabled = !editableByActor || self;
         }
       });
-      card.append(name, detail, role, save, revoke);
+      actions.className = "team-member-actions";
+      actionsLabel.textContent = "•••";
+      actionsLabel.setAttribute("aria-label", `Действия для @${member.username}`);
+      actionMenu.className = "team-member-action-menu";
+      actionMenu.append(role, save, revoke);
+      actions.append(actionsLabel, actionMenu);
+      actions.hidden = !editableByActor || self;
+      card.append(avatar, identityBlock, roleBadge, actions);
       members.append(card);
     }
+  }
+
+  function renderOwnershipMembers(values) {
     transferOwnershipMember.replaceChildren();
     for (const member of values.filter((value) => value.id !== selectedTeam.membershipID)) {
       const option = documentValue.createElement("option");
@@ -1264,6 +1307,30 @@ export function initializeTeamWorkspace({
       transferOwnershipMember.append(option);
     }
     transferOwnershipForm.querySelector("button").disabled = transferOwnershipMember.options.length === 0;
+  }
+
+  async function loadMemberPage({ reset = false } = {}) {
+    if (!selectedTeam) return;
+    const generation = ++memberRequestGeneration;
+    memberMore.disabled = true;
+    const page = await client.listTeamMembersPage(selectedTeam.id, {
+      search: memberSearch.value,
+      role: memberRoleFilter.value,
+      limit: 50,
+      cursor: reset ? null : memberNextCursor,
+    });
+    if (generation !== memberRequestGeneration) return;
+    teamMembers = reset ? page.members : [...teamMembers, ...page.members];
+    memberNextCursor = page.nextCursor;
+    memberTotal = page.total;
+    renderMembers(teamMembers);
+  }
+
+  async function loadOwnershipMembers() {
+    if (!selectedTeam || selectedTeam.role !== "owner" || ownershipMembers.length > 0) return;
+    transferOwnershipForm.querySelector("button").disabled = true;
+    ownershipMembers = await client.listTeamMembers(selectedTeam.id);
+    renderOwnershipMembers(ownershipMembers);
   }
 
   function invitationTarget(invitation) {
@@ -1533,6 +1600,11 @@ export function initializeTeamWorkspace({
     membersView.hidden = activeView !== "members";
     vaultDirectoryView.hidden = !["vaults", "hosts"].includes(activeView);
     lifecyclePanel.hidden = activeView !== "management" || selectedTeam?.role !== "owner";
+    if (activeView === "management" && selectedTeam?.role === "owner") {
+      void loadOwnershipMembers().catch(() => {
+        setText(message, "Не удалось загрузить список для передачи владения.");
+      });
+    }
     createVaultForm.hidden = activeView !== "vaults" || !canManage();
     workspace.hidden = activeView !== "hosts" || !controller;
     if (activeView === "hosts") recordType.value = "host";
@@ -1584,9 +1656,15 @@ export function initializeTeamWorkspace({
   }
 
   async function loadSelectedTeam() {
+    const memberGeneration = ++memberRequestGeneration;
     selectedTeam = teams.find((team) => team.id === teamSelect.value) ?? null;
     lockCurrentVault();
     if (!selectedTeam) {
+      teamMembers = [];
+      ownershipMembers = [];
+      memberNextCursor = null;
+      memberTotal = 0;
+      renderMembers(teamMembers);
       teamInvitations = [];
       renderTeamInvitations();
       selectedPanel.hidden = true;
@@ -1606,18 +1684,32 @@ export function initializeTeamWorkspace({
     renameTeamForm.elements.name.value = selectedTeam.name;
     archiveTeamForm.reset();
     transferOwnershipForm.reset();
-    const [loadedMembers, sharedVaults, loadedInvitations] = await Promise.all([
-      client.listTeamMembers(selectedTeam.id),
+    const loadedTeamID = selectedTeam.id;
+    ownershipMembers = [];
+    transferOwnershipMember.replaceChildren();
+    transferOwnershipForm.querySelector("button").disabled = true;
+    const [loadedMemberPage, sharedVaults, loadedInvitations] = await Promise.all([
+      client.listTeamMembersPage(selectedTeam.id, {
+        search: memberSearch.value,
+        role: memberRoleFilter.value,
+        limit: 50,
+      }),
       client.listSharedVaults(selectedTeam.id),
       canManage() ? client.listTeamInvitations(selectedTeam.id) : Promise.resolve([]),
     ]);
-    teamMembers = loadedMembers;
-    renderMembers(teamMembers);
+    if (selectedTeam?.id !== loadedTeamID) return;
+    if (memberGeneration === memberRequestGeneration) {
+      teamMembers = loadedMemberPage.members;
+      memberNextCursor = loadedMemberPage.nextCursor;
+      memberTotal = loadedMemberPage.total;
+      renderMembers(teamMembers);
+    }
     vaults = sharedVaults;
     teamInvitations = loadedInvitations;
     renderTeamInvitations();
     populateVaults();
     updateTeamMessage();
+    if (activeView === "management" && selectedTeam.role === "owner") await loadOwnershipMembers();
     if (activeView === "hosts" && vaults.length > 0) await openSelectedVault();
   }
 
@@ -1846,6 +1938,21 @@ export function initializeTeamWorkspace({
     loadSelectedTeam().catch(() => setText(message, "Не удалось загрузить Team."));
   });
   teamRefresh.addEventListener("click", () => loadTeams(selectedTeam?.id).catch(() => setText(message, "Не удалось обновить Teams.")));
+  memberSearch.addEventListener("input", () => {
+    clearTimeout(memberSearchTimer);
+    memberSearchTimer = setTimeout(() => {
+      loadMemberPage({ reset: true }).catch(() => setText(message, "Не удалось выполнить поиск участников."));
+    }, 250);
+  });
+  memberRoleFilter.addEventListener("change", () => {
+    loadMemberPage({ reset: true }).catch(() => setText(message, "Не удалось применить фильтр роли."));
+  });
+  memberMore.addEventListener("click", () => {
+    loadMemberPage().catch(() => {
+      memberMore.disabled = false;
+      setText(message, "Не удалось загрузить следующую страницу участников.");
+    });
+  });
   devicesRefresh.addEventListener("click", () => loadDevices().catch(() => setText(message, "Не удалось обновить устройства.")));
   vaultOpen.addEventListener("click", () => {
     if (activeView === "vaults") {
@@ -2074,6 +2181,11 @@ export function initializeTeamWorkspace({
       teams = [];
       vaults = [];
       teamMembers = [];
+      ownershipMembers = [];
+      memberNextCursor = null;
+      memberTotal = 0;
+      memberRequestGeneration += 1;
+      clearTimeout(memberSearchTimer);
       teamInvitations = [];
       accountInvitations = [];
       selectedTeam = null;

--- a/cloud/public/index.html
+++ b/cloud/public/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Защищённая синхронизация Selective Remote">
   <title>Selective Remote Cloud</title>
-  <link rel="stylesheet" href="/styles.css?v=127">
+  <link rel="stylesheet" href="/styles.css?v=128">
 </head>
 <body>
   <main class="shell">
@@ -488,33 +488,57 @@
         </div>
         <div class="team-columns">
           <div id="team-members-view">
-            <h3>Участники</h3>
-            <div class="team-members" id="team-members"></div>
-            <form id="team-invite-form">
-              <h4>Пригласить на 48 часов</h4>
-              <label for="team-invite-username">Публичный @username</label>
-              <input id="team-invite-username" name="username" minlength="3" maxlength="32" autocomplete="off" placeholder="username" required>
-              <label for="team-invite-role">Роль</label>
-              <select id="team-invite-role" name="role">
-                <option value="viewer">Viewer</option>
-                <option value="editor">Editor</option>
-                <option value="admin">Admin</option>
-              </select>
-              <button type="submit">Пригласить по @username</button>
-              <label for="team-invite-email">Email</label>
-              <input id="team-invite-email" name="email" type="email" maxlength="320" autocomplete="off" placeholder="user@example.com">
-              <button type="button" class="secondary" id="team-invite-email-submit">Отправить приглашение по email</button>
-              <button type="button" class="secondary" id="team-invite-link-create">Создать одноразовую ссылку</button>
-              <div id="team-invite-link-result" hidden>
-                <label for="team-invite-link-value">Одноразовая ссылка</label>
-                <input id="team-invite-link-value" type="text" readonly>
-                <button type="button" class="secondary" id="team-invite-link-copy">Скопировать ссылку</button>
-              </div>
-            </form>
-            <section aria-labelledby="team-active-invitations-title">
-              <h4 id="team-active-invitations-title">Активные приглашения</h4>
-              <div class="team-invitations" id="team-active-invitations"></div>
-            </section>
+            <div class="team-members-layout">
+              <section class="team-member-directory" aria-labelledby="team-members-title">
+                <div class="team-member-directory-heading">
+                  <h3 id="team-members-title">Участники</h3>
+                  <span id="team-member-count" aria-live="polite">0</span>
+                </div>
+                <div class="team-member-toolbar">
+                  <label for="team-member-search"><span>Поиск</span>
+                    <input id="team-member-search" type="search" maxlength="120" placeholder="Имя или @username">
+                  </label>
+                  <label for="team-member-role-filter"><span>Роль</span>
+                    <select id="team-member-role-filter">
+                      <option value="">Все роли</option>
+                      <option value="owner">Owner</option>
+                      <option value="admin">Admin</option>
+                      <option value="editor">Editor</option>
+                      <option value="viewer">Viewer</option>
+                    </select>
+                  </label>
+                </div>
+                <div class="team-members" id="team-members"></div>
+                <button type="button" class="secondary team-member-more" id="team-member-more" hidden>Показать ещё</button>
+              </section>
+              <aside class="team-member-invitations" aria-labelledby="team-invitations-title">
+                <form id="team-invite-form">
+                  <h4 id="team-invitations-title">Пригласить на 48 часов</h4>
+                  <label for="team-invite-username">Публичный @username</label>
+                  <input id="team-invite-username" name="username" minlength="3" maxlength="32" autocomplete="off" placeholder="username" required>
+                  <label for="team-invite-role">Роль</label>
+                  <select id="team-invite-role" name="role">
+                    <option value="viewer">Viewer</option>
+                    <option value="editor">Editor</option>
+                    <option value="admin">Admin</option>
+                  </select>
+                  <button type="submit">Пригласить по @username</button>
+                  <label for="team-invite-email">Email</label>
+                  <input id="team-invite-email" name="email" type="email" maxlength="320" autocomplete="off" placeholder="user@example.com">
+                  <button type="button" class="secondary" id="team-invite-email-submit">Отправить приглашение по email</button>
+                  <button type="button" class="secondary" id="team-invite-link-create">Создать одноразовую ссылку</button>
+                  <div id="team-invite-link-result" hidden>
+                    <label for="team-invite-link-value">Одноразовая ссылка</label>
+                    <input id="team-invite-link-value" type="text" readonly>
+                    <button type="button" class="secondary" id="team-invite-link-copy">Скопировать ссылку</button>
+                  </div>
+                </form>
+                <section aria-labelledby="team-active-invitations-title">
+                  <h4 id="team-active-invitations-title">Активные приглашения</h4>
+                  <div class="team-invitations" id="team-active-invitations"></div>
+                </section>
+              </aside>
+            </div>
           </div>
           <div id="team-vault-directory-view">
             <h3 class="team-vault-directory-heading">Папки команды</h3>
@@ -645,6 +669,6 @@
       <p>Регистрация доступна только во время контролируемого окна. Вход, подтверждение почты и восстановление пароля остаются доступны для существующего аккаунта.</p>
     </section>
   </main>
-  <script type="module" src="/app.js?v=127"></script>
+  <script type="module" src="/app.js?v=128"></script>
 </body>
 </html>

--- a/cloud/public/styles.css
+++ b/cloud/public/styles.css
@@ -118,11 +118,29 @@ body { margin:0; min-height:100vh; background:var(--body-bg); color:var(--ink); 
 .team-devices strong,.team-devices small,.team-device-fingerprint { grid-column:1; overflow-wrap:anywhere; }
 .team-devices small,.team-device-fingerprint { color:var(--muted); }.team-device-fingerprint { margin:0; font:12px ui-monospace,monospace; }
 .team-devices button { grid-row:1 / span 3; }.team-devices button.danger { grid-column:3; }
-.team-members { display:grid; gap:10px; margin-bottom:20px; }
-.team-members article { display:grid; grid-template-columns:minmax(180px,1fr) minmax(110px,auto); gap:8px 10px; align-items:center; padding:14px; border:1px solid var(--line); border-radius:12px; }
-.team-members strong,.team-members small { grid-column:1; overflow-wrap:anywhere; }.team-members small { color:var(--muted); }
-.team-members select { grid-column:2; grid-row:1 / span 2; min-width:110px; }
-.team-members button { grid-column:1; grid-row:3; justify-self:start; padding:9px 11px; }.team-members button.danger { grid-column:2; grid-row:3; }
+.team-members-layout { display:grid; grid-template-columns:minmax(0,1fr) minmax(280px,340px); gap:22px; align-items:start; }
+.team-member-directory-heading { display:flex; align-items:center; justify-content:space-between; gap:16px; }
+.team-member-directory-heading h3 { margin:0; }
+.team-member-directory-heading span { color:var(--muted); font-size:13px; }
+.team-member-toolbar { display:grid; grid-template-columns:minmax(220px,1fr) minmax(140px,.35fr); gap:12px; margin:14px 0; }
+.team-member-toolbar label { display:grid; gap:6px; color:var(--muted); font-size:12px; }
+.team-member-toolbar input,.team-member-toolbar select { width:100%; box-sizing:border-box; border:1px solid var(--line); border-radius:10px; padding:10px 12px; background:#07100d; color:var(--ink); font:inherit; }
+.team-members { display:grid; gap:6px; margin-bottom:12px; }
+.team-members article { display:grid; grid-template-columns:36px minmax(0,1fr) auto auto; gap:4px 12px; align-items:center; min-height:48px; padding:7px 10px; border:1px solid var(--line); border-radius:10px; }
+.team-member-avatar { grid-row:1 / span 2; display:grid; place-items:center; width:34px; height:34px; border-radius:50%; background:#75e0b418; color:var(--accent); font-weight:800; }
+.team-member-identity { min-width:0; }
+.team-member-identity strong,.team-member-identity small { display:block; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.team-member-identity small { color:var(--muted); margin-top:2px; }
+.team-member-role { padding:5px 8px; border-radius:999px; background:#ffffff0a; color:var(--muted); font-size:12px; font-weight:750; text-transform:capitalize; }
+.team-member-actions { position:relative; }
+.team-member-actions summary { list-style:none; display:grid; place-items:center; width:32px; height:32px; border-radius:8px; color:var(--muted); cursor:pointer; font-weight:800; }
+.team-member-actions summary::-webkit-details-marker { display:none; }
+.team-member-actions summary:hover { color:var(--ink); background:#ffffff0a; }
+.team-member-actions[open] .team-member-action-menu { display:grid; }
+.team-member-action-menu { display:none; position:absolute; z-index:10; right:0; top:36px; width:210px; gap:8px; padding:10px; border:1px solid var(--line); border-radius:12px; background:#0b1713; box-shadow:0 18px 40px #0008; }
+.team-member-action-menu select,.team-member-action-menu button { width:100%; box-sizing:border-box; }
+.team-member-more { justify-self:start; }
+.team-member-invitations { padding-left:22px; border-left:1px solid var(--line); }
 .team-invitations { display:grid; gap:10px; margin:12px 0 20px; }
 .team-invitations article { display:grid; grid-template-columns:minmax(0,1fr) auto; gap:7px 12px; align-items:center; padding:13px; border:1px solid var(--line); border-radius:12px; }
 .team-invitations strong,.team-invitations small { grid-column:1; overflow-wrap:anywhere; }.team-invitations small { color:var(--muted); }
@@ -210,5 +228,6 @@ body { margin:0; min-height:100vh; background:var(--body-bg); color:var(--ink); 
 @keyframes preview-arrive { from { opacity:0; transform:translateX(22px) scale(.985); } to { opacity:1; transform:none; } }
 @keyframes preview-float { 0%,100% { transform:translateY(0); } 50% { transform:translateY(-7px); } }
 @media (max-width:880px) { .shell{width:min(100% - 24px,1180px);padding-top:18px}.brand{flex-wrap:wrap}.brand-actions{order:3;width:100%}.brand-actions button{flex:1}.status{margin-left:auto}.hero{grid-template-columns:1fr;padding:48px 0;gap:36px}.hero.auth-active{grid-template-columns:1fr;min-height:620px}.hero h2{font-size:clamp(40px,11vw,68px)}.hero-preview{padding:22px}.auth-card{width:100%;max-width:560px}.vault-visual{width:230px}.grid,.team-onboarding,.team-columns,.team-lifecycle-forms,.workspace-stats,.donation-grid{grid-template-columns:1fr}.workspace-layout{grid-template-columns:1fr;min-height:0}.workspace-sidebar{border-right:0;border-bottom:1px solid var(--line)}.workspace-sidebar nav{grid-template-columns:repeat(2,minmax(0,1fr))}.workspace-security{display:none}.workspace-main{padding:20px}.workspace-header,.workspace-welcome{align-items:flex-start;flex-direction:column}.vault-heading,.vault-toolbar,.access,.team-summary,.team-devices-heading,.workspace-team-overview-heading,.workspace-team-overview-content{align-items:start;flex-direction:column}.vault-heading-side{justify-items:start;text-align:left}.workspace-team-overview-heading>p{text-align:left}.workspace-team-actions{justify-content:flex-start}.vault-actions{justify-content:flex-start}.vault-panel form,.record-form{grid-template-columns:1fr}.vault-panel button,.record-form button{grid-column:1}.record-form-actions{grid-column:1}.personal-vault-browser{grid-template-columns:1fr}.vault-records{grid-template-columns:1fr}.team-picker,.team-picker.compact{grid-template-columns:1fr}.team-members article,.team-devices article,.team-invitations article{grid-template-columns:1fr}.team-members strong,.team-members small,.team-members select,.team-members button,.team-members button.danger,.team-devices strong,.team-devices small,.team-device-fingerprint,.team-devices button,.team-devices button.danger,.team-invitations strong,.team-invitations small,.team-invitations button{grid-column:1;grid-row:auto}.status{font-size:0}.status::after{content:"●";font-size:16px} }
+@media (max-width:880px) { .team-members-layout,.team-member-toolbar{grid-template-columns:1fr}.team-member-invitations{padding-left:0;padding-top:20px;border-left:0;border-top:1px solid var(--line)}.team-members article{grid-template-columns:36px minmax(0,1fr) auto auto}.team-member-avatar{grid-row:1}.team-member-identity{grid-column:2}.team-member-role{grid-column:3}.team-member-actions{grid-column:4}.team-member-action-menu{position:fixed;left:16px;right:16px;top:auto;width:auto} }
 @media (max-width:560px) { .workspace-sidebar nav{grid-template-columns:1fr}.workspace-main{padding:16px}.workspace-header{padding-bottom:18px}.hero-preview-grid,.about-highlights{grid-template-columns:1fr}.auth-card{padding:22px}.workspace-welcome,.about-project-card,.about-support-card,.workspace-team-overview{padding:20px}.about-support-copy{display:grid}.workspace-team-metrics{display:grid;width:100%;grid-template-columns:1fr 1fr}.workspace-team-metrics span{min-width:0}.workspace-team-actions{display:grid;width:100%}.team-host-browser{grid-template-columns:1fr}.team-section-tabs button{flex-basis:calc(50% - 8px)}.record-actions{display:grid;grid-template-columns:1fr 1fr}.record-actions button{width:100%} }
 @media (prefers-reduced-motion:reduce) { *,*::before,*::after{animation:none!important;transition:none!important;scroll-behavior:auto!important}.orbit{animation:none} }

--- a/cloud/public/vault-sync.js
+++ b/cloud/public/vault-sync.js
@@ -731,6 +731,26 @@ export function createAuthenticatedVaultClient({ fetchValue = globalThis.fetch }
       if (normalizedCursor) query.set("cursor", normalizedCursor);
       const response = await authorizedRequest(`/v1/teams/${normalizedTeamID}/members?${query}`);
       const result = await responseJSON(response, "team_members_download_failed");
+      if (response.ok && Array.isArray(result.members)
+        && !("nextCursor" in result) && !("total" in result)) {
+        const filtered = result.members.map(normalizedTeamMember).filter((member) => (
+          (!normalizedSearch
+            || member.username.toLowerCase().includes(normalizedSearch)
+            || member.displayName.toLowerCase().includes(normalizedSearch))
+          && (!normalizedRole || member.role === normalizedRole)
+        ));
+        const cursorIndex = normalizedCursor
+          ? filtered.findIndex((member) => member.id === normalizedCursor)
+          : -1;
+        const start = normalizedCursor ? cursorIndex + 1 : 0;
+        if (normalizedCursor && cursorIndex < 0) throw new Error("team_members_download_failed");
+        const members = filtered.slice(start, start + limit);
+        return {
+          members,
+          nextCursor: start + members.length < filtered.length ? members.at(-1)?.id ?? null : null,
+          total: filtered.length,
+        };
+      }
       if (!response.ok || !Array.isArray(result.members) || result.members.length > limit
         || !Number.isSafeInteger(result.total) || result.total < result.members.length
         || (result.nextCursor !== null && !uuidPattern.test(String(result.nextCursor ?? "")))) {

--- a/cloud/public/vault-sync.js
+++ b/cloud/public/vault-sync.js
@@ -715,6 +715,34 @@ export function createAuthenticatedVaultClient({ fetchValue = globalThis.fetch }
       return result.members.map(normalizedTeamMember);
     },
 
+    async listTeamMembersPage(teamID, { search = "", role = "", limit = 50, cursor = null } = {}) {
+      const normalizedTeamID = normalizedUUID(teamID, "invalid_team");
+      const normalizedSearch = String(search ?? "").trim().toLowerCase();
+      const normalizedRole = String(role ?? "").trim().toLowerCase();
+      if (normalizedSearch.length > 120
+        || (normalizedRole && !["owner", "admin", "editor", "viewer"].includes(normalizedRole))
+        || !Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
+        throw new Error("invalid_team_member_query");
+      }
+      const normalizedCursor = cursor === null ? null : normalizedUUID(cursor, "invalid_team_member_query");
+      const query = new URLSearchParams({ limit: String(limit) });
+      if (normalizedSearch) query.set("search", normalizedSearch);
+      if (normalizedRole) query.set("role", normalizedRole);
+      if (normalizedCursor) query.set("cursor", normalizedCursor);
+      const response = await authorizedRequest(`/v1/teams/${normalizedTeamID}/members?${query}`);
+      const result = await responseJSON(response, "team_members_download_failed");
+      if (!response.ok || !Array.isArray(result.members) || result.members.length > limit
+        || !Number.isSafeInteger(result.total) || result.total < result.members.length
+        || (result.nextCursor !== null && !uuidPattern.test(String(result.nextCursor ?? "")))) {
+        throw new Error("team_members_download_failed");
+      }
+      return {
+        members: result.members.map(normalizedTeamMember),
+        nextCursor: result.nextCursor,
+        total: result.total,
+      };
+    },
+
     async listTeamInvitations(teamID) {
       const normalizedTeamID = normalizedUUID(teamID, "invalid_team");
       const response = await authorizedRequest(`/v1/teams/${normalizedTeamID}/invitations`);

--- a/cloud/src/postgres-store.mjs
+++ b/cloud/src/postgres-store.mjs
@@ -797,7 +797,8 @@ export class PostgresStore {
     });
   }
 
-  async listTeamMembers(teamID, actorUserID) {
+  async listTeamMembers(teamID, actorUserID, page = null) {
+    if (page !== null) return this.listTeamMembersPage(teamID, actorUserID, page);
     const result = await this.pool.query(
       `SELECT member.id, member.user_id, member.role, member.epoch,
          member.joined_at, account.username, account.display_name
@@ -812,6 +813,55 @@ export class PostgresStore {
     );
     if (result.rows.length === 0) throw new Error("team_not_found");
     return result.rows;
+  }
+
+  async listTeamMembersPage(teamID, actorUserID, { search, role, limit, cursor }) {
+    const result = await this.pool.query(
+      `WITH filtered AS (
+         SELECT member.id, member.user_id, member.role, member.epoch,
+           member.joined_at, account.username, account.display_name,
+           CASE member.role WHEN 'owner' THEN 0 WHEN 'admin' THEN 1
+             WHEN 'editor' THEN 2 ELSE 3 END AS role_rank,
+           lower(account.username) AS sort_username
+         FROM team_memberships AS actor
+         JOIN teams AS team ON team.id = actor.team_id AND team.archived_at IS NULL
+         JOIN team_memberships AS member ON member.team_id = team.id AND member.revoked_at IS NULL
+         JOIN users AS account ON account.id = member.user_id AND account.disabled_at IS NULL
+         WHERE actor.team_id = $1 AND actor.user_id = $2 AND actor.revoked_at IS NULL
+           AND ($3::text IS NULL OR strpos(lower(account.username), $3) > 0
+             OR strpos(lower(account.display_name), $3) > 0)
+           AND ($4::text IS NULL OR member.role = $4)
+       ), cursor_position AS (
+         SELECT role_rank, sort_username, id FROM filtered WHERE id = $5::uuid
+       )
+       SELECT id, user_id, role, epoch, joined_at, username, display_name,
+         (SELECT count(*)::integer FROM filtered) AS filtered_total
+       FROM filtered
+       WHERE $5::uuid IS NULL OR (role_rank, sort_username, id) >
+         (SELECT role_rank, sort_username, id FROM cursor_position)
+       ORDER BY role_rank, sort_username, id
+       LIMIT $6`,
+      [teamID, actorUserID, search, role, cursor, limit + 1],
+    );
+    if (result.rows.length === 0) {
+      const actor = await this.pool.query(
+        `SELECT 1 FROM team_memberships AS membership
+         JOIN teams AS team ON team.id = membership.team_id AND team.archived_at IS NULL
+         WHERE membership.team_id = $1 AND membership.user_id = $2
+           AND membership.revoked_at IS NULL`,
+        [teamID, actorUserID],
+      );
+      if (!actor.rows[0]) throw new Error("team_not_found");
+      return { rows: [], nextCursor: null, total: 0 };
+    }
+    const total = Number(result.rows[0].filtered_total);
+    const hasMore = result.rows.length > limit;
+    const rows = result.rows.slice(0, limit).map((row) => {
+      const member = { ...row };
+      delete member.filtered_total;
+      return member;
+    });
+    return { rows, nextCursor: hasMore ? rows.at(-1).id : null, total };
   }
 
   async listTeamInvitations(teamID, actorUserID) {

--- a/cloud/src/server.mjs
+++ b/cloud/src/server.mjs
@@ -251,7 +251,21 @@ async function route(request, response) {
     const teamMembersMatch = url.pathname.match(/^\/v1\/teams\/([^/]+)\/members$/i);
     if (method === "GET" && teamMembersMatch) {
       if (!isUUID(teamMembersMatch[1])) return sendError(response, 404, "team_not_found");
-      return handleOperation(response, () => service.listTeamMembers(session, teamMembersMatch[1]));
+      const paged = ["search", "role", "limit", "cursor"]
+        .some((name) => url.searchParams.has(name));
+      return handleOperation(
+        response,
+        () => service.listTeamMembers(
+          session,
+          teamMembersMatch[1],
+          paged ? {
+            search: url.searchParams.get("search"),
+            role: url.searchParams.get("role"),
+            limit: url.searchParams.get("limit"),
+            cursor: url.searchParams.get("cursor"),
+          } : null,
+        ),
+      );
     }
     const teamInvitationsMatch = url.pathname.match(/^\/v1\/teams\/([^/]+)\/invitations$/i);
     if (teamInvitationsMatch) {

--- a/cloud/src/service-error.mjs
+++ b/cloud/src/service-error.mjs
@@ -32,6 +32,7 @@ const operationStatuses = Object.freeze({
   vault_missing: 404,
   invalid_team: 400,
   invalid_team_role: 400,
+  invalid_team_member_query: 400,
   invalid_shared_vault: 400,
   invalid_idempotency_key: 400,
   invalid_team_invitation: 400,

--- a/cloud/src/service.mjs
+++ b/cloud/src/service.mjs
@@ -361,9 +361,21 @@ export class CloudService {
     });
   }
 
-  async listTeamMembers(session, teamID) {
-    const rows = await this.store.listTeamMembers(teamID, session.user_id);
-    return { members: rows.map(publicTeamMember) };
+  async listTeamMembers(session, teamID, input = null) {
+    if (input === null) {
+      const rows = await this.store.listTeamMembers(teamID, session.user_id);
+      return { members: rows.map(publicTeamMember) };
+    }
+    const page = await this.store.listTeamMembers(
+      teamID,
+      session.user_id,
+      validateTeamMemberListQuery(input),
+    );
+    return {
+      members: page.rows.map(publicTeamMember),
+      nextCursor: page.nextCursor,
+      total: page.total,
+    };
   }
 
   async listTeamInvitations(session, teamID) {
@@ -655,6 +667,24 @@ function publicTeamMember(row) {
     epoch: Number(row.epoch),
     joinedAt: row.joined_at,
   };
+}
+
+function validateTeamMemberListQuery(input) {
+  const search = String(input?.search ?? "").trim().toLowerCase();
+  if (search.length > 120) throw new Error("invalid_team_member_query");
+  const role = String(input?.role ?? "").trim().toLowerCase();
+  if (role && !["owner", "admin", "editor", "viewer"].includes(role)) {
+    throw new Error("invalid_team_member_query");
+  }
+  const rawLimit = String(input?.limit ?? "50").trim();
+  if (!/^\d{1,3}$/.test(rawLimit)) throw new Error("invalid_team_member_query");
+  const limit = Number(rawLimit);
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
+    throw new Error("invalid_team_member_query");
+  }
+  const cursor = String(input?.cursor ?? "").trim().toLowerCase();
+  if (cursor && !isUUID(cursor)) throw new Error("invalid_team_member_query");
+  return { search: search || null, role: role || null, limit, cursor: cursor || null };
 }
 
 function publicTeamInvitation(row, acceptanceURL = null) {

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -178,6 +178,9 @@ test("macOS Cloud settings expose device-bound sign-in and native Team managemen
   assert.match(teamManagement, /NavigationSplitView/);
   assert.match(teamManagement, /client\.createTeam/);
   assert.match(teamManagement, /client\.teamMembers/);
+  assert.match(teamManagement, /client\.teamMembersPage/);
+  assert.match(teamManagement, /\.searchable\(/);
+  assert.match(teamManagement, /memberRoleFilter/);
   assert.match(teamManagement, /client\.inviteTeamMember/);
   assert.match(teamManagement, /client\.createTeamInvitationLink/);
   assert.match(teamManagement, /client\.pendingTeamInvitations/);

--- a/cloud/tests/macos-cloud-source.test.mjs
+++ b/cloud/tests/macos-cloud-source.test.mjs
@@ -179,6 +179,7 @@ test("macOS Cloud settings expose device-bound sign-in and native Team managemen
   assert.match(teamManagement, /client\.createTeam/);
   assert.match(teamManagement, /client\.teamMembers/);
   assert.match(teamManagement, /client\.teamMembersPage/);
+  assert.match(client, /validTeamMembersJSON\(data\)[\s\S]*legacy\.members/u);
   assert.match(teamManagement, /\.searchable\(/);
   assert.match(teamManagement, /memberRoleFilter/);
   assert.match(teamManagement, /client\.inviteTeamMember/);

--- a/cloud/tests/public-team-vault-client.test.mjs
+++ b/cloud/tests/public-team-vault-client.test.mjs
@@ -330,6 +330,7 @@ test("browser Team management covers lifecycle, members, invitations and shared 
       }
       if (path.startsWith(`/v1/teams/${teamID}/members?`) && !options.method) {
         const query = new URLSearchParams(path.split("?", 2)[1]);
+        if (query.get("search") === "legacy") return jsonResponse(200, { members: [member] });
         assert.equal(query.get("search"), "user");
         assert.equal(query.get("role"), "owner");
         assert.equal(query.get("limit"), "50");
@@ -393,6 +394,9 @@ test("browser Team management covers lifecycle, members, invitations and shared 
   assert.deepEqual(await client.listTeamMembers(teamID), [member]);
   assert.deepEqual(await client.listTeamMembersPage(teamID, { search: " User ", role: "OWNER" }), {
     members: [member], nextCursor: null, total: 1,
+  });
+  assert.deepEqual(await client.listTeamMembersPage(teamID, { search: "legacy" }), {
+    members: [], nextCursor: null, total: 0,
   });
   assert.deepEqual(await client.listTeamInvitations(teamID), [usernameInvitation, { ...linkInvitation, acceptanceURL: null }]);
   assert.deepEqual(await client.listPendingTeamInvitations(), [pendingInvitation]);

--- a/cloud/tests/public-team-vault-client.test.mjs
+++ b/cloud/tests/public-team-vault-client.test.mjs
@@ -328,6 +328,13 @@ test("browser Team management covers lifecycle, members, invitations and shared 
       if (path === `/v1/teams/${teamID}` && options.method === "DELETE") {
         return jsonResponse(200, { archived: true, teamID });
       }
+      if (path.startsWith(`/v1/teams/${teamID}/members?`) && !options.method) {
+        const query = new URLSearchParams(path.split("?", 2)[1]);
+        assert.equal(query.get("search"), "user");
+        assert.equal(query.get("role"), "owner");
+        assert.equal(query.get("limit"), "50");
+        return jsonResponse(200, { members: [member], nextCursor: null, total: 1 });
+      }
       if (path.endsWith("/members") && !options.method) return jsonResponse(200, { members: [member] });
       if (path === `/v1/teams/${teamID}/invitations` && !options.method) {
         return jsonResponse(200, { invitations: [usernameInvitation, { ...linkInvitation, acceptanceURL: null }] });
@@ -384,6 +391,9 @@ test("browser Team management covers lifecycle, members, invitations and shared 
   }), /team_name_mismatch/);
   assert.equal(calls.filter(({ path, options }) => path === `/v1/teams/${teamID}` && options.method === "DELETE").length, 1);
   assert.deepEqual(await client.listTeamMembers(teamID), [member]);
+  assert.deepEqual(await client.listTeamMembersPage(teamID, { search: " User ", role: "OWNER" }), {
+    members: [member], nextCursor: null, total: 1,
+  });
   assert.deepEqual(await client.listTeamInvitations(teamID), [usernameInvitation, { ...linkInvitation, acceptanceURL: null }]);
   assert.deepEqual(await client.listPendingTeamInvitations(), [pendingInvitation]);
   const invitation = await client.inviteTeamMember({ teamID, username: "@MEMBER", role: "viewer" });

--- a/cloud/tests/public-vault-ui.test.mjs
+++ b/cloud/tests/public-vault-ui.test.mjs
@@ -254,8 +254,8 @@ test("portal exposes separate public, authentication and workspace states", asyn
   ]);
 
   assert.match(html, /id="cloud-account"[^>]*hidden/u);
-  assert.match(html, /\/styles\.css\?v=127/u);
-  assert.match(html, /\/app\.js\?v=127/u);
+  assert.match(html, /\/styles\.css\?v=128/u);
+  assert.match(html, /\/app\.js\?v=128/u);
   assert.match(html, /id="cloud-workspace"[^>]*hidden/u);
   assert.match(html, /data-open-auth="login"/u);
   assert.match(html, /data-open-auth="registration"/u);
@@ -307,6 +307,9 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(html, /data-workspace-target="team-vault">Команды/u);
   assert.match(html, /id="team-view-tabs"/u);
   assert.match(html, /data-team-view="members">Участники/u);
+  assert.match(html, /id="team-member-search"/u);
+  assert.match(html, /id="team-member-role-filter"/u);
+  assert.match(html, /id="team-member-more"/u);
   assert.match(html, /data-team-view="vaults">Vaults/u);
   assert.match(html, /data-team-view="hosts">Хосты/u);
   assert.match(html, /class="host-scope-switcher"/u);
@@ -357,7 +360,8 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.match(styles, /:root\[data-theme="light"\] \.resource-card-clickable:hover/u);
   assert.match(styles, /@keyframes reveal-up/u);
   assert.match(styles, /prefers-reduced-motion:reduce[^}]*[\s\S]*animation:none!important/u);
-  assert.match(styles, /\.team-members article\s*\{[^}]*grid-template-columns:minmax\(180px,1fr\) minmax\(110px,auto\)/u);
+  assert.match(styles, /\.team-members article\s*\{[^}]*grid-template-columns:36px minmax\(0,1fr\) auto auto/u);
+  assert.match(styles, /\.team-member-actions/u);
   assert.match(application, /initializePortalNavigation/u);
   assert.match(application, /BroadcastChannel\("selective-remote\.personal-vault\.session\.v1"\)/u);
   assert.match(application, /restoreRememberedSession\(restoredUser\.id\)/u);
@@ -367,7 +371,8 @@ test("portal exposes separate public, authentication and workspace states", asyn
   assert.doesNotMatch(html, /<div class="vault-toolbar">\s*<div><h3>Личный Vault/u);
   assert.match(application, /ваш текущий username/u);
   assert.match(application, /teamUI\?\.setView\(teamView \|\| "teams"\)/u);
-  assert.match(application, /Team «\$\{selectedTeam\.name\}» · участников: \$\{teamMembers\.length\}/u);
+  assert.match(application, /Team «\$\{selectedTeam\.name\}» · участников: \$\{memberTotal\}/u);
+  assert.match(application, /listTeamMembersPage/u);
   assert.match(application, /Команда «\$\{selectedTeam\.name\}» · папок: \$\{vaults\.length\}/u);
   assert.match(application, /createVaultForm\.hidden = activeView !== "vaults" \|\| !canManage\(\)/u);
   assert.match(application, /workspace\.hidden = activeView !== "hosts" \|\| !controller/u);

--- a/cloud/tests/team-api-surface.test.mjs
+++ b/cloud/tests/team-api-surface.test.mjs
@@ -26,6 +26,9 @@ test("Team routes are authenticated, explicitly scoped and idempotent", () => {
   assert.match(serverSource, /team_invitation_accept_ip/);
   assert.match(serverSource, /url\.pathname === "\/v1\/team-invitations"/);
   assert.match(serverSource, /service\.listTeamInvitations/);
+  assert.match(serverSource, /url\.searchParams\.has\(name\)/);
+  assert.match(serverSource, /search: url\.searchParams\.get\("search"\)/);
+  assert.match(serverSource, /cursor: url\.searchParams\.get\("cursor"\)/);
   assert.match(serverSource, /service\.listPendingTeamInvitations/);
   assert.match(serverSource, /service\.putSharedVault/);
   assert.match(serverSource, /service\.renameSharedVault/);

--- a/cloud/tests/team-postgres-store.test.mjs
+++ b/cloud/tests/team-postgres-store.test.mjs
@@ -71,6 +71,39 @@ function mutationReservation(sql) {
   return sql.includes("INSERT INTO team_mutation_receipts") ? { rows: [{ actor_user_id: actorUserID }] } : null;
 }
 
+test("Team member pages use stable cursor ordering and bounded server-side filters", async () => {
+  const secondID = "87806d7b-d3a9-4701-8262-f247bd5de1e9";
+  const thirdID = "97806d7b-d3a9-4701-8262-f247bd5de1e9";
+  const rows = [membershipID, secondID, thirdID].map((id, index) => ({
+    id,
+    user_id: `user-${index}`,
+    username: `member${index}`,
+    display_name: `Member ${index}`,
+    role: "viewer",
+    epoch: 1,
+    joined_at: "2026-09-12T00:00:00.000Z",
+    filtered_total: 3,
+  }));
+  const f = fixture((sql) => sql.includes("WITH filtered AS") ? { rows } : { rows: [] });
+  assert.deepEqual(await f.store.listTeamMembers(teamID, actorUserID, {
+    search: "member",
+    role: "viewer",
+    limit: 2,
+    cursor: null,
+  }), {
+    rows: rows.slice(0, 2).map((row) => {
+      const member = { ...row };
+      delete member.filtered_total;
+      return member;
+    }),
+    nextCursor: secondID,
+    total: 3,
+  });
+  assert.deepEqual(f.queries[0].parameters, [teamID, actorUserID, "member", "viewer", null, 3]);
+  assert.match(f.queries[0].sql, /strpos\(lower\(account\.username\), \$3\)/u);
+  assert.match(f.queries[0].sql, /\(role_rank, sort_username, id\) >/u);
+});
+
 test("Team invitation listing exposes only active invitations manageable by the actor", async () => {
   const viewerInvitation = {
     actor_role: "admin", id: "471c3424-b6aa-41a0-959f-aeaa1e3ef79d", role: "viewer",

--- a/cloud/tests/team-service.test.mjs
+++ b/cloud/tests/team-service.test.mjs
@@ -144,9 +144,13 @@ class TeamStore {
     return { revoked: true, rotationRequiredVaults: 2 };
   }
 
-  async listTeamMembers(team, actor) {
-    this.calls.push(["listTeamMembers", team, actor]);
-    return [{ id: membershipID, user_id: "user-1", role: "owner", epoch: 1 }];
+  async listTeamMembers(team, actor, page = null) {
+    this.calls.push(["listTeamMembers", team, actor, page]);
+    const member = {
+      id: membershipID, user_id: "user-1", username: "owner", display_name: "Owner",
+      role: "owner", epoch: 1, joined_at: "2026-09-12T00:00:00.000Z",
+    };
+    return page ? { rows: [member], nextCursor: null, total: 1 } : [member];
   }
 
   async listSharedVaults(team, actor) {
@@ -513,6 +517,28 @@ test("member and shared-Vault operations preserve explicit Team scope", async ()
   for (const [, value] of store.calls) {
     if (value && typeof value === "object" && "actorUserID" in value) assert.equal(value.actorUserID, "user-1");
   }
+});
+
+test("member directory query is normalized without changing the legacy response contract", async () => {
+  const store = new TeamStore();
+  const service = new CloudService(store, config);
+  assert.deepEqual(await service.listTeamMembers(session, teamID, {
+    search: "  OWN  ", role: "OWNER", limit: "25", cursor: membershipID,
+  }), {
+    members: [{
+      id: membershipID, userID: "user-1", username: "owner", displayName: "Owner",
+      role: "owner", epoch: 1, joinedAt: "2026-09-12T00:00:00.000Z",
+    }],
+    nextCursor: null,
+    total: 1,
+  });
+  assert.deepEqual(store.calls[0], ["listTeamMembers", teamID, "user-1", {
+    search: "own", role: "owner", limit: 25, cursor: membershipID,
+  }]);
+  await assert.rejects(
+    service.listTeamMembers(session, teamID, { limit: "101" }),
+    /invalid_team_member_query/,
+  );
 });
 
 test("Team ciphertext service binds session device, generation and wrapper context", async () => {

--- a/docs/cloud-v0.32-architecture.md
+++ b/docs/cloud-v0.32-architecture.md
@@ -212,7 +212,7 @@ than overloading the personal route.
 | `PATCH` | `/v1/teams/{teamID}` | Rename a Team (Owner only) |
 | `POST` | `/v1/teams/{teamID}/ownership-transfer` | Re-authenticate and atomically transfer Owner |
 | `DELETE` | `/v1/teams/{teamID}` | Re-authenticate, confirm exact name and soft-archive Team |
-| `GET` | `/v1/teams/{teamID}/members` | List active Team members |
+| `GET` | `/v1/teams/{teamID}/members` | List active Team members; optional `search`, `role`, `limit` and `cursor` enable a bounded directory page while the parameter-free legacy response remains compatible |
 | `GET` | `/v1/teams/{teamID}/invitations` | List active role-manageable invitations |
 | `POST` | `/v1/teams/{teamID}/invitations` | Create an `@username` or single-use-link invitation |
 | `DELETE` | `/v1/teams/{teamID}/invitations/{invitationID}` | Cancel a pending invitation |

--- a/docs/cloud-v0.32-architecture.md
+++ b/docs/cloud-v0.32-architecture.md
@@ -212,7 +212,7 @@ than overloading the personal route.
 | `PATCH` | `/v1/teams/{teamID}` | Rename a Team (Owner only) |
 | `POST` | `/v1/teams/{teamID}/ownership-transfer` | Re-authenticate and atomically transfer Owner |
 | `DELETE` | `/v1/teams/{teamID}` | Re-authenticate, confirm exact name and soft-archive Team |
-| `GET` | `/v1/teams/{teamID}/members` | List active Team members; optional `search`, `role`, `limit` and `cursor` enable a bounded directory page while the parameter-free legacy response remains compatible |
+| `GET` | `/v1/teams/{teamID}/members` | List active Team members; optional `search`, `role`, `limit` and `cursor` enable a bounded directory page while the parameter-free legacy response remains compatible; new clients fall back to local filtering/paging when an older server returns `{ members }` |
 | `GET` | `/v1/teams/{teamID}/invitations` | List active role-manageable invitations |
 | `POST` | `/v1/teams/{teamID}/invitations` | Create an `@username` or single-use-link invitation |
 | `DELETE` | `/v1/teams/{teamID}/invitations/{invitationID}` | Cancel a pending invitation |


### PR DESCRIPTION
## Summary

- add an opt-in paged Team member directory API with server-side name/@username search, role filtering, stable membership cursors, totals, and a 50-row default / 100-row cap
- preserve the parameter-free `GET /v1/teams/{teamID}/members` response for released macOS and browser clients
- let new browser/macOS clients fall back to local filtering and paging when staging still runs the legacy server response
- replace large web member cards with compact rows, role badges, per-member `•••` actions, search/filter controls, counts, and incremental loading
- keep ownership transfer complete by loading the legacy full directory only when the Owner opens Team management
- add native macOS member search, role filtering, counts, and incremental loading
- document the compatibility contract and update the browser asset revision to v128

## Safety

- no database migration
- no change to Team authorization, last-Owner protection, revocation, or Vault key-rotation rules
- member revoke still refreshes Vault state before the workspace continues
- no deployment or runtime environment change

## Verification

- 95 focused local Node tests passed
- CI #695 succeeded, including Swift tests, Cloud/browser tests, Release build, and the real PostgreSQL 16 transaction job
- Test DMG #317 succeeded
- artifact: `SelectiveRemote-test-128-arm64`
- artifact ID: `10294098468`
- digest: `sha256:f7927c1c513bf592891351f7476d0a84d4ed9146450573306824efc885384802`

## Remaining acceptance

- install Test DMG #317 against current PR #127 staging and exercise a synthetic large Team
- verify search, role filters, paging, member actions, revoke/rotation state, and full Owner-transfer selection
